### PR TITLE
ci: fix invalid autoMergeAllowed field in auto-release workflows

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -318,12 +318,11 @@ jobs:
       - name: Enable auto-merge for version-bump PR
         if: steps.config.outputs.enabled == 'true' && steps.should-skip.outputs.should_skip == 'false' && steps.version-bump-pr.outputs.pull-request-number
         run: |
-          ALLOWED=$(gh repo view ${{ github.repository }} --json autoMergeAllowed -q '.autoMergeAllowed')
-          if [[ "$ALLOWED" == "true" ]]; then
-            gh pr merge ${{ steps.version-bump-pr.outputs.pull-request-number }} --auto --squash
+          if gh pr merge ${{ steps.version-bump-pr.outputs.pull-request-number }} --auto --squash 2>/dev/null; then
             echo "✅ Auto-merge enabled for version-bump PR #${{ steps.version-bump-pr.outputs.pull-request-number }}"
           else
-            echo "ℹ️ Auto-merge is disabled in repository settings. Version-bump PR #${{ steps.version-bump-pr.outputs.pull-request-number }} will require manual merge."
+            echo "ℹ️ Could not enable auto-merge (may be disabled in repository settings or branch protection)."
+            echo "ℹ️ Version-bump PR #${{ steps.version-bump-pr.outputs.pull-request-number }} will require manual merge."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-release.yml
+++ b/.github/workflows/dependabot-auto-release.yml
@@ -243,12 +243,11 @@ jobs:
       - name: Enable auto-merge for version-bump PR
         if: steps.version-bump-pr.outputs.pull-request-number
         run: |
-          ALLOWED=$(gh repo view ${{ github.repository }} --json autoMergeAllowed -q '.autoMergeAllowed')
-          if [[ "$ALLOWED" == "true" ]]; then
-            gh pr merge ${{ steps.version-bump-pr.outputs.pull-request-number }} --auto --squash
+          if gh pr merge ${{ steps.version-bump-pr.outputs.pull-request-number }} --auto --squash 2>/dev/null; then
             echo "✅ Auto-merge enabled for version-bump PR #${{ steps.version-bump-pr.outputs.pull-request-number }}"
           else
-            echo "ℹ️ Auto-merge is disabled in repository settings. Version-bump PR #${{ steps.version-bump-pr.outputs.pull-request-number }} will require manual merge."
+            echo "ℹ️ Could not enable auto-merge (may be disabled in repository settings or branch protection)."
+            echo "ℹ️ Version-bump PR #${{ steps.version-bump-pr.outputs.pull-request-number }} will require manual merge."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaced invalid `gh repo view --json autoMergeAllowed` check with a try-catch approach that attempts `gh pr merge --auto --squash` directly and handles failure gracefully
- Applied the same fix to both `auto-release-on-merge.yml` and `dependabot-auto-release.yml`

## Root Cause

The `autoMergeAllowed` field does not exist in the `gh repo view` JSON output. PR #473 introduced this check, which causes every auto-release run to fail at the "Enable auto-merge" step with `Unknown JSON field: "autoMergeAllowed"`.

## Fix

Instead of pre-checking a non-existent field, simply try the `gh pr merge --auto --squash` command and handle failure:

```yaml
if gh pr merge <PR> --auto --squash 2>/dev/null; then
  echo "Auto-merge enabled"
else
  echo "Could not enable auto-merge, manual merge required"
fi
```

Fixes #477

## Test plan

- [x] YAML lint passes on both workflow files
- [x] All 2946 tests pass
- [ ] After merge, verify auto-release workflow no longer fails at the auto-merge step

🤖 Generated with [Claude Code](https://claude.com/claude-code)