### PR TITLE
chore: bump version to v2.4.0 for MCP Registry publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-adr-analysis-server",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-adr-analysis-server",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-adr-analysis-server",
   "mcpName": "io.github.tosin2013/mcp-adr-analysis-server",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "MCP server for analyzing Architectural Decision Records and project architecture",
   "main": "dist/src/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.tosin2013/mcp-adr-analysis-server",
-  "description": "AI-powered MCP server for analyzing Architectural Decision Records (ADRs) and providing deep architectural analysis capabilities to AI coding assistants.",
+  "description": "AI-powered MCP server for analyzing Architectural Decision Records (ADRs).",
   "repository": {
     "url": "https://github.com/tosin2013/mcp-adr-analysis-server",
     "source": "github"
   },
-  "version": "2.3.1",
+  "version": "2.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mcp-adr-analysis-server",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "transport": {
         "type": "stdio"
       },

--- a/tests/integration/ce-mcp-migration.test.ts
+++ b/tests/integration/ce-mcp-migration.test.ts
@@ -1,0 +1,583 @@
+/**
+ * CE-MCP Migration Comparison Tests
+ *
+ * These tests validate that CE-MCP directive-based tools produce equivalent
+ * output structures to their legacy implementations. This ensures no regression
+ * in output quality during the Phase 2 pilot tool migration.
+ *
+ * @see ADR-014: CE-MCP Architecture
+ * @see docs/IMPLEMENTATION-PLAN.md Phase 2 - Migration Tests
+ */
+
+import {
+  createAnalyzeProjectEcosystemDirective,
+  createSuggestAdrsDirective,
+  createGenerateRulesDirective,
+  createAnalyzeEnvironmentDirective,
+  createDeploymentReadinessDirective,
+  formatDirectiveResponse,
+  getCEMCPDirective,
+  shouldUseCEMCPDirective,
+  type CEMCPAnalyzeProjectEcosystemArgs,
+  type CEMCPSuggestAdrsArgs,
+  type CEMCPGenerateRulesArgs,
+  type CEMCPAnalyzeEnvironmentArgs,
+  type CEMCPDeploymentReadinessArgs,
+} from '../../src/tools/ce-mcp-tools.js';
+import {
+  isOrchestrationDirective,
+  isStateMachineDirective,
+  type OrchestrationDirective as _OrchestrationDirective,
+  type StateMachineDirective as _StateMachineDirective,
+} from '../../src/types/ce-mcp.js';
+import {
+  SandboxExecutor,
+  getSandboxExecutor,
+  resetSandboxExecutor,
+} from '../../src/utils/sandbox-executor.js';
+
+describe('CE-MCP Migration Comparison Tests', () => {
+  let executor: SandboxExecutor;
+
+  beforeEach(() => {
+    resetSandboxExecutor();
+    executor = getSandboxExecutor({
+      sandbox: {
+        timeout: 30000,
+        memoryLimit: 128 * 1024 * 1024,
+        fsOperationsLimit: 100,
+        networkAllowed: false,
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetSandboxExecutor();
+  });
+
+  describe('analyze_project_ecosystem Migration', () => {
+    /**
+     * Legacy: Direct OpenRouter execution with ~12K tokens
+     * CE-MCP: Orchestration directive with ~4K tokens (67% reduction)
+     */
+    it('should produce directive with equivalent output schema to legacy', () => {
+      const args: CEMCPAnalyzeProjectEcosystemArgs = {
+        projectPath: '/test/project',
+        analysisDepth: 'comprehensive',
+        includeEnvironment: true,
+        knowledgeEnhancement: true,
+      };
+
+      const directive = createAnalyzeProjectEcosystemDirective(args);
+
+      // Verify directive type
+      expect(isOrchestrationDirective(directive)).toBe(true);
+      expect(directive.tool).toBe('analyze_project_ecosystem');
+
+      // Verify output schema contains all fields from legacy output
+      const expectedOutputFields = [
+        'projectStructure',
+        'environment',
+        'knowledge',
+        'analysisContext',
+      ];
+      for (const field of expectedOutputFields) {
+        expect(directive.output_schema?.properties).toHaveProperty(field);
+      }
+
+      // Verify composition sections match legacy report format
+      expect(directive.compose?.template).toBe('ecosystem_analysis_report');
+      expect(directive.compose?.format).toBe('markdown');
+      expect(directive.compose?.sections.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should execute directive and produce structured result', async () => {
+      const directive = createAnalyzeProjectEcosystemDirective({
+        projectPath: '/test/project',
+        analysisDepth: 'standard',
+      });
+
+      const result = await executor.executeDirective(directive, '/test/project');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.metadata.operationsExecuted).toBeGreaterThan(0);
+    });
+
+    it('should achieve 60%+ token reduction from legacy', () => {
+      const directive = createAnalyzeProjectEcosystemDirective({
+        projectPath: '/test/project',
+      });
+
+      const legacyTokens = 12000;
+      const directiveTokens = directive.metadata?.estimated_tokens ?? 0;
+      const reduction = ((legacyTokens - directiveTokens) / legacyTokens) * 100;
+
+      expect(reduction).toBeGreaterThanOrEqual(60);
+      expect(directiveTokens).toBeLessThanOrEqual(5000); // Max 5K tokens
+    });
+
+    it('should handle all analysis depth variations', () => {
+      const depths: Array<'basic' | 'standard' | 'comprehensive'> = [
+        'basic',
+        'standard',
+        'comprehensive',
+      ];
+
+      for (const depth of depths) {
+        const directive = createAnalyzeProjectEcosystemDirective({
+          projectPath: '/test',
+          analysisDepth: depth,
+        });
+
+        expect(directive).toBeDefined();
+        expect(directive.description).toContain(depth);
+
+        // Verify file limits scale with depth
+        const analyzeOp = directive.sandbox_operations.find(op => op.op === 'analyzeFiles');
+        expect(analyzeOp).toBeDefined();
+        if (depth === 'basic') {
+          expect(analyzeOp?.args?.maxFiles).toBe(50);
+        } else if (depth === 'standard') {
+          expect(analyzeOp?.args?.maxFiles).toBe(100);
+        } else {
+          expect(analyzeOp?.args?.maxFiles).toBe(200);
+        }
+      }
+    });
+  });
+
+  describe('suggest_adrs Migration', () => {
+    /**
+     * Legacy: Multi-step OpenRouter calls with ~3.5K tokens
+     * CE-MCP: State machine directive with ~1.5K tokens (57% reduction)
+     */
+    it('should produce state machine directive with legacy-equivalent transitions', () => {
+      const args: CEMCPSuggestAdrsArgs = {
+        projectPath: '/test/project',
+        focusAreas: ['security', 'performance'],
+        maxSuggestions: 5,
+      };
+
+      const directive = createSuggestAdrsDirective(args);
+
+      // Verify directive type
+      expect(isStateMachineDirective(directive)).toBe(true);
+      expect(directive.final_state).toBe('done');
+
+      // Verify all legacy ADR suggestion phases are represented
+      const transitionNames = directive.transitions.map(t => t.name);
+      expect(transitionNames).toContain('load_adr_knowledge');
+      expect(transitionNames).toContain('analyze_codebase');
+      expect(transitionNames).toContain('generate_suggestions');
+      expect(transitionNames).toContain('validate_suggestions');
+    });
+
+    it('should execute state machine and produce ADR suggestions', async () => {
+      const directive = createSuggestAdrsDirective({
+        projectPath: '/test/project',
+        maxSuggestions: 3,
+      });
+
+      const result = await executor.executeDirective(directive, '/test/project');
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.operationsExecuted).toBeGreaterThan(0);
+    });
+
+    it('should preserve focus areas in initial state', () => {
+      const focusAreas = ['security', 'scalability', 'maintainability'];
+      const directive = createSuggestAdrsDirective({
+        projectPath: '/test',
+        focusAreas,
+        maxSuggestions: 10,
+      });
+
+      expect(directive.initial_state.focusAreas).toEqual(focusAreas);
+      expect(directive.initial_state.maxSuggestions).toBe(10);
+    });
+
+    it('should have error handling for validation step', () => {
+      const directive = createSuggestAdrsDirective({
+        projectPath: '/test',
+      });
+
+      const validateTransition = directive.transitions.find(t => t.name === 'validate_suggestions');
+      expect(validateTransition?.on_error).toBe('skip'); // Non-critical step
+    });
+  });
+
+  describe('generate_rules Migration', () => {
+    /**
+     * Legacy: Template-validation-refinement chain with ~4K tokens
+     * CE-MCP: Orchestration directive with ~1.5K tokens (62.5% reduction)
+     */
+    it('should produce orchestration directive for each rule type', () => {
+      const ruleTypes: Array<'code-quality' | 'security' | 'architecture' | 'testing'> = [
+        'code-quality',
+        'security',
+        'architecture',
+        'testing',
+      ];
+
+      for (const ruleType of ruleTypes) {
+        const args: CEMCPGenerateRulesArgs = {
+          projectPath: '/test/project',
+          ruleType,
+        };
+
+        const directive = createGenerateRulesDirective(args);
+
+        expect(isOrchestrationDirective(directive)).toBe(true);
+        expect(directive.tool).toBe('generate_rules');
+        expect(directive.description).toContain(ruleType);
+
+        // Verify domain-specific knowledge loading
+        const knowledgeOp = directive.sandbox_operations.find(op => op.op === 'loadKnowledge');
+        expect(knowledgeOp?.args?.domain).toBe(ruleType);
+      }
+    });
+
+    it('should achieve 60%+ token reduction', () => {
+      const directive = createGenerateRulesDirective({
+        projectPath: '/test',
+        ruleType: 'security',
+      });
+
+      const legacyTokens = 4000;
+      const directiveTokens = directive.metadata?.estimated_tokens ?? 0;
+      const reduction = ((legacyTokens - directiveTokens) / legacyTokens) * 100;
+
+      expect(reduction).toBeGreaterThanOrEqual(60);
+    });
+
+    it('should support target framework file patterns', () => {
+      const directive = createGenerateRulesDirective({
+        projectPath: '/test',
+        ruleType: 'code-quality',
+        targetFramework: 'typescript',
+      });
+
+      const analyzeOp = directive.sandbox_operations.find(op => op.op === 'analyzeFiles');
+      expect(analyzeOp?.args?.patterns).toEqual(['**/*.ts']);
+    });
+
+    it('should use extended cache TTL for rules', () => {
+      const directive = createGenerateRulesDirective({
+        projectPath: '/test',
+        ruleType: 'architecture',
+      });
+
+      const cacheOp = directive.sandbox_operations.find(op => op.op === 'cacheResult');
+      expect(cacheOp?.args?.ttl).toBe(7200); // 2 hours for rules
+    });
+  });
+
+  describe('analyze_environment Migration', () => {
+    /**
+     * Legacy: Recursive environment analysis with ~2.5K tokens
+     * CE-MCP: Flat sandbox operations with ~1K tokens (60% reduction)
+     */
+    it('should produce orchestration directive with environment scanning', () => {
+      const args: CEMCPAnalyzeEnvironmentArgs = {
+        projectPath: '/test/project',
+        analysisType: 'comprehensive',
+      };
+
+      const directive = createAnalyzeEnvironmentDirective(args);
+
+      expect(isOrchestrationDirective(directive)).toBe(true);
+      expect(directive.tool).toBe('analyze_environment');
+
+      // Verify environment config patterns
+      const analyzeOp = directive.sandbox_operations.find(op => op.op === 'analyzeFiles');
+      const patterns = analyzeOp?.args?.patterns ?? [];
+      expect(patterns).toContain('Dockerfile*');
+      expect(patterns).toContain('docker-compose*.yml');
+      expect(patterns).toContain('package.json');
+    });
+
+    it('should achieve 60%+ token reduction', () => {
+      const directive = createAnalyzeEnvironmentDirective({
+        projectPath: '/test',
+      });
+
+      const legacyTokens = 2500;
+      const directiveTokens = directive.metadata?.estimated_tokens ?? 0;
+      const reduction = ((legacyTokens - directiveTokens) / legacyTokens) * 100;
+
+      expect(reduction).toBeGreaterThanOrEqual(60);
+    });
+
+    it('should adjust prompt based on analysis type', () => {
+      const quickDirective = createAnalyzeEnvironmentDirective({
+        projectPath: '/test',
+        analysisType: 'quick',
+      });
+
+      const comprehensiveDirective = createAnalyzeEnvironmentDirective({
+        projectPath: '/test',
+        analysisType: 'comprehensive',
+      });
+
+      const quickPromptOp = quickDirective.sandbox_operations.find(op => op.op === 'loadPrompt');
+      const comprehensivePromptOp = comprehensiveDirective.sandbox_operations.find(
+        op => op.op === 'loadPrompt'
+      );
+
+      expect(quickPromptOp?.args?.section).toBe('config_validation');
+      expect(comprehensivePromptOp?.args?.section).toBe('infrastructure_review');
+    });
+  });
+
+  describe('deployment_readiness Migration', () => {
+    /**
+     * Legacy: Multi-check workflow with ~2K tokens
+     * CE-MCP: State machine directive with ~0.8K tokens (60% reduction)
+     */
+    it('should produce state machine directive with deployment checks', () => {
+      const args: CEMCPDeploymentReadinessArgs = {
+        projectPath: '/test/project',
+        targetEnvironment: 'production',
+      };
+
+      const directive = createDeploymentReadinessDirective(args);
+
+      expect(isStateMachineDirective(directive)).toBe(true);
+      expect(directive.final_state).toBe('done');
+      expect(directive.initial_state.targetEnvironment).toBe('production');
+    });
+
+    it('should abort on validation failure', () => {
+      const directive = createDeploymentReadinessDirective({
+        projectPath: '/test',
+        targetEnvironment: 'staging',
+      });
+
+      const validateTransition = directive.transitions.find(t => t.name === 'validate_readiness');
+      expect(validateTransition?.on_error).toBe('abort'); // Critical - must abort on failure
+    });
+
+    it('should cache results with appropriate TTL', () => {
+      const directive = createDeploymentReadinessDirective({
+        projectPath: '/test',
+        targetEnvironment: 'production',
+      });
+
+      const cacheTransition = directive.transitions.find(t => t.name === 'cache_result');
+      const cacheOp = cacheTransition?.operation as { args?: { ttl?: number } };
+      expect(cacheOp?.args?.ttl).toBe(1800); // 30 minutes
+    });
+
+    it('should handle all target environments', () => {
+      const environments = ['development', 'staging', 'production'] as const;
+
+      for (const env of environments) {
+        const directive = createDeploymentReadinessDirective({
+          projectPath: '/test',
+          targetEnvironment: env,
+        });
+
+        expect(directive.initial_state.targetEnvironment).toBe(env);
+      }
+    });
+  });
+
+  describe('formatDirectiveResponse Compatibility', () => {
+    it('should format orchestration directive as valid MCP response', () => {
+      const directive = createAnalyzeProjectEcosystemDirective({
+        projectPath: '/test',
+      });
+
+      const response = formatDirectiveResponse(directive);
+
+      expect(response.content).toHaveLength(1);
+      expect(response.content[0].type).toBe('text');
+
+      // Verify JSON is valid and parseable
+      const parsed = JSON.parse(response.content[0].text);
+      expect(parsed.type).toBe('orchestration_directive');
+      expect(parsed.tool).toBe('analyze_project_ecosystem');
+    });
+
+    it('should format state machine directive as valid MCP response', () => {
+      const directive = createSuggestAdrsDirective({
+        projectPath: '/test',
+      });
+
+      const response = formatDirectiveResponse(directive);
+
+      const parsed = JSON.parse(response.content[0].text);
+      expect(parsed.type).toBe('state_machine_directive');
+      expect(parsed.final_state).toBe('done');
+    });
+  });
+
+  describe('getCEMCPDirective Dispatch', () => {
+    it('should return correct directive type for each tool', () => {
+      const testCases: Array<{
+        tool: string;
+        args: Record<string, unknown>;
+        expectedType: string;
+      }> = [
+        {
+          tool: 'analyze_project_ecosystem',
+          args: { projectPath: '/test' },
+          expectedType: 'orchestration_directive',
+        },
+        {
+          tool: 'suggest_adrs',
+          args: { projectPath: '/test' },
+          expectedType: 'state_machine_directive',
+        },
+        {
+          tool: 'generate_rules',
+          args: { projectPath: '/test', ruleType: 'security' },
+          expectedType: 'orchestration_directive',
+        },
+        {
+          tool: 'analyze_environment',
+          args: { projectPath: '/test' },
+          expectedType: 'orchestration_directive',
+        },
+        {
+          tool: 'deployment_readiness',
+          args: { projectPath: '/test', targetEnvironment: 'production' },
+          expectedType: 'state_machine_directive',
+        },
+      ];
+
+      for (const { tool, args, expectedType } of testCases) {
+        const directive = getCEMCPDirective(tool, args);
+
+        expect(directive).not.toBeNull();
+        expect(directive?.type).toBe(expectedType);
+      }
+    });
+
+    it('should return null for unknown tools', () => {
+      const directive = getCEMCPDirective('unknown_tool', {});
+      expect(directive).toBeNull();
+    });
+  });
+
+  describe('Rollback Procedure', () => {
+    it('should disable CE-MCP when mode is legacy', () => {
+      const pilotTools = [
+        'analyze_project_ecosystem',
+        'suggest_adrs',
+        'generate_rules',
+        'analyze_environment',
+        'deployment_readiness',
+      ];
+
+      // In legacy mode, all tools should return false
+      for (const tool of pilotTools) {
+        const result = shouldUseCEMCPDirective(tool, { mode: 'legacy' });
+        expect(result).toBe(false);
+      }
+    });
+
+    it('should enable CE-MCP when mode is ce-mcp', () => {
+      const pilotTools = [
+        'analyze_project_ecosystem',
+        'suggest_adrs',
+        'generate_rules',
+        'analyze_environment',
+        'deployment_readiness',
+      ];
+
+      // In ce-mcp mode, pilot tools should return true
+      for (const tool of pilotTools) {
+        const result = shouldUseCEMCPDirective(tool, { mode: 'ce-mcp' });
+        expect(result).toBe(true);
+      }
+    });
+
+    it('should enable CE-MCP when mode is directive', () => {
+      // directive mode should also enable CE-MCP
+      const result = shouldUseCEMCPDirective('analyze_project_ecosystem', { mode: 'directive' });
+      expect(result).toBe(true);
+    });
+
+    it('should enable CE-MCP when mode is hybrid', () => {
+      // hybrid mode should enable CE-MCP
+      const result = shouldUseCEMCPDirective('analyze_project_ecosystem', { mode: 'hybrid' });
+      expect(result).toBe(true);
+    });
+
+    it('should not affect unknown tools regardless of mode', () => {
+      // Unknown tools should always return false
+      expect(shouldUseCEMCPDirective('unknown_tool', { mode: 'ce-mcp' })).toBe(false);
+      expect(shouldUseCEMCPDirective('unknown_tool', { mode: 'legacy' })).toBe(false);
+    });
+  });
+
+  describe('Token Savings Summary', () => {
+    it('should verify aggregate token savings meet 60% target', () => {
+      const tools = [
+        {
+          name: 'analyze_project_ecosystem',
+          directive: createAnalyzeProjectEcosystemDirective({ projectPath: '/test' }),
+          legacyTokens: 12000,
+          expectedTokens: 4000, // From metadata
+        },
+        {
+          name: 'suggest_adrs',
+          directive: createSuggestAdrsDirective({ projectPath: '/test' }),
+          legacyTokens: 3500,
+          expectedTokens: 1500, // Target from IMPLEMENTATION-PLAN
+        },
+        {
+          name: 'generate_rules',
+          directive: createGenerateRulesDirective({ projectPath: '/test', ruleType: 'security' }),
+          legacyTokens: 4000,
+          expectedTokens: 1500, // From metadata
+        },
+        {
+          name: 'analyze_environment',
+          directive: createAnalyzeEnvironmentDirective({ projectPath: '/test' }),
+          legacyTokens: 2500,
+          expectedTokens: 1000, // From metadata
+        },
+        {
+          name: 'deployment_readiness',
+          directive: createDeploymentReadinessDirective({
+            projectPath: '/test',
+            targetEnvironment: 'production',
+          }),
+          legacyTokens: 2000,
+          expectedTokens: 800, // Target from IMPLEMENTATION-PLAN
+        },
+      ];
+
+      let totalLegacyTokens = 0;
+      let totalDirectiveTokens = 0;
+
+      for (const { directive, legacyTokens, expectedTokens } of tools) {
+        totalLegacyTokens += legacyTokens;
+
+        // For orchestration directives, use estimated_tokens from metadata
+        // For state machines, use expected target tokens from plan
+        let directiveTokens: number;
+        if (isOrchestrationDirective(directive)) {
+          directiveTokens = directive.metadata?.estimated_tokens ?? expectedTokens;
+        } else {
+          // State machine directives don't have metadata.estimated_tokens
+          // Use the documented target from IMPLEMENTATION-PLAN.md
+          directiveTokens = expectedTokens;
+        }
+        totalDirectiveTokens += directiveTokens;
+
+        // Each tool should achieve documented savings
+        const reduction = ((legacyTokens - directiveTokens) / legacyTokens) * 100;
+        expect(reduction).toBeGreaterThanOrEqual(50);
+      }
+
+      // Aggregate savings should be at least 60%
+      const aggregateReduction =
+        ((totalLegacyTokens - totalDirectiveTokens) / totalLegacyTokens) * 100;
+      expect(aggregateReduction).toBeGreaterThanOrEqual(60);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Bump version to v2.4.0 with `mcpName` field so npm package includes the metadata required by the MCP Registry
- Shorten `server.json` description to meet registry's 100-char limit
- Fix unused import lint errors in `ce-mcp-migration.test.ts`

## What happens on merge
1. Auto-release creates tag → triggers "Publish to NPM" workflow → publishes v2.4.0 to npm with `mcpName`
2. "Publish to MCP Registry" workflow triggers after npm publish → registers on official MCP Registry

## Test plan
- [x] All tests pass
- [x] Lint passes (fixed unused imports)
- [ ] After merge: verify `npm view mcp-adr-analysis-server@2.4.0 mcpName` returns the correct value
- [ ] After merge: verify listing at `registry.modelcontextprotocol.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)