### PR TITLE
fix(ci): publish.yml workflow_call detection (follow-up to #814)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -228,7 +228,14 @@ jobs:
       - name: Determine version and source
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_call" && -n "${{ inputs.version }}" ]]; then
+          # NOTE: Detect the workflow_call path by `inputs.version` being set,
+          # NOT by `github.event_name == 'workflow_call'`. Inside a reusable
+          # workflow, `github.event_name` reflects the CALLER's event (e.g.
+          # `pull_request`), not `workflow_call`. This is the same trap that
+          # silently skipped the outer test-and-publish gate before #814.
+          # `inputs.version` is only populated on the workflow_call path,
+          # making it a reliable discriminator.
+          if [[ -n "${{ inputs.version }}" ]]; then
             # Called from another workflow with version
             TAG_NAME="${{ inputs.version }}"
             VERSION=${TAG_NAME#v}  # Remove 'v' prefix


### PR DESCRIPTION
## Summary

Follow-up fix discovered while verifying the #814 (#787) release-pipeline repair.

#814 correctly fixed the **outer** `test-and-publish` gate in `publish.yml`, so the job now runs on the auto-release-driven `workflow_call` path. But the **inner** version-source detection (line 231) had the **same `github.event_name == 'workflow_call'` trap**:

\`\`\`yaml
if [[ "${{ github.event_name }}" == "workflow_call" && -n "${{ inputs.version }}" ]]; then
\`\`\`

Inside a reusable workflow, \`github.event_name\` reflects the caller's event (\`pull_request\` from \`auto-release-on-merge.yml\`), not \`workflow_call\`. So the first branch never matched, the script fell through to \`exit 1\`, and v2.6.0 and v2.6.1 never reached npm even though their GitHub tags + releases were created.

## Evidence

From the failing run for the #814 merge ([run 25085393531](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/25085393531)):

\`\`\`
publish-npm / test-and-publish — failure
if [[ "pull_request" == "workflow_call" && -n "v2.6.1" ]]; then
...
❌ Could not determine version source
\`\`\`

Current state: \`npm view mcp-adr-analysis-server dist-tags\` reports \`latest: 2.5.4\` (last successful publish was 2026-04-22), while main is at v2.6.1.

## Fix

Replace the broken first condition with a check on \`inputs.version\` directly. \`inputs.version\` is only populated on the \`workflow_call\` path, so it's a reliable discriminator that doesn't depend on the (caller-influenced) event name. Same shape as the #814 fix, just one level deeper.

## Test plan

- [ ] Merge this PR
- [ ] Trigger \`publish.yml\` via \`workflow_dispatch\` with \`version=v2.6.1\` (or wait for the next auto-release-driven push)
- [ ] Verify \`publish-npm / test-and-publish\` reaches the \`Publishing from workflow call\` log line and proceeds past version detection
- [ ] Verify \`npm view mcp-adr-analysis-server dist-tags\` reports \`latest: 2.6.1\` within ~2 min

Made with [Cursor](https://cursor.com)