### PR TITLE
fix(ci): upgrade npm to >=11.5.1 so Trusted Publishing actually authenticates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -265,31 +265,36 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22' # Node 22 ships with npm 11+ for OIDC Trusted Publishing
+          # NOTE: Node 22.x currently ships with npm 10.x, NOT npm 11. The "Verify
+          # npm version" step below force-installs npm@11.5.1+ because OIDC Trusted
+          # Publishing AUTH is only supported on npm >= 11.5.1. (npm 10 can SIGN
+          # provenance, which is why earlier failures showed `Signed provenance
+          # statement` succeed and then `PUT` 404 — npm 10 silently fell back to
+          # legacy auth. See npm/cli#9088 for the misleading-404 symptom.)
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Verify npm version for OIDC
+      - name: Verify npm version for OIDC Trusted Publishing
         run: |
           echo "=== Verifying npm version for OIDC Trusted Publishing ==="
           NPM_VERSION=$(npm --version)
           echo "npm version: $NPM_VERSION"
 
-          # Extract major version
-          MAJOR_VERSION=$(echo "$NPM_VERSION" | cut -d. -f1)
-          MINOR_VERSION=$(echo "$NPM_VERSION" | cut -d. -f2)
-
-          # Require npm >= 10.0.0 for OIDC provenance (npm 10+ supports --provenance)
-          if [[ "$MAJOR_VERSION" -lt 10 ]]; then
-            echo "⚠️ npm version $NPM_VERSION is too old for OIDC provenance"
-            echo "Upgrading npm to 11.5.1..."
-            npm install -g npm@11.5.1 || {
-              echo "⚠️ npm upgrade failed, continuing with current version"
-              echo "Current npm version: $(npm --version)"
-            }
-            echo "npm version: $(npm --version)"
+          # OIDC Trusted Publishing requires npm >= 11.5.1.
+          # https://docs.npmjs.com/trusted-publishers/
+          # https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
+          # Symptom of running on npm 10: `Signed provenance statement` succeeds,
+          # then `PUT https://registry.npmjs.org/...` returns 404 because TP-OIDC
+          # auth is silently skipped. See npm/cli#9088.
+          REQUIRED_NPM="11.5.1"
+          if [[ "$(printf '%s\n%s' "$REQUIRED_NPM" "$NPM_VERSION" | sort -V | head -n1)" != "$REQUIRED_NPM" ]]; then
+            echo "⚠️ npm $NPM_VERSION is below required $REQUIRED_NPM for Trusted Publishing"
+            echo "Upgrading to npm@latest..."
+            npm install -g npm@latest
+            echo "✅ npm upgraded to $(npm --version)"
           else
-            echo "✅ npm version $NPM_VERSION supports OIDC provenance publishing"
+            echo "✅ npm $NPM_VERSION satisfies the >= $REQUIRED_NPM requirement for Trusted Publishing"
           fi
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

The OIDC Trusted Publishing 404 errors we've been chasing are NOT a Trusted Publisher misconfiguration on npmjs.com. The runner is publishing on **npm 10.9.7**, which can _sign_ provenance via OIDC but cannot _authenticate_ publishes via OIDC. Trusted Publishing requires **npm ≥ 11.5.1**.

The previous version check only required `npm >= 10`, on the false assumption (per the inline comment) that Node 22 ships with npm 11+. Node 22.x actually ships with npm 10.x. So the upgrade branch in the script never fired and every publish run silently fell back to legacy auth, producing the misleading `404 Not Found - PUT https://registry.npmjs.org/...`.

## Evidence

From publish run [25088689236](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/25088689236) (v2.6.2 retag):

```
npm version: 10.9.7
✅ npm version 10.9.7 supports OIDC provenance publishing   ← false: this only covers signing
...
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: ...
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/mcp-adr-analysis-server - Not found
```

The provenance step succeeded (npm 10 supports `--provenance` signing) but the actual publish PUT failed with 404 because npm 10 does not implement OIDC auth for publishing.

References:
- [npm Trusted Publishing GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) — confirms npm CLI ≥ 11.5.1 required
- [Trusted publishing for npm packages](https://docs.npmjs.com/trusted-publishers/) — same
- [npm/cli#9088](https://github.com/npm/cli/issues/9088) — exact symptom: misleading 404 / ENEEDAUTH from older npm versions when TP is configured

## Change

- Replace the buggy `MAJOR_VERSION -lt 10` check with a real semver compare against `11.5.1` using `sort -V`.
- Upgrade to `npm@latest` when the runner's npm is below 11.5.1 (rather than pinning, so we get future patches automatically).
- Update the misleading "Node 22 ships with npm 11+" comment on the `setup-node` step.

## Test plan

- [ ] PR CI passes (no behavior change for installs/tests; just an extra `npm install -g` in publish job).
- [ ] After merge, retry the v2.6.2 publish via `gh workflow run publish.yml` (or re-push the v2.6.2 tag) and verify the runner reports `npm upgraded to 11.x.y` and the publish step succeeds.
- [ ] Verify on npm: `npm view mcp-adr-analysis-server dist-tags` shows `latest: 2.6.2`.
- [ ] Confirm the existing Trusted Publisher rule on npmjs.com is the matching rule (no changes needed there).
- [ ] Backfill v2.6.0 and v2.6.1 publishes the same way.

Once OIDC publishing is verified end-to-end, follow up to remove the temporary OIDC-claims diagnostic from #867.

Made with [Cursor](https://cursor.com)