### PR TITLE
chore: bump version to v2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-adr-analysis-server",
-  "version": "2.1.28",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-adr-analysis-server",
-      "version": "2.1.28",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-adr-analysis-server",
-  "version": "2.1.28",
+  "version": "2.2.1",
   "description": "MCP server for analyzing Architectural Decision Records and project architecture",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump package.json version from 2.1.28 to 2.2.1
- Aligns package version with the upcoming v2.2.1 release

## Context
The package.json version fell out of sync (was at 2.1.28 while latest release is v2.2.0). This brings it current for the v2.2.1 release covering 15 commits of dependency updates and CI improvements since v2.2.0.

> This PR updates `package.json` and `package-lock.json` only.
> The `no-release` label prevents this merge from triggering another release.