### PR TITLE
fix(scripts): pre-flight reject tags whose package.json doesn't match tag name

### DIFF
--- a/scripts/sync-tags-to-npm.sh
+++ b/scripts/sync-tags-to-npm.sh
@@ -203,6 +203,56 @@ if [[ "$PUBLISH" != "true" ]]; then
 fi
 
 # --publish path
+# ----------------------------------------------------------------------------
+# Pre-validate EVERY missing tag before we publish ANYTHING. The
+# auto-release-on-merge workflow has historically created tags whose
+# `package.json` does NOT match the tag name (e.g. v2.5.5 was tagged on a
+# commit where package.json still said 2.5.4). If we don't catch that now,
+# `npm publish` will silently rebuild the WRONG version, get rejected with
+# "You cannot publish over the previously published versions: X" — and the
+# script will already be partway through its sweep with you in detached HEAD.
+# Fail fast with a clear diagnosis instead.
+echo ""
+echo "================================================"
+echo "Pre-flight: validating tag <-> package.json"
+echo "================================================"
+MISMATCHED=()
+for tag in "${MISSING[@]}"; do
+    expected="${tag#v}"
+    actual=$(git show "$tag:package.json" 2>/dev/null | jq -r '.version' 2>/dev/null || echo "?")
+    if [[ "$expected" == "$actual" ]]; then
+        printf "  ${GREEN}✓${NC} %-12s package.json=%s\n" "$tag" "$actual"
+    else
+        printf "  ${RED}✗${NC} %-12s package.json=%s (expected %s)\n" "$tag" "$actual" "$expected"
+        MISMATCHED+=("$tag (pkg=$actual)")
+    fi
+done
+
+if [[ ${#MISMATCHED[@]} -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}ABORTING:${NC} ${#MISMATCHED[@]} tag(s) point at a commit whose package.json"
+    echo -e "${RED}does NOT match the tag name.${NC} Publishing them would rebuild the wrong"
+    echo "version and either be rejected by npm or, worse, silently overwrite"
+    echo "the wrong version slot."
+    echo ""
+    echo "Mismatched tags:"
+    for entry in "${MISMATCHED[@]}"; do echo "  - $entry"; done
+    echo ""
+    echo "Likely cause: the auto-release-on-merge.yml workflow created the tag"
+    echo "BEFORE its 'git push origin main' of the bump commit succeeded (or"
+    echo "before that bump commit existed at all). Look for a 'chore: bump"
+    echo "version to vX.Y.Z' commit on main — if one exists, re-point the tag:"
+    echo ""
+    echo "  git tag -f vX.Y.Z <bump-commit-sha>"
+    echo "  git push --force origin vX.Y.Z"
+    echo ""
+    echo "If no bump commit exists, the tag is orphaned and should either be"
+    echo "deleted ('git push origin :vX.Y.Z') or backfilled with a manual"
+    echo "bump PR before this script can publish it."
+    git checkout "$ORIGINAL_BRANCH" --quiet 2>/dev/null || true
+    exit 1
+fi
+
 echo ""
 echo "================================================"
 echo "Publishing missing tags"


### PR DESCRIPTION
## Summary

Add a fail-fast pre-flight to `scripts/sync-tags-to-npm.sh` so it refuses to
publish tags whose `package.json` version doesn't match the tag name.

## Why

We have malformed tags on `main` right now:

| tag      | package.json at tag | bump commit on main           |
|----------|---------------------|-------------------------------|
| `v2.5.5` | **2.5.4**           | ❌ none (orphan)               |
| `v2.6.0` | **2.5.4**           | ✅ `4de49f91` (PR #850)        |
| `v2.6.1` | **2.6.0**           | ✅ `3a877ad2` (PR #861)        |
| `v2.6.2` | **2.6.1**           | ❌ none (orphan)               |

Most likely cause: `auto-release-on-merge.yml` creates and pushes the tag
*before* its `git push origin main` of the bump commit succeeds (`main` is
protected, the push silently fails, the tag lands on the prior PR merge
commit which still has the OLD `package.json`).

Without this fix, `--publish` happily checks out e.g. `v2.5.5`, builds it
(producing `mcp-adr-analysis-server-2.5.4.tgz` — wrong version!), then
`npm publish` rejects with `You cannot publish over the previously published
versions: 2.5.4`. By that point you're partway through the sweep, in detached
HEAD, with stale build artifacts.

## What this PR does

- Walks every missing tag and reads `package.json` AT the tag.
- If any tag mismatches, the script aborts BEFORE touching npm, prints which
  tags are bad, and tells you exactly how to fix them (re-tag onto the
  matching `chore: bump version to vX.Y.Z` commit, or delete the orphan).

Sample output:

```
================================================
Pre-flight: validating tag <-> package.json
================================================
  ✗ v2.5.5       package.json=2.5.4 (expected 2.5.5)
  ✗ v2.6.0       package.json=2.5.4 (expected 2.6.0)
  ✗ v2.6.1       package.json=2.6.0 (expected 2.6.1)
  ✗ v2.6.2       package.json=2.6.1 (expected 2.6.2)

ABORTING: 4 tag(s) point at a commit whose package.json
does NOT match the tag name. ...
```

## What this PR does NOT do

- It does NOT remediate the malformed tags. That requires either a re-tag +
  force-push (where a matching bump commit exists) or a manual bump PR (for
  orphans).
- It does NOT fix the upstream `auto-release-on-merge.yml` bug. We're still
  going to mint bad tags every PR until that workflow is fixed (separate PR).

## Test plan

- [x] Branch off `main`, run the pre-flight logic against the 4 known-bad
  tags — all 4 trigger the abort. ✓
- [ ] Once merged: rerun `./scripts/sync-tags-to-npm.sh --publish` and
  confirm the abort fires before any `npm publish` happens.

Made with [Cursor](https://cursor.com)