### PR TITLE
chore(scripts): rebuild sync-tags-to-npm.sh as a real reconciliation tool

### DIFF
--- a/scripts/sync-tags-to-npm.sh
+++ b/scripts/sync-tags-to-npm.sh
@@ -1,191 +1,257 @@
 #!/bin/bash
 
-# Temporary script to sync GitHub tags to npm
-# This ensures all GitHub tags are published to npm
+# Reconcile GitHub release tags with the npm registry, and (optionally) publish
+# any v* tags that are missing from npm.
+#
+# Background: the package has a stuck v3.0.0 on npm (mistaken publish on
+# 2025-07-04) while the maintained line is v2.x. Because of that, every npm
+# publish on the v2 line MUST pass `--tag latest` explicitly — otherwise npm
+# refuses with `Cannot implicitly apply the "latest" tag because previously
+# published version 3.0.0 is higher`. This script handles that automatically.
+#
+# Modes:
+#   ./sync-tags-to-npm.sh             # report-only, recent gap (default)
+#   ./sync-tags-to-npm.sh --all       # report-only, include historical missing tags
+#   ./sync-tags-to-npm.sh --publish   # publish recent gap (newer than npm latest)
+#   ./sync-tags-to-npm.sh --publish --all  # publish ALL missing tags (use with care)
+#
+# "Recent" means tags whose version is greater than the current npm `latest`
+# dist-tag. Historical gaps (older patch versions never published) are usually
+# abandoned and not worth backfilling; --all opts back into seeing them.
+#
+# Requirements (for --publish):
+#   - `npm whoami` must succeed (i.e. you have an authenticated ~/.npmrc)
+#   - clean working tree (the script will checkout tags and return you to your
+#     original branch when done)
 
 set -e
 
-echo "================================================"
-echo "GitHub Tags to NPM Sync Script"
-echo "================================================"
-echo ""
-
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+BOLD='\033[1m'
+NC='\033[0m'
 
-# Configuration
-DRY_RUN=${1:-true}
-if [ "$1" == "--publish" ]; then
-    DRY_RUN=false
-fi
+PACKAGE="mcp-adr-analysis-server"
+PUBLISH=false
+SHOW_ALL=false
+for arg in "$@"; do
+    case "$arg" in
+        --publish) PUBLISH=true ;;
+        --all)     SHOW_ALL=true ;;
+        -h|--help)
+            sed -n '3,18p' "$0" | sed 's/^# //;s/^#//'
+            exit 0 ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Run with --help for usage." >&2
+            exit 2 ;;
+    esac
+done
 
-echo -e "${BLUE}Mode: $([ "$DRY_RUN" == "true" ] && echo "DRY RUN (use --publish to actually publish)" || echo "PUBLISHING")${NC}"
+echo "================================================"
+echo "GitHub Tags <-> npm Reconciliation"
+echo "================================================"
+echo ""
+echo -e "${BLUE}Package:${NC} $PACKAGE"
+echo -e "${BLUE}Mode:${NC}    $([ "$PUBLISH" == "true" ] && echo -e "${BOLD}PUBLISH${NC}" || echo -e "report-only (pass --publish to actually publish)")"
+echo -e "${BLUE}Scope:${NC}   $([ "$SHOW_ALL" == "true" ] && echo "ALL missing tags (including abandoned history)" || echo "recent gap only (newer than npm latest); pass --all for full history)")"
 echo ""
 
