### PR TITLE
chore: add MCP Registry metadata for official registry submission

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,43 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_run:
+    workflows: ['Publish to NPM']
+    types: [completed]
+    branches: [main]
+
+jobs:
+  publish-mcp-registry:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get current version
+        id: version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Publish to MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
+      - name: Verify publication
+        run: |
+          sleep 5
+          curl -s "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.tosin2013/mcp-adr-analysis-server"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mcp-adr-analysis-server",
+  "mcpName": "io.github.tosin2013/mcp-adr-analysis-server",
   "version": "2.3.0",
   "description": "MCP server for analyzing Architectural Decision Records and project architecture",
   "main": "dist/src/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tosin2013/mcp-adr-analysis-server",
+  "description": "AI-powered MCP server for analyzing Architectural Decision Records (ADRs) and providing deep architectural analysis capabilities to AI coding assistants.",
+  "repository": {
+    "url": "https://github.com/tosin2013/mcp-adr-analysis-server",
+    "source": "github"
+  },
+  "version": "2.3.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "mcp-adr-analysis-server",
+      "version": "2.3.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PROJECT_PATH",
+          "description": "Path to the project directory to analyze (defaults to current directory)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "OPENROUTER_API_KEY",
+          "description": "OpenRouter API key for AI-powered analysis (required for full execution mode)",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "EXECUTION_MODE",
+          "description": "Execution mode: 'full' for AI results or 'prompt-only' for prompts (default: prompt-only)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "ADR_DIRECTORY",
+          "description": "ADR directory relative to project path (default: docs/adrs)",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `mcpName` field to `package.json` for MCP Registry identification
- Create `server.json` with the official MCP Registry schema (`2025-12-11`)
- Add `publish-mcp-registry.yml` CI workflow that auto-publishes to the MCP Registry after each npm release

## Details

This PR adds the metadata required to list mcp-adr-analysis-server on the [official MCP Registry](https://registry.modelcontextprotocol.io). The `server.json` declares the npm transport, environment variables, and repository info. The CI workflow triggers after the "Publish to NPM" workflow succeeds and uses `github-oidc` authentication (no stored tokens needed).

After merge, the first publish to the MCP Registry must be done manually using `mcp-publisher` CLI with GitHub device flow auth. All subsequent releases will be handled automatically by the new workflow.

## Test plan
- [x] All 3004 tests pass (pre-push hook verified)
- [x] `server.json` conforms to the MCP Registry schema
- [x] `mcpName` in `package.json` matches `name` in `server.json`
- [x] `server.json` is excluded from npm package (`files` array unchanged)
- [ ] After merge: manually run `mcp-publisher publish` for first-time registration
- [ ] Verify listing at `registry.modelcontextprotocol.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)