### PR TITLE
fix(ci): don't downgrade npm 'latest' dist-tag when publishing older versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -461,18 +461,49 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           TAG_NAME="${{ steps.version.outputs.tag }}"
 
-          # Determine npm dist-tag based on version type
+          # Determine npm dist-tag.
+          #
+          # Prereleases keep their conventional tag (beta/alpha/rc bucket).
+          #
+          # Stable releases ONLY claim `latest` if they are strictly newer than
+          # the current `latest` on npm. This guards against the silent-downgrade
+          # bug we hit during the v2.6.0/v2.6.1/v2.6.2 backfill: publishing an
+          # older version with `npm publish --tag latest` overwrites `latest`,
+          # causing fresh `npm install <pkg>` to suddenly pull an older release.
+          #
+          # When the version being published is older than (or equal to) the
+          # current `latest`, we publish under the `previous` dist-tag instead.
+          # That keeps the version installable via `npm install <pkg>@previous`
+          # or `@<exact-version>` without touching `latest`.
           if [[ "${{ github.event.inputs.version_bump }}" == "prerelease" ]] || [[ "$VERSION" == *"beta"* ]] || [[ "$VERSION" == *"alpha"* ]] || [[ "$VERSION" == *"rc"* ]]; then
             echo "Publishing prerelease version: $VERSION"
-            npm publish --tag beta --provenance --access public
             PUBLISH_TAG="beta"
           else
-            echo "Publishing stable version: $VERSION"
-            # Publish with explicit 'latest' tag to ensure it's set correctly
-            # Uses OIDC Trusted Publishing - no token required
-            npm publish --tag latest --provenance --access public
-            PUBLISH_TAG="latest"
+            echo "Determining stable dist-tag for $VERSION..."
+            # Query current `latest` on npm. Returns empty if package doesn't
+            # exist yet (first-ever publish) or on transient registry errors.
+            CURRENT_LATEST=$(npm view mcp-adr-analysis-server@latest version 2>/dev/null || echo "")
+
+            if [[ -z "$CURRENT_LATEST" ]]; then
+              echo "  No existing 'latest' on npm — claiming 'latest' for $VERSION"
+              PUBLISH_TAG="latest"
+            else
+              # Semver-aware compare via `sort -V`. If $VERSION sorts last AND
+              # is not equal to $CURRENT_LATEST, it is strictly greater.
+              HIGHEST=$(printf '%s\n%s' "$VERSION" "$CURRENT_LATEST" | sort -V | tail -n1)
+              if [[ "$HIGHEST" == "$VERSION" && "$VERSION" != "$CURRENT_LATEST" ]]; then
+                echo "  $VERSION > current 'latest' ($CURRENT_LATEST) — claiming 'latest'"
+                PUBLISH_TAG="latest"
+              else
+                echo "::warning::Publishing $VERSION which is <= current 'latest' ($CURRENT_LATEST). Using dist-tag 'previous' to avoid downgrading 'latest'. Install via 'npm install mcp-adr-analysis-server@$VERSION' for the exact version."
+                PUBLISH_TAG="previous"
+              fi
+            fi
           fi
+
+          echo "Publishing with --tag $PUBLISH_TAG"
+          # OIDC Trusted Publishing — no token required.
+          npm publish --tag "$PUBLISH_TAG" --provenance --access public
 
           echo "✅ Successfully published to NPM"
           echo "   Version: $VERSION"


### PR DESCRIPTION
## Summary

Backfilling v2.6.0/v2.6.1/v2.6.2 onto npm exposed a latent bug: `publish.yml` ran `npm publish --tag latest` for every non-prerelease version, **silently overwriting `latest`** even when the version being published was older than what `latest` already pointed to.

During the backfill `latest` flipped through `2.6.0 → 2.6.1 → 2.6.2` before v2.6.4 reclaimed it. We got lucky that v2.6.4 shipped last.

## Fix

Query the current `latest` on npm before publishing and only claim `--tag latest` when the new version is **strictly greater** (semver-aware via `sort -V`). Otherwise publish under `--tag previous` so the version stays installable without disturbing `latest`.

```bash
CURRENT_LATEST=$(npm view mcp-adr-analysis-server@latest version 2>/dev/null || echo "")
if [[ -z "$CURRENT_LATEST" ]]; then
    PUBLISH_TAG="latest"   # first publish ever
else
    HIGHEST=$(printf '%s\n%s' "$VERSION" "$CURRENT_LATEST" | sort -V | tail -n1)
    if [[ "$HIGHEST" == "$VERSION" && "$VERSION" != "$CURRENT_LATEST" ]]; then
        PUBLISH_TAG="latest"
    else
        PUBLISH_TAG="previous"   # backfill / out-of-order release
    fi
fi
npm publish --tag "$PUBLISH_TAG" --provenance --access public
```

## Cases verified locally

| \`\$VERSION\` | \`\$CURRENT_LATEST\` | result |
|---|---|---|
| 2.6.5  | 2.6.4  | latest |
| 2.6.4  | 2.6.4  | previous (defensive — npm would reject re-publish anyway) |
| 2.6.3  | 2.6.4  | previous |
| 2.7.0  | 2.6.4  | latest |
| 2.6.10 | 2.6.9  | latest (numeric, not lexical) |
| 2.6.9  | 2.6.10 | previous |
| 1.0.0  | empty  | latest (first-ever publish) |

## Notes

- Prerelease branch (beta/alpha/rc) is unchanged.
- The existing "Verify NPM dist-tags" step already reads \$PUBLISH_TAG from env, so it correctly verifies whichever tag we ended up using.
- When falling back to previous, the run emits ::warning:: so the choice surfaces loudly in the GitHub Actions log.

## Test plan

- [ ] PR CI passes.
- [ ] After merge, the next regular release will hit the latest path (no behavior change for the happy path).
- [ ] To exercise the previous path: optionally backfill or hot-fix an older release line — npm view dist-tags should show the new previous entry without latest moving.

Made with [Cursor](https://cursor.com)