### PR TITLE
chore: bump version to v2.6.2 (backfill for orphan tag)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-adr-analysis-server",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-adr-analysis-server",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-adr-analysis-server",
   "mcpName": "io.github.tosin2013/mcp-adr-analysis-server",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "MCP server for analyzing Architectural Decision Records and project architecture",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Backfill bump for the existing `v2.6.2` tag. The tag was originally created on
commit `69b0ec88` (PR #863, fix(ci): detect workflow_call path) where
`package.json` still said `2.6.1`, making it unpublishable to npm:

> `npm error You cannot publish over the previously published versions: 2.6.1`

After this PR merges, the `v2.6.2` tag will be re-pointed onto this bump
commit so its `package.json` matches the tag name, and
[.github/workflows/publish.yml](.github/workflows/publish.yml) can finally
publish it via OIDC Trusted Publisher.

## Why no `no-release` would be a bad idea

This PR is labeled `no-release` so [.github/workflows/auto-release-on-merge.yml](.github/workflows/auto-release-on-merge.yml)
skips on its merge — otherwise that workflow would mint another tag (would-be
`v2.6.3`), and given the underlying ordering bug it would be malformed in
exactly the same way the four current orphans are. We're trying to *stop*
making new bad tags here.

## Companion to the broader remediation plan

This is Phase B of the "Finish OIDC Publish via Trusted Publisher" plan:

- v2.6.0 tag — corrected (force-pushed onto `4de49f91`)
- v2.6.1 tag — corrected (force-pushed onto `3a877ad2`)
- v2.6.2 tag — corrected via this PR + a follow-up retag onto the squash-merge SHA
- v2.5.5 tag — being deleted (orphan, can't backfill due to semver downgrade from 2.6.1)

The actual `auto-release-on-merge.yml` ordering bug (which is what mints these
malformed tags in the first place) will be fixed in a separate follow-up PR.

## Test plan

- [x] `npm version patch --no-git-tag-version` ran cleanly (2.6.1 → 2.6.2). ✓
- [x] Pre-commit hooks (typecheck, build, smoke test, gitleaks) passed. ✓
- [ ] CI passes on this PR.
- [ ] After merge: re-tag `v2.6.2` onto the squash-merge SHA, force-push, and
      confirm [.github/workflows/publish.yml](.github/workflows/publish.yml) succeeds end-to-end (Trusted Publisher must be configured on npmjs.com first).

Made with [Cursor](https://cursor.com)