### PR TITLE
ci(dependabot): add auto-merge workflow for low-risk dependency updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # Belt-and-braces: check both the event actor and the PR author.
+    # pull_request_target runs with write perms, so we want defence in depth.
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,11 +23,13 @@ jobs:
 
       - name: Check if auto-merge is allowed
         id: check
+        env:
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
-          DEPENDENCY_NAMES="${{ steps.metadata.outputs.dependency-names }}"
-          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
-
           echo "dependency-names=$DEPENDENCY_NAMES" >> $GITHUB_STEP_SUMMARY
+          echo "dependency-type=$DEPENDENCY_TYPE" >> $GITHUB_STEP_SUMMARY
           echo "update-type=$UPDATE_TYPE" >> $GITHUB_STEP_SUMMARY
 
           # Skip MCP SDK updates — these require manual review via dependencies.yml
@@ -44,6 +48,17 @@ jobs:
             exit 0
           fi
 
+          # Skip direct production deps — patch bumps on runtime-critical deps
+          # (zod, openai, hono, firecrawl-js, etc.) can break type inference or
+          # runtime behaviour. Auto-merge is limited to dev-deps, transitive
+          # deps, and GitHub Actions.
+          if [[ "$DEPENDENCY_TYPE" == "direct:production" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=Direct production dependencies require manual review" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping auto-merge: direct:production dependency"
+            exit 0
+          fi
+
           echo "skip=false" >> $GITHUB_OUTPUT
 
       - name: Approve PR
@@ -58,26 +73,56 @@ jobs:
             --body "Auto-approved: **${UPDATE_TYPE}** update for \`${DEPENDENCY_NAMES}\`"
 
       - name: Enable auto-merge
+        id: enable-automerge
         if: steps.check.outputs.skip != 'true'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge "$PR_URL" --auto --squash
+          # Graceful fallback: if auto-merge is disabled at the repo level
+          # (Settings → Pull Requests → Allow auto-merge), `gh pr merge --auto`
+          # exits non-zero. Log it to the step summary instead of failing the
+          # workflow — the PR stays open for manual merge.
+          if gh pr merge "$PR_URL" --auto --squash 2>&1 | tee /tmp/merge.log; then
+            echo "automerge=enabled" >> $GITHUB_OUTPUT
+            echo "::notice::Auto-merge enabled; will merge once required checks pass"
+          else
+            echo "automerge=failed" >> $GITHUB_OUTPUT
+            MSG=$(cat /tmp/merge.log | head -5)
+            echo "::warning::Could not enable auto-merge — PR left open for manual review. Likely cause: repo-level 'Allow auto-merge' is disabled. Details: $MSG"
+          fi
+        continue-on-error: true
 
       - name: Summary
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          SKIP: ${{ steps.check.outputs.skip }}
+          SKIP_REASON: ${{ steps.check.outputs.reason }}
+          AUTOMERGE: ${{ steps.enable-automerge.outputs.automerge }}
         run: |
-          echo "## Dependabot Auto-Merge" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**PR**: #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Dependency**: \`${{ steps.metadata.outputs.dependency-names }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Update type**: ${{ steps.metadata.outputs.update-type }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [[ "${{ steps.check.outputs.skip }}" == "true" ]]; then
-            echo "**Action**: Skipped — ${{ steps.check.outputs.reason }}" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "**Action**: Approved and auto-merge enabled (squash)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Merge will proceed once all required status checks pass." >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Dependabot Auto-Merge"
+            echo ""
+            echo "**PR**: #${PR_NUMBER} — ${PR_TITLE}"
+            echo "**Dependency**: \`${DEPENDENCY_NAMES}\`"
+            echo "**Dependency type**: \`${DEPENDENCY_TYPE}\`"
+            echo "**Update type**: \`${UPDATE_TYPE}\`"
+            echo ""
+            if [[ "$SKIP" == "true" ]]; then
+              echo "**Action**: Skipped — ${SKIP_REASON}"
+            elif [[ "$AUTOMERGE" == "enabled" ]]; then
+              echo "**Action**: Approved and auto-merge enabled (squash)"
+              echo ""
+              echo "Merge will proceed once all required status checks pass."
+            else
+              echo "**Action**: Approved, but auto-merge could NOT be enabled"
+              echo ""
+              echo "This usually means repo-level 'Allow auto-merge' is disabled."
+              echo "Settings → General → Pull Requests → Allow auto-merge."
+              echo "PR left open for manual merge."
+            fi
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,83 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if auto-merge is allowed
+        id: check
+        run: |
+          DEPENDENCY_NAMES="${{ steps.metadata.outputs.dependency-names }}"
+          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
+
+          echo "dependency-names=$DEPENDENCY_NAMES" >> $GITHUB_STEP_SUMMARY
+          echo "update-type=$UPDATE_TYPE" >> $GITHUB_STEP_SUMMARY
+
+          # Skip MCP SDK updates — these require manual review via dependencies.yml
+          if echo "$DEPENDENCY_NAMES" | grep -q "@modelcontextprotocol/sdk"; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=MCP SDK updates require manual review" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping auto-merge: MCP SDK updates require manual review"
+            exit 0
+          fi
+
+          # Skip major version bumps
+          if [[ "$UPDATE_TYPE" == "version-update:semver-major" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=Major version bumps require manual review" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping auto-merge: major version bump"
+            exit 0
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Approve PR
+        if: steps.check.outputs.skip != 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          gh pr review "$PR_URL" --approve \
+            --body "Auto-approved: **${UPDATE_TYPE}** update for \`${DEPENDENCY_NAMES}\`"
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.skip != 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "$PR_URL" --auto --squash
+
+      - name: Summary
+        run: |
+          echo "## Dependabot Auto-Merge" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**PR**: #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Dependency**: \`${{ steps.metadata.outputs.dependency-names }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Update type**: ${{ steps.metadata.outputs.update-type }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ steps.check.outputs.skip }}" == "true" ]]; then
+            echo "**Action**: Skipped — ${{ steps.check.outputs.reason }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Action**: Approved and auto-merge enabled (squash)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Merge will proceed once all required status checks pass." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
Auto-approves and enables auto-merge (squash) for **low-risk** Dependabot PRs. The scope is intentionally conservative: only dev-deps, transitive deps, and GitHub Actions bumps auto-merge. Production deps stay in the manual-review queue.

## Auto-merge gate

| Dependency-type / update-type              | Action                                      |
| ------------------------------------------ | ------------------------------------------- |
| `direct:development` (patch/minor)         | ✅ Auto-approve + auto-merge                |
| `indirect` (transitive, patch/minor)       | ✅ Auto-approve + auto-merge                |
| `github_actions` ecosystem (patch/minor)   | ✅ Auto-approve + auto-merge                |
| `direct:production` (any type)             | ⏸️ Skip — manual review (zod, openai, etc.) |
| `@modelcontextprotocol/sdk` (any type)     | ⏸️ Skip — manual review                     |
| Any major version bump                     | ⏸️ Skip — manual review                     |

## Safety mechanisms
- `pull_request_target` with explicit `contents: write` / `pull-requests: write` permissions.
- Belt-and-braces actor check: **both** `github.actor == 'dependabot[bot]'` AND `github.event.pull_request.user.login == 'dependabot[bot]'`.
- Every skip reason logged to the step summary for auditability.
- `gh pr merge --auto --squash` is non-blocking — branch protection (`build`, `lint`, `test (20)`, `test (22)`) still gates the actual merge.
- Graceful fallback if repo-level "Allow auto-merge" is disabled: the workflow logs a warning in the step summary and leaves the PR open for manual merge instead of erroring the job.

## Why the CHANGELOG backfill made this necessary

The CHANGELOG backfill in #782 made it visible that ~70% of the 48 tags between v2.0.14 and v2.5.0 were pure dependency bumps. Auto-merging the low-risk subset cuts review fatigue without handing the keys over for production dependencies.

## Repo-level prerequisites — one-time, admin only

Both need to be verified in the repo settings before this workflow has any observable effect:

1. **Settings → General → Pull Requests → "Allow auto-merge"** must be ON. Without this, `gh pr merge --auto` exits non-zero. The workflow now handles that gracefully (PR stays open), but auto-merge won't actually happen.
2. **Settings → Code security → Dependabot → "Allow GitHub Actions to create and approve pull requests"** should be ON so the Dependabot token can trigger the workflow.

Branch-protection approvals: none required on `main` currently (`required_pull_request_reviews: null`), so the workflow's self-approval satisfies any future requirement if added.

## Test plan
- [ ] Repo-level auto-merge ON (see above)
- [ ] Merge this PR
- [ ] Next `direct:development` Dependabot patch bump → auto-approved + auto-merged once CI green
- [ ] Next `direct:production` Dependabot PR (e.g., zod / openai / hono) → skip reason in step summary, PR stays open
- [ ] Next `@modelcontextprotocol/sdk` bump → skip reason logged
- [ ] Any major bump → skip reason logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)