### PR TITLE
fix(ci): work around npm self-upgrade MODULE_NOT_FOUND race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -290,8 +290,12 @@ jobs:
           REQUIRED_NPM="11.5.1"
           if [[ "$(printf '%s\n%s' "$REQUIRED_NPM" "$NPM_VERSION" | sort -V | head -n1)" != "$REQUIRED_NPM" ]]; then
             echo "⚠️ npm $NPM_VERSION is below required $REQUIRED_NPM for Trusted Publishing"
-            echo "Upgrading to npm@latest..."
-            npm install -g npm@latest
+            # NOTE: Use --force to work around the well-known "npm self-upgrade
+            # MODULE_NOT_FOUND" race where npm 10.x loses access to its own deps
+            # (e.g. promise-retry) mid-upgrade. Pin to a specific known-good
+            # version rather than `@latest` for determinism. See npm/cli#3268.
+            echo "Installing npm@${REQUIRED_NPM}..."
+            npm install -g "npm@${REQUIRED_NPM}" --force --no-audit --no-fund
             echo "✅ npm upgraded to $(npm --version)"
           else
             echo "✅ npm $NPM_VERSION satisfies the >= $REQUIRED_NPM requirement for Trusted Publishing"


### PR DESCRIPTION
## Summary

Follow-up to #876. PR #876's `npm install -g npm@latest` step hit the long-standing npm self-upgrade race ([npm/cli#3268](https://github.com/npm/cli/issues/3268)): while npm 10.9.7 installs the new npm globally, it loses access to its own `node_modules` mid-flight and crashes:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
```

Visible on the v2.6.3 publish run [25113195490](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/25113195490).

## Change

Three small tweaks to make the self-upgrade deterministic:

1. **`--force`** — bypasses the broken self-dep checks during the upgrade.
2. **Pin to `npm@11.5.1`** (the documented Trusted-Publishing minimum) instead of `@latest`, so the build doesn't drift on us between runs. We can raise the floor explicitly when we need to.
3. **`--no-audit --no-fund`** — keeps the install quick and the logs clean.

## Test plan

- [ ] PR CI passes.
- [ ] After merge, re-tag v2.6.3 (or push a new tag) so `publish.yml` runs on the patched workflow.
- [ ] Verify the runner reports `npm upgraded to 11.5.1` and the publish step reaches the actual `npm publish` line.
- [ ] Verify on npm: `npm view mcp-adr-analysis-server dist-tags` shows `latest: 2.6.3`.

Once OIDC publishing is confirmed end-to-end, follow up to remove the temporary OIDC-claims diagnostic from #867.

Made with [Cursor](https://cursor.com)