### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,3 +424,8 @@ MIT License - see [LICENSE](LICENSE) file for details.
 **Built with ❤️ by [Tosin Akinosho](https://github.com/tosin2013) for AI-driven architectural analysis**
 
 _Empowering AI assistants with deep architectural intelligence and decision-making capabilities._
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tosin2013-mcp-adr-analysis-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tosin2013-mcp-adr-analysis-server)