### PR TITLE
chore(ci): add OIDC token diagnostic to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -447,6 +447,30 @@ jobs:
 
           echo "✅ Package is ready for publishing"
 
+      - name: Inspect OIDC token claims (diagnostic)
+        # Temporary diagnostic to surface the exact subject claim that npm's
+        # Trusted Publisher will match against. Do NOT remove until OIDC
+        # publishing has been verified end-to-end. See PR #864 + the
+        # `Finish OIDC Trusted Publisher` plan for context.
+        run: |
+          OIDC_TOKEN=$(curl -sLS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" \
+            | jq -r .value)
+          if [[ -z "$OIDC_TOKEN" || "$OIDC_TOKEN" == "null" ]]; then
+            echo "::error::Failed to obtain OIDC token (id-token: write missing?)"
+            exit 1
+          fi
+          # JWT payload is the second dot-separated segment, base64url-encoded.
+          # Pad to a multiple of 4 so plain base64 -d accepts it.
+          PAYLOAD_RAW=$(echo "$OIDC_TOKEN" | cut -d. -f2)
+          PAD=$(( 4 - ${#PAYLOAD_RAW} % 4 ))
+          [[ "$PAD" -lt 4 ]] && PAYLOAD_RAW="${PAYLOAD_RAW}$(printf '=%.0s' $(seq 1 $PAD))"
+          PAYLOAD=$(echo "$PAYLOAD_RAW" | tr '_-' '/+' | base64 -d 2>/dev/null)
+          echo "::group::OIDC token claims (configure these on npmjs.com)"
+          echo "$PAYLOAD" | jq '{aud, sub, repository, repository_owner, workflow_ref, job_workflow_ref, environment, ref, event_name}'
+          echo "::endgroup::"
+
       - name: Publish to NPM
         run: |
           VERSION="${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

Surfaces the exact OIDC subject claim that npm sees when `publish.yml` runs, so we can correctly configure the Trusted Publisher on npmjs.com.

## Why

Per `gh run list --workflow publish.yml`, **no successful run since the OIDC migration in commit \`115896b9\` (Jan 18 2026)**. Today's v2.6.2 attempt reached \`npm publish --provenance\` and got back:

\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/mcp-adr-analysis-server
\`\`\`

In OIDC publish flow, that 404 means \"no Trusted Publisher matches this OIDC token's subject claim.\" To register the matching rule on npmjs.com correctly, we need to see what \`job_workflow_ref\` actually looks like in our specific call path (which goes through \`workflow_call\` from \`auto-release-on-merge.yml\`).

## What this PR does

Adds one diagnostic step to the \`test-and-publish\` job, immediately before \`npm publish\`. It:

1. Requests an OIDC token scoped to \`npm:registry.npmjs.org\` (same audience npm uses).
2. Base64-decodes the JWT payload (no token leakage \u2014 the token itself is masked by GitHub).
3. Prints \`{aud, sub, repository, repository_owner, workflow_ref, job_workflow_ref, environment, ref, event_name}\` in a collapsible log group.

## Expected outcome

This PR's publish-npm job will still **fail** (it's the same 404 \u2014 npmjs.com config is the actual fix). That's fine; we're harvesting the diagnostic from the log. Once Trusted Publisher is configured on npmjs.com using the printed \`job_workflow_ref\`, the next publish run will succeed.

A follow-up PR removes (or hides behind a debug flag) the diagnostic once OIDC publishing is verified end-to-end.

## Plan reference

Phase 1 of the \`Finish OIDC Trusted Publisher\` plan.

Made with [Cursor](https://cursor.com)