### PR TITLE
fix(ci): make publish gate a single source of truth (#787)

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -101,12 +101,51 @@ jobs:
 
       - name: Set publish gate output
         id: publish-gate
+        env:
+          SHOULD_SKIP: ${{ steps.should-skip.outputs.should_skip }}
+          CONFIG_ENABLED: ${{ steps.config.outputs.enabled }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [[ "${{ steps.should-skip.outputs.should_skip }}" == "true" ]]; then
-            echo "should_publish=false" >> $GITHUB_OUTPUT
+          # Compute the gate explicitly. This is the single source of truth for
+          # whether publish-npm should run. Do NOT re-evaluate github.event
+          # context in the publish-npm job — the downstream evaluation has been
+          # unreliable historically (see #787).
+          if [[ "$CONFIG_ENABLED" != "true" ]]; then
+            GATE="false"
+            REASON="auto-release disabled in .github/auto-release.config.json"
+          elif [[ "$SHOULD_SKIP" == "true" ]]; then
+            GATE="false"
+            REASON="PR carries a skip-release label"
+          elif [[ "$PR_MERGED" != "true" ]]; then
+            GATE="false"
+            REASON="PR was not merged"
+          elif [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+            GATE="false"
+            REASON="Dependabot PRs are handled by dependabot-auto-merge.yml"
           else
-            echo "should_publish=true" >> $GITHUB_OUTPUT
+            GATE="true"
+            REASON="All preconditions met"
           fi
+
+          echo "should_publish=$GATE" >> $GITHUB_OUTPUT
+          echo "gate_reason=$REASON" >> $GITHUB_OUTPUT
+
+          # Surface the decision in workflow logs + step summary so future
+          # debugging does not require guessing at context values.
+          echo "::notice::publish gate = $GATE ($REASON)"
+          {
+            echo "## Publish gate decision"
+            echo ""
+            echo "| Input | Value |"
+            echo "|---|---|"
+            echo "| config.enabled | \`$CONFIG_ENABLED\` |"
+            echo "| should_skip | \`$SHOULD_SKIP\` |"
+            echo "| pr.merged | \`$PR_MERGED\` |"
+            echo "| pr.author | \`$PR_AUTHOR\` |"
+            echo ""
+            echo "**Decision**: \`should_publish=$GATE\` — $REASON"
+          } >> $GITHUB_STEP_SUMMARY
 
       - name: Determine version bump type
         id: version-type
@@ -400,12 +439,23 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "To enable auto-release, update `.github/auto-release.config.json` or remove skip labels." >> $GITHUB_STEP_SUMMARY
 
-  # Trigger NPM publishing
+  # Trigger NPM publishing.
+  #
+  # Do NOT re-check github.event.pull_request.* here — those have been
+  # unreliable in downstream jobs historically (see #787). The
+  # `publish-gate` step in `auto-release` is the single source of truth
+  # and already factors in PR merged state, skip labels, Dependabot
+  # authorship, and the enabled flag.
+  #
+  # Equality check against 'true' is the simplest GHA-safe comparison:
+  # `fromJSON()` had edge cases when the output was an empty string
+  # (the previous attempted fix in #808 used fromJSON and still failed).
   publish-npm:
     needs: auto-release
-    if: github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]' && fromJSON(needs.auto-release.outputs.should-publish)
+    if: needs.auto-release.outputs.should-publish == 'true'
     uses: ./.github/workflows/publish.yml
     with:
       version: v${{ needs.auto-release.outputs.new-version }}
       skip_tests: false
-    # Using OIDC Trusted Publishing - no token required
+    # Uses OIDC Trusted Publishing — no NPM_TOKEN required.
+    # Trusted Publisher is configured on npmjs.com for this repo + publish.yml.


### PR DESCRIPTION
## Summary
Fixes the root cause of #787: `publish-npm` is silently SKIPPED on every auto-release run, even when the auto-release job succeeds. v2.5.1, v2.5.2, and v2.5.3 all hit this; the npm catch-up was done manually.

## Root cause
Previously the \`publish-npm\` job gated on three conditions chained with \`&&\`:

\`\`\`yaml
if: github.event.pull_request.merged == true
    && github.event.pull_request.user.login != 'dependabot[bot]'
    && fromJSON(needs.auto-release.outputs.should-publish)
\`\`\`

The \`should-publish\` output was correctly set to \`"true"\` by the gate step (verified in logs), but the \`&&\` chain still evaluated to falsy. The exact reason is unclear, but the prior attempted fix (#808) swapped \`== 'true'\` for \`fromJSON()\` and still failed. Two bugs in one month on the same gate is a strong signal the expression pattern itself is fragile.

## Fix
Consolidate all preconditions into the \`publish-gate\` step inside \`auto-release\`:

- \`config.enabled == 'true'\` (from \`.github/auto-release.config.json\`)
- \`should_skip == 'false'\` (no skip labels on the PR)
- \`github.event.pull_request.merged == 'true'\`
- \`github.event.pull_request.user.login != 'dependabot[bot]'\`

The step emits \`should_publish=true|false\` plus a human-readable reason. The \`publish-npm\` job becomes a plain single-field comparison:

\`\`\`yaml
if: needs.auto-release.outputs.should-publish == 'true'
\`\`\`

String equality against \`'true'\` has no known GHA edge cases, unlike \`fromJSON()\` or multi-clause \`github.event\` lookups in downstream jobs.

## Also improves debuggability
Every run now writes a **publish gate decision** table to the step summary:

| Input | Value |
|---|---|
| config.enabled | \`true\` |
| should_skip | \`false\` |
| pr.merged | \`true\` |
| pr.author | \`tosin2013\` |

**Decision**: \`should_publish=true\` — All preconditions met

No more guessing at context values when the gate misfires.

## Test plan

- [ ] Merge this PR (will trigger auto-release on main for v2.5.4)
- [ ] Check the \`publish gate decision\` table in the auto-release step summary
- [ ] Verify \`publish-npm / create-release\` and \`publish-npm / test-and-publish\` no longer show as SKIPPED
- [ ] Verify \`npm view mcp-adr-analysis-server dist-tags\` reports \`latest: 2.5.4\` after the workflow completes
- [ ] Verify \`registry.modelcontextprotocol.io\` also updates via the downstream \`publish-mcp-registry.yml\`

## Doesn't fix (separate work)

- The \`action_required\` CI blocker on bot-authored PRs (the chore/version-bump-* PRs). That is a repo Actions setting change, not a workflow change.
- The v2.5.1 tag pointing to a pre-v2.5.0 SHA. Already fixed in #808 via \`Capture merge commit SHA\` guarded with a merge-base check.

Closes #787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)