### PR TITLE
deps-dev: bump vitest and @vitest/coverage-v8 to 4.0.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/node": "^25.0.2",
         "@typescript-eslint/eslint-plugin": "^8.45.0",
         "@typescript-eslint/parser": "^8.45.0",
-        "@vitest/coverage-v8": "^4.0.16",
+        "@vitest/coverage-v8": "^4.0.17",
         "ajv": "^8.17.1",
         "eslint": "^9.36.0",
         "eslint-config-prettier": "^10.1.8",
@@ -57,7 +57,7 @@
         "tsx": "^4.6.0",
         "typedoc": "^0.28.13",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.16"
+        "vitest": "^4.0.17"
       },
       "engines": {
         "node": ">=20.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/node": "^25.0.2",
     "@typescript-eslint/eslint-plugin": "^8.45.0",
     "@typescript-eslint/parser": "^8.45.0",
-    "@vitest/coverage-v8": "^4.0.16",
+    "@vitest/coverage-v8": "^4.0.17",
     "ajv": "^8.17.1",
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",
@@ -90,7 +90,7 @@
     "tsx": "^4.6.0",
     "typedoc": "^0.28.13",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.16"
+    "vitest": "^4.0.17"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
- Updates `vitest` from 4.0.16 to 4.0.17
- Updates `@vitest/coverage-v8` from 4.0.16 to 4.0.17

This combines the updates from the previous Dependabot PRs #405 and #414, ensuring peer dependency compatibility between vitest and its coverage package.

## Test plan
- [x] All 2851 tests pass locally
- [x] Pre-commit hooks pass
- [x] Pre-push security checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)