### PR TITLE
ci: add missing setup steps to ai-executor-integration workflow

### DIFF
--- a/.github/workflows/ai-executor-integration.md
+++ b/.github/workflows/ai-executor-integration.md
@@ -43,6 +43,32 @@ Key files:
 
 ## Validation Steps
 
+### Step 0: Install Dependencies and Build
+
+Install build tools required for native module compilation (e.g., tree-sitter), then install npm dependencies with error-tolerant fallbacks, and build the project.
+
+```bash
+# Install build tools for native modules (requires sudo)
+sudo apt-get update -qq && sudo apt-get install -y build-essential python3 || echo "⚠️ Could not install build tools (may already be present)"
+
+# Install npm dependencies with fallback
+if ! npm ci; then
+  echo "⚠️ npm ci failed, falling back to npm install..."
+  npm install
+fi
+
+# Rebuild tree-sitter native bindings (non-blocking)
+echo "🔨 Rebuilding tree-sitter native bindings..."
+if ! npm rebuild tree-sitter; then
+  echo "⚠️ Tree-sitter rebuild failed, but continuing (tests handle graceful fallback)"
+fi
+
+# Build the project (required for dist/ artifacts)
+npm run build
+```
+
+If `npm` is not available or both install commands fail, Steps 1-5 will not be able to run. Report the dependency installation failure as the root cause.
+
 ### Step 1: Test Prompt Mode
 
 This must always work, regardless of API key availability:


### PR DESCRIPTION
## Summary

- Add Step 0 (Install Dependencies and Build) to the AI Executor Integration agentic workflow prompt, fixing the infrastructure-level failure that prevented all validation steps from running

## Root Cause

The `ai-executor-integration.md` workflow prompt instructed the Copilot agent to run `npm test` and validate `dist/` artifacts without first installing dependencies or building the project. The agent would fail immediately because:

- No `node_modules/` directory (no `npm ci` or `npm install`)
- No `dist/` directory (no `npm run build`)
- `node-gyp` blocked by firewall when trying to compile tree-sitter native modules

## Fix

Added **Step 0: Install Dependencies and Build** to the `.md` prompt file, matching the proven pattern from `mcp-server-validation.md`:

1. `sudo apt-get install build-essential python3` — native module compilation tools
2. `npm ci` with fallback to `npm install` — dependency installation
3. `npm rebuild tree-sitter` — non-blocking native binding rebuild
4. `npm run build` — TypeScript compilation to `dist/`

No changes to the auto-generated `.lock.yml` file are needed since the `.md` content is imported at runtime via `{{#runtime-import}}`.

## Test plan

- [x] All 2946 tests pass locally
- [x] Pre-commit and pre-push hooks pass
- [ ] Manually trigger the AI Executor Integration workflow after merge to verify

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)