### PR TITLE
fix(test): use fake timers in uptime tracking test to eliminate flakiness

### DIFF
--- a/tests/utils/monitoring.test.ts
+++ b/tests/utils/monitoring.test.ts
@@ -3,7 +3,7 @@
  * Tests monitoring, analytics, and health check functionality
  */
 
-import { describe, it, expect, _beforeEach, _afterEach } from 'vitest';
+import { describe, it, expect, vi, _beforeEach, _afterEach } from 'vitest';
 import {
   MonitoringManager,
   MetricType,
@@ -449,10 +449,24 @@ describe('Monitoring and Analytics', () => {
   });
 
   describe('Uptime Tracking', () => {
-    it('should track uptime', async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
-      const uptime = monitor.getUptime();
-      expect(uptime).toBeGreaterThanOrEqual(10);
+    it('should track uptime', () => {
+      vi.useFakeTimers();
+      try {
+        const timedMonitor = new MonitoringManager({
+          enabled: true,
+          metricsRetentionMs: 60000,
+          aggregationIntervalMs: 10000,
+          maxMetricsInMemory: 1000,
+          enableHealthChecks: false,
+        });
+        vi.advanceTimersByTime(10);
+        const uptime = timedMonitor.getUptime();
+        expect(uptime).toBeGreaterThanOrEqual(10);
+        timedMonitor.stop();
+        timedMonitor.reset();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- **`tests/utils/monitoring.test.ts`**: Replace real `setTimeout(resolve, 10)` with `vi.useFakeTimers()` + `vi.advanceTimersByTime(10)` in the uptime tracking test to eliminate Node.js 22 timer flakiness

## Root Cause

The test used `setTimeout(resolve, 10)` then asserted `uptime >= 10ms`. Node.js 22 timer resolution can fire slightly early (9ms observed in CI), causing a flaky failure on `test (22)` while `test (20)` always passed.

## Fix

Use Vitest's fake timers to deterministically advance time by exactly 10ms, making the test reliable regardless of runtime timer precision. This is consistent with the approach used in PR #530 for a similar flaky timing test.

Fixes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)