-# Function to check if version exists on npm
-check_npm_version() {
-    local version=$1
-    # Remove 'v' prefix if present
-    version=${version#v}
-
-    # Check if version exists on npm
-    if npm view mcp-adr-analysis-server@$version version >/dev/null 2>&1; then
-        return 0
-    else
-        return 1
-    fi
-}
-
-# Function to publish a specific version
-publish_version() {
-    local tag=$1
-    local commit=$2
-
-    # Remove 'v' prefix for version number
-    local version=${tag#v}
-
-    echo -e "${YELLOW}Publishing $tag (version $version)...${NC}"
-
-    # Checkout the tag
-    echo "  → Checking out $tag..."
-    git checkout $tag --quiet
-
-    # The tag should already have the correct version in package.json
-    # No need to update it since we're on the exact tag
-
-    # Build the project
-    echo "  → Building project..."
-    npm run build
-
-    # Publish to npm (skip prepublishOnly hooks to avoid linting issues)
-    if [ "$DRY_RUN" == "true" ]; then
-        echo -e "  ${BLUE}→ [DRY RUN] Would run: npm publish --ignore-scripts${NC}"
-        echo "  → Dry run of npm publish..."
-        npm publish --dry-run --ignore-scripts
-    else
-        echo "  → Publishing to npm (skipping hooks)..."
-        npm publish --ignore-scripts
-        echo -e "  ${GREEN}✓ Published $tag to npm${NC}"
-    fi
-
-    echo ""
-}
-
-# Store current branch to return to it later
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$CURRENT_BRANCH" == "HEAD" ]; then
-    CURRENT_BRANCH=$(git rev-parse HEAD)
+# Track original branch so we can restore it after tag checkouts
+ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$ORIGINAL_BRANCH" == "HEAD" ]]; then
+    ORIGINAL_BRANCH=$(git rev-parse HEAD)
 fi
 
-# Ensure we have latest tags
-echo "Fetching latest tags from GitHub..."
+# Pre-flight checks for --publish mode
+if [[ "$PUBLISH" == "true" ]]; then
+    echo "Pre-flight checks..."
+    if ! NPM_USER=$(npm whoami 2>/dev/null); then
+        echo -e "${RED}✗ npm whoami failed.${NC} Run \`npm login\` first."
+        exit 1
+    fi
+    echo -e "  ${GREEN}✓${NC} npm authenticated as: ${BOLD}$NPM_USER${NC}"
+
+    if ! git diff-index --quiet HEAD --; then
+        echo -e "${RED}✗ Working tree has uncommitted changes.${NC} Commit or stash first."
+        exit 1
+    fi
+    echo -e "  ${GREEN}✓${NC} working tree is clean"
+    echo ""
+fi
+
+# Fetch tags so we have the freshest view
+echo "Fetching tags from origin..."
 git fetch --tags --quiet 2>/dev/null || true
 
-# Get all tags from GitHub
-echo -e "${BLUE}Analyzing GitHub tags...${NC}"
-GITHUB_TAGS=$(git tag -l | grep "^v" | sort -V)
+# Build the list of v* tags from git, sorted by semver. Use a portable
+# read-into-array pattern (mapfile is bash 4+; macOS ships 3.2 by default).
+GITHUB_TAGS=()
+while IFS= read -r tag; do
+    GITHUB_TAGS+=("$tag")
+done < <(git tag -l 'v*' | sort -V)
+if [[ ${#GITHUB_TAGS[@]} -eq 0 ]]; then
+    echo -e "${RED}✗ No v* tags found locally. Did you fetch?${NC}"
+    exit 1
+fi
 
-# Arrays to store results
-MISSING_ON_NPM=()
-EXISTS_ON_NPM=()
-FAILED_TAGS=()
+# Pull the full version list from npm in one call (~1 round-trip vs N)
+echo "Reading npm version list..."
+NPM_VERSIONS_JSON=$(npm view "$PACKAGE" versions --json 2>/dev/null)
+if [[ -z "$NPM_VERSIONS_JSON" ]]; then
+    echo -e "${RED}✗ Could not read npm versions for $PACKAGE.${NC}"
+    exit 1
+fi
 
-# Check each tag
-echo ""
-echo "Checking npm registry for each tag..."
-echo "----------------------------------------"
+# What is currently `latest` on npm? Used to filter "recent" gaps.
+NPM_LATEST=$(npm view "$PACKAGE" dist-tags.latest 2>/dev/null)
 
-for tag in $GITHUB_TAGS; do
-    version=${tag#v}
-    printf "Checking %-10s ... " "$tag"
-
-    if check_npm_version $version; then
-        echo -e "${GREEN}✓ exists on npm${NC}"
-        EXISTS_ON_NPM+=($tag)
+# Compare GitHub tags vs npm. Classify each missing tag as "recent" (newer
+# than npm latest) or "historical" (older — typically abandoned).
+MISSING_RECENT=()
+MISSING_HISTORICAL=()
+PRESENT=()
+for tag in "${GITHUB_TAGS[@]}"; do
+    version="${tag#v}"
+    if echo "$NPM_VERSIONS_JSON" | jq -e --arg v "$version" 'index($v)' >/dev/null; then
+        PRESENT+=("$tag")
     else
-        echo -e "${RED}✗ missing on npm${NC}"
-        MISSING_ON_NPM+=($tag)
+        # `sort -V` puts higher versions later; use it to compare against
+        # NPM_LATEST without pulling in a semver dependency.
+        if [[ -n "$NPM_LATEST" ]] && [[ "$version" == "$(printf '%s\n%s\n' "$version" "$NPM_LATEST" | sort -V | tail -1)" ]] && [[ "$version" != "$NPM_LATEST" ]]; then
+            MISSING_RECENT+=("$tag")
+        else
+            MISSING_HISTORICAL+=("$tag")
+        fi
     fi
 done
 
+# Pick the working set based on --all
+if [[ "$SHOW_ALL" == "true" ]]; then
+    MISSING=("${MISSING_RECENT[@]}" "${MISSING_HISTORICAL[@]}")
+else
+    MISSING=("${MISSING_RECENT[@]}")
+fi
+
+# Report
 echo ""
 echo "================================================"
-echo "Summary:"
+echo "Reconciliation Report"
 echo "================================================"
-echo -e "${GREEN}Tags on npm:${NC} ${#EXISTS_ON_NPM[@]}"
-echo -e "${RED}Missing tags:${NC} ${#MISSING_ON_NPM[@]}"
+echo -e "GitHub v* tags:           ${BOLD}${#GITHUB_TAGS[@]}${NC}"
+echo -e "Already on npm:           ${GREEN}${BOLD}${#PRESENT[@]}${NC}"
+echo -e "Missing (recent gap):     ${RED}${BOLD}${#MISSING_RECENT[@]}${NC}"
+echo -e "Missing (historical):     ${YELLOW}${BOLD}${#MISSING_HISTORICAL[@]}${NC}  (use --all to act on these)"
+echo ""
 
-if [ ${#MISSING_ON_NPM[@]} -eq 0 ]; then
-    echo -e "${GREEN}✓ All GitHub tags are already published to npm!${NC}"
-    git checkout $CURRENT_BRANCH --quiet
+# Show recent tag status (last 10 GitHub tags by semver)
+echo -e "${BLUE}Recent GitHub tags and their npm status:${NC}"
+START=$(( ${#GITHUB_TAGS[@]} > 10 ? ${#GITHUB_TAGS[@]} - 10 : 0 ))
+for ((i=START; i<${#GITHUB_TAGS[@]}; i++)); do
+    tag="${GITHUB_TAGS[$i]}"
+    version="${tag#v}"
+    if echo "$NPM_VERSIONS_JSON" | jq -e --arg v "$version" 'index($v)' >/dev/null; then
+        printf "  ${GREEN}✓${NC} %-12s %s\n" "$tag" "(on npm)"
+    else
+        printf "  ${RED}✗${NC} %-12s %s\n" "$tag" "(MISSING)"
+    fi
+done
+
+# Always surface the current dist-tag situation since it changes publish args
+echo ""
+echo -e "${BLUE}Current npm dist-tags:${NC}"
+npm view "$PACKAGE" dist-tags --json 2>/dev/null | jq -r 'to_entries | .[] | "  \(.key): \(.value)"'
+HIGHEST_NPM=$(echo "$NPM_VERSIONS_JSON" | jq -r 'sort_by(. | split(".") | map(tonumber? // 0)) | last')
+echo -e "${BLUE}Highest published version on npm:${NC} $HIGHEST_NPM"
+if [[ "$HIGHEST_NPM" != "$NPM_LATEST" ]]; then
+    echo -e "  ${YELLOW}⚠${NC} Highest version ($HIGHEST_NPM) does NOT match latest tag ($NPM_LATEST)."
+    echo -e "  ${YELLOW}  All v2.x publishes must pass \`--tag latest\` to override npm's default.${NC}"
+fi
+
+if [[ ${#MISSING[@]} -eq 0 ]]; then
+    echo ""
+    echo -e "${GREEN}✓ All GitHub v* tags are already published to npm.${NC}"
     exit 0
 fi
 
+# Print missing tags (chronological / semver order)
 echo ""
-echo "Missing tags that need to be published:"
-for tag in "${MISSING_ON_NPM[@]}"; do
+echo -e "${RED}Missing tags (need publish):${NC}"
+for tag in "${MISSING[@]}"; do
     echo "  - $tag"
 done
 
+# In report mode, surface the exact commands the user (or this script with
+# --publish) would run.
+if [[ "$PUBLISH" != "true" ]]; then
+    echo ""
+    echo "================================================"
+    echo "To publish locally (requires npm auth + clean tree):"
+    echo "================================================"
+    echo "  ./scripts/sync-tags-to-npm.sh --publish"
+    echo ""
+    echo "Or per-tag manually:"
+    for tag in "${MISSING[@]}"; do
+        echo "  git checkout $tag && npm ci && npm run build && npm publish --tag latest --access public --ignore-scripts"
+    done
+    echo ""
+    echo "After publishing, return to your branch with:"
+    echo "  git checkout $ORIGINAL_BRANCH"
+    exit 0
+fi
+
+# --publish path
 echo ""
 echo "================================================"
-echo "Publishing missing tags to npm"
+echo "Publishing missing tags"
 echo "================================================"
-echo ""
 
-# Process each missing tag
-for tag in "${MISSING_ON_NPM[@]}"; do
-    echo "----------------------------------------"
-    echo "Processing $tag"
-    echo "----------------------------------------"
+FAILED=()
+for tag in "${MISSING[@]}"; do
+    version="${tag#v}"
+    echo ""
+    echo -e "${YELLOW}── $tag ──${NC}"
 
-    # Get commit hash for tag
-    commit=$(git rev-list -n 1 $tag)
+    echo "  → checkout $tag"
+    git checkout "$tag" --quiet
 
-    # Try to publish
-    if publish_version $tag $commit; then
-        echo -e "${GREEN}✓ Successfully processed $tag${NC}"
+    echo "  → npm ci"
+    npm ci --silent
+
+    echo "  → npm run build"
+    npm run build >/dev/null
+
+    # --tag latest is mandatory while v3.0.0 sits above us; --ignore-scripts
+    # avoids the prepublishOnly hook (which re-runs the full build + lint).
+    echo "  → npm publish --tag latest --access public --ignore-scripts"
+    if npm publish --tag latest --access public --ignore-scripts; then
+        echo -e "  ${GREEN}✓ published $tag${NC}"
     else
-        echo -e "${RED}✗ Failed to publish $tag${NC}"
-        FAILED_TAGS+=($tag)
+        echo -e "  ${RED}✗ failed to publish $tag${NC}"
+        FAILED+=("$tag")
     fi
 done
 
-# Return to original branch
+# Restore original branch
 echo ""
-echo "Returning to original branch..."
-git checkout $CURRENT_BRANCH --quiet
+echo "Restoring original branch: $ORIGINAL_BRANCH"
+git checkout "$ORIGINAL_BRANCH" --quiet
 
-# Final summary
+# Summary
 echo ""
 echo "================================================"
-echo "Final Results:"
+echo "Final Results"
 echo "================================================"
-echo -e "${GREEN}Successfully processed:${NC} $((${#MISSING_ON_NPM[@]} - ${#FAILED_TAGS[@]})) tags"
-
-if [ ${#FAILED_TAGS[@]} -gt 0 ]; then
-    echo -e "${RED}Failed tags:${NC} ${#FAILED_TAGS[@]}"
-    for tag in "${FAILED_TAGS[@]}"; do
+SUCCESS_COUNT=$(( ${#MISSING[@]} - ${#FAILED[@]} ))
+echo -e "${GREEN}Published:${NC} $SUCCESS_COUNT / ${#MISSING[@]}"
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo -e "${RED}Failed:${NC} ${#FAILED[@]}"
+    for tag in "${FAILED[@]}"; do
         echo "  - $tag"
     done
     exit 1
-else
-    echo -e "${GREEN}✓ All missing tags have been published to npm!${NC}"
 fi
-
 echo ""
-echo "================================================"
-echo "Verification:"
-echo "================================================"
-echo "You can verify the published versions at:"
-echo "https://www.npmjs.com/package/mcp-adr-analysis-server?activeTab=versions"
-echo ""
-
-if [ "$DRY_RUN" == "true" ]; then
-    echo -e "${YELLOW}This was a DRY RUN. To actually publish, run:${NC}"
-    echo -e "${BLUE}./scripts/sync-tags-to-npm.sh --publish${NC}"
-fi
+echo "Verify at: https://www.npmjs.com/package/$PACKAGE?activeTab=versions"


### PR DESCRIPTION
## Summary

Rewrite `scripts/sync-tags-to-npm.sh` so it actually works against the current
state of the npm registry, and so its output is operationally useful instead of
noisy.

The previous version had two latent bugs that would have failed silently the
moment we needed it (which is now, as we backfill the v2.5.5–v2.6.2 gap):

1. It called `npm publish` (and even `npm publish --dry-run`) without
   `--tag latest`. While **v3.0.0** is sitting above us on npm (a stuck
   mistaken publish from 2025-07-04), npm refuses to implicitly assign
   `latest` to a lower v2.x version and aborts:
   > `Cannot implicitly apply the "latest" tag because previously published version 3.0.0 is higher`.
   So the reconciliation never actually worked end-to-end, even in dry-run.
2. It counted **every** old missing tag (33 across the v1.x / v2.0.x / v2.1.x
   history) as "needs publish", which is operationally noisy — those are
   abandoned and not coming back.

This PR:

- Pre-flights `npm whoami` and a clean working tree before publishing.
- Fetches the npm version list once (single round-trip) instead of per-tag.
- Classifies missing tags as **recent gap** (above current `latest`) vs
  **historical**, and only acts on the recent gap by default. `--all` opts
  back into the full history.
- Always passes `--tag latest --access public --ignore-scripts` on publish —
  the only combination that works while v3.0.0 is stuck above us.
- Prints exact per-tag commands in report mode so you can backfill one version
  by hand if you don't want the full sweep.
- Uses a portable `read`-into-array pattern (`mapfile` is bash 4+, macOS still
  ships 3.2).

### Sample output (current state of main)

```
GitHub v* tags:           57
Already on npm:           24
Missing (recent gap):     4
Missing (historical):     29  (use --all to act on these)

Recent GitHub tags and their npm status:
  ✓ v2.4.1       (on npm)
  ✓ v2.5.0       (on npm)
  ...
  ✓ v2.5.4       (on npm)
  ✗ v2.5.5       (MISSING)
  ✗ v2.6.0       (MISSING)
  ✗ v2.6.1       (MISSING)
  ✗ v2.6.2       (MISSING)

Current npm dist-tags:
  latest: 2.5.4
Highest published version on npm: 3.0.0
  ⚠ Highest version (3.0.0) does NOT match latest tag (2.5.4).
    All v2.x publishes must pass `--tag latest` to override npm's default.
```

## Context

This is the reconciliation tool referenced in the **"Finish OIDC Trusted
Publisher"** plan — Phase 2 (catch npm up to v2.6.2), so that Phase 4's
`workflow_dispatch` prerelease is a clean OIDC-only test rather than a
tangled gap-fill.

## Test plan

- [x] Run `./scripts/sync-tags-to-npm.sh` (report mode) → identifies
  `v2.5.5, v2.6.0, v2.6.1, v2.6.2` as the recent gap. ✓
- [ ] After merge: maintainer runs `./scripts/sync-tags-to-npm.sh --publish`
  from authenticated CLI to backfill those 4 versions on npm.
- [ ] Then trigger `publish.yml` via `workflow_dispatch` with
  `version_bump: prerelease` to verify OIDC Trusted Publisher works
  end-to-end (that's Phase 4 of the plan).

Made with [Cursor](https://cursor.com)