### PR TITLE
fix: regression-guard tsconfig rootDir to prevent dist/src/src/ nesting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc && chmod +x dist/src/index.js",
+    "postbuild": "node scripts/validate-build.js",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/validate-build.js
+++ b/scripts/validate-build.js
@@ -27,7 +27,7 @@ if (!existsSync(mainEntry)) {
   errors.push(`Main entry point not found: ${mainEntry}`);
 } else {
   console.log('✅ Main entry point exists');
-  
+
   // Check if it's a valid JS file with MCP functionality
   try {
     const content = readFileSync(mainEntry, 'utf8');
@@ -61,11 +61,11 @@ if (!existsSync('package.json')) {
   try {
     const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
     console.log(`✅ Package: ${pkg.name}@${pkg.version}`);
-    
+
     if (!pkg.main) {
       warnings.push('package.json missing main field');
     }
-    
+
     if (!pkg.bin) {
       warnings.push('package.json missing bin field');
     }
@@ -86,7 +86,7 @@ if (!existsSync(declarationFile)) {
 const essentialFiles = [
   'dist/src/utils/config.js',
   'dist/src/types/index.js',
-  'dist/src/utils/file-system.js'
+  'dist/src/utils/file-system.js',
 ];
 
 for (const file of essentialFiles) {
@@ -98,11 +98,7 @@ for (const file of essentialFiles) {
 }
 
 // Check 6: Tool files (optional but expected)
-const toolFiles = [
-  'dist/src/tools',
-  'dist/src/resources',
-  'dist/src/prompts'
-];
+const toolFiles = ['dist/src/tools', 'dist/src/resources', 'dist/src/prompts'];
 
 for (const file of toolFiles) {
   if (!existsSync(file)) {
@@ -110,6 +106,26 @@ for (const file of toolFiles) {
   } else {
     console.log(`✅ ${file} directory exists`);
   }
+}
+
+// Check 7: tsconfig.json rootDir is correctly set so output does NOT nest as
+// dist/src/src/. Regression guard for issue #784 (auto-detected by the
+// `esm-module-validation` agentic workflow). When `tsconfig.json.rootDir`
+// is missing or wrong, `tsc` infers the project root as the common ancestor
+// of all source files (often the repo root), producing dist/src/src/index.js
+// instead of dist/src/index.js — at which point package.json's "main" can't
+// be resolved at runtime. Fixed in PR #800 by adding `rootDir: "./src"`;
+// this check makes sure that fix can't silently regress.
+const wrongPath = 'dist/src/src/index.js';
+const wrongDir = 'dist/src/src';
+if (existsSync(wrongPath) || existsSync(wrongDir)) {
+  errors.push(
+    `tsconfig.json rootDir misconfiguration detected: ${wrongPath} exists. ` +
+      `This means tsc inferred the project root as the repo root rather than src/. ` +
+      `Set "rootDir": "./src" in tsconfig.json. See issue #784 / PR #800.`
+  );
+} else {
+  console.log('✅ No dist/src/src/ nesting (rootDir is correctly set)');
 }
 
 // Report results

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,12 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
+    // DO NOT REMOVE rootDir. If it's missing, tsc infers the project root
+    // as the common ancestor of all source files (often the repo root),
+    // producing dist/src/src/index.js instead of dist/src/index.js — and
+    // package.json's "main" then 404s at runtime. This bit us in #784;
+    // the fix landed in #800 and is regression-guarded by
+    // scripts/validate-build.js (Check 7).
     "rootDir": "./src",
     "outDir": "./dist/src",
     "strict": true,


### PR DESCRIPTION
Closes #784.

## The bug

\`tsconfig.json\` previously had no \`rootDir\`, so \`tsc\` inferred the project root as the common ancestor of all source files (the repo root), producing \`dist/src/src/index.js\` instead of \`dist/src/index.js\`. At runtime \`package.json\`'s \`main\` would 404 with:

\`\`\`
Error: Cannot find module '.../dist/src/index.js'
\`\`\`

TypeScript 6 also surfaces this explicitly as \`TS5011\`.

## The fix

The actual fix already shipped in #800 (the TS6 migration added \`rootDir: "./src"\`). This PR locks the fix in with **three layers of defense** so we can't silently regress:

### 1. JSONC comment in \`tsconfig.json\`
Warns the next person to "tidy up" the file and points them at #784 / #800 / the validator.

\`\`\`jsonc
// DO NOT REMOVE rootDir. If it's missing, tsc infers the project root
// as the common ancestor of all source files (often the repo root),
// producing dist/src/src/index.js instead of dist/src/index.js — and
// package.json's "main" then 404s at runtime. This bit us in #784;
// the fix landed in #800 and is regression-guarded by
// scripts/validate-build.js (Check 7).
"rootDir": "./src",
\`\`\`

### 2. \`postbuild\` hook in \`package.json\`
Runs the existing \`scripts/validate-build.js\` after every local \`npm run build\`, so regressions surface to developers immediately, not just in CI.

### 3. \`scripts/validate-build.js\` Check 7
Explicit assertion that \`dist/src/src/\` does NOT exist. Catches the case where someone sets \`rootDir\` to a wrong path (so TS6's TS5011 wouldn't fire) or downgrades TypeScript below 6. Already wired into \`build.yml\` and \`test.yml\` workflows.

## Test plan

- [x] **Happy path** — \`npm run build\` succeeds; Check 7 logs \`✅ No dist/src/src/ nesting (rootDir is correctly set)\`. Verified locally.
- [x] **Failure simulation** — temporarily commented out \`rootDir\` and ran \`npm run build\`. Result: tsc fails fast with \`error TS5011: The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set...\`. The validator never even runs because tsc bails first — exactly the behavior we want. Then restored.
- [ ] CI passes on this PR.

## Bonus: pipeline integration test

This is also the first real release going through the hardened pipeline post-CI work (#876 / #879 / #881 / #882 / #884). Will trigger:
- \`auto-release-on-merge.yml\` — bump PR for v2.6.5 (will need close+reopen unless RELEASE_TOKEN is set)
- \`publish.yml\` — uses npm 11.5.1+ (#876, #879), no OIDC diagnostic noise (#881), and the new dist-tag logic (#884) which should publish v2.6.5 with \`--tag latest\` since 2.6.5 > 2.6.4.

Made with [Cursor](https://cursor.com)