### PR TITLE
fix(ci): fix test-and-publish condition for reusable-workflow-call path (#787)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,8 +195,24 @@ jobs:
   test-and-publish:
     runs-on: ubuntu-latest
     needs: [create-release]
-    # Run if we created a release OR if triggered by tag push OR called from another workflow
-    if: always() && (needs.create-release.result == 'success' || github.event_name == 'push' || github.event_name == 'workflow_call')
+    # Run in all entry paths EXCEPT when create-release actively failed.
+    #
+    # Expected results of needs.create-release.result:
+    #   - 'success'   → workflow_dispatch path succeeded; test-and-publish should run
+    #   - 'skipped'   → create-release's `if: github.event_name == 'workflow_dispatch'`
+    #                   evaluated false, which happens for push/workflow_call paths;
+    #                   test-and-publish still needs to run
+    #   - 'failure'   → workflow_dispatch path hit an error; don't attempt publish
+    #   - 'cancelled' → don't attempt publish
+    #
+    # Historical note (#787): the previous condition checked
+    # `github.event_name == 'workflow_call'` to detect the reusable-workflow-call
+    # path. But inside a reusable workflow, `github.event_name` reflects the
+    # CALLER's event (e.g. `pull_request` when called from auto-release-on-merge),
+    # NOT `workflow_call`. That silently skipped this job for every
+    # auto-release-driven publish, causing v2.5.1–v2.5.3 to land on GitHub but
+    # never reach npm. The broader `!= 'failure'` check handles all paths.
+    if: always() && needs.create-release.result != 'failure' && needs.create-release.result != 'cancelled'
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Summary
**This is the real root cause** of why v2.5.1–v2.5.3 landed as GitHub tags but never reached npm. The previous attempted fixes (#808, #810) hardened the publish gate in \`auto-release-on-merge.yml\`, but \`publish-npm\`'s sub-jobs still showed as SKIPPED on every run. I spent time trying to diagnose the caller-side condition before realizing the issue is inside \`publish.yml\` itself.

## The bug

\`publish.yml\` line 199:
\`\`\`yaml
test-and-publish:
  needs: [create-release]
  if: always() && (
    needs.create-release.result == 'success'
    || github.event_name == 'push'
    || github.event_name == 'workflow_call'   # <-- never matches
  )
\`\`\`

When \`publish.yml\` is called as a reusable workflow via \`uses: ./.github/workflows/publish.yml\` from \`auto-release-on-merge.yml\`, \`github.event_name\` inside the called workflow is the **caller's** event (\`pull_request: closed\`), NOT \`workflow_call\`. Per [GitHub docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context):

> The \`github\` context within the reusable workflow is evaluated based on the event that triggered the caller workflow.

So for every auto-release-driven publish:
- \`needs.create-release.result == 'success'\` → false (\`create-release\` was skipped, since its own \`if:\` requires \`workflow_dispatch\`)
- \`github.event_name == 'push'\` → false (it's \`pull_request\`)
- \`github.event_name == 'workflow_call'\` → **false** (it's \`pull_request\`, NOT \`workflow_call\`)

All three branches false → \`test-and-publish\` skipped → no npm publish.

This also explains why \`v2.4.1\` DID reach npm: it was published via the \`push: tags: v*\` trigger directly, not through the reusable workflow call. That path hits \`github.event_name == 'push'\` → true → publish runs.

## The fix

Replace the event-name check with a result-based check:

\`\`\`yaml
if: always() && needs.create-release.result != 'failure' && needs.create-release.result != 'cancelled'
\`\`\`

This handles all four entry paths correctly:

| Trigger | \`create-release.result\` | test-and-publish runs? |
|---|---|---|
| \`workflow_dispatch\` | \`success\` | ✅ |
| \`push: tags: v*\` | \`skipped\` (if: workflow_dispatch was false) | ✅ |
| \`workflow_call\` | \`skipped\` | ✅ |
| \`pull_request\` closed (via auto-release-on-merge) | \`skipped\` | ✅ |
| Something upstream broke | \`failure\` | ❌ |
| Run cancelled | \`cancelled\` | ❌ |

Also adds a detailed comment documenting the historical context so this doesn't get rediscovered the hard way in another 7 months.

## Test plan
- [ ] Merge this PR → auto-release fires for v2.5.5
- [ ] Check the \`Publish gate decision\` step summary on the auto-release run (added by #810) — should show \`should_publish=true\`
- [ ] Verify \`publish-npm / test-and-publish\` is **no longer SKIPPED** — should be \`success\`
- [ ] Verify \`npm view mcp-adr-analysis-server dist-tags\` reports \`latest: 2.5.5\` within ~2 min of merge
- [ ] Verify \`registry.modelcontextprotocol.io\` also updates via \`publish-mcp-registry.yml\`

Fixes #787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)