### PR TITLE
chore(ci): remove temporary OIDC token claims diagnostic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -456,30 +456,6 @@ jobs:
 
           echo "✅ Package is ready for publishing"
 
-      - name: Inspect OIDC token claims (diagnostic)
-        # Temporary diagnostic to surface the exact subject claim that npm's
-        # Trusted Publisher will match against. Do NOT remove until OIDC
-        # publishing has been verified end-to-end. See PR #864 + the
-        # `Finish OIDC Trusted Publisher` plan for context.
-        run: |
-          OIDC_TOKEN=$(curl -sLS \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" \
-            | jq -r .value)
-          if [[ -z "$OIDC_TOKEN" || "$OIDC_TOKEN" == "null" ]]; then
-            echo "::error::Failed to obtain OIDC token (id-token: write missing?)"
-            exit 1
-          fi
-          # JWT payload is the second dot-separated segment, base64url-encoded.
-          # Pad to a multiple of 4 so plain base64 -d accepts it.
-          PAYLOAD_RAW=$(echo "$OIDC_TOKEN" | cut -d. -f2)
-          PAD=$(( 4 - ${#PAYLOAD_RAW} % 4 ))
-          [[ "$PAD" -lt 4 ]] && PAYLOAD_RAW="${PAYLOAD_RAW}$(printf '=%.0s' $(seq 1 $PAD))"
-          PAYLOAD=$(echo "$PAYLOAD_RAW" | tr '_-' '/+' | base64 -d 2>/dev/null)
-          echo "::group::OIDC token claims (configure these on npmjs.com)"
-          echo "$PAYLOAD" | jq '{aud, sub, repository, repository_owner, workflow_ref, job_workflow_ref, environment, ref, event_name}'
-          echo "::endgroup::"
-
       - name: Publish to NPM
         run: |
           VERSION="${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

OIDC Trusted Publishing is now verified end-to-end:
- Publish run [25114104531](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/25114104531) succeeded
- `npm view mcp-adr-analysis-server dist-tags` → `{"latest":"2.6.3"}`

The OIDC token-claims diagnostic step was added in #867 specifically to surface the exact `job_workflow_ref` claim for configuring npmjs.com's Trusted Publisher. It has served its purpose; removing it.

## Note on the original 404 mystery

The 404s we chased for days were NOT a TP misconfiguration. They were caused by Node 22 shipping with npm 10.x while OIDC Trusted Publishing requires npm ≥ 11.5.1 ([npm/cli#9088](https://github.com/npm/cli/issues/9088) — "Trusted publishing failures report misleading 404 / ENEEDAUTH errors"). Fixed by #876 and #879. The TP rule on npmjs.com was correct from the start.

## Test plan

- [ ] PR CI passes.
- [ ] After merge, the next publish run (v2.6.4 or any later release) does not contain the OIDC diagnostic block in its log.

Made with [Cursor](https://cursor.com)