### PR TITLE
fix(ci): tolerate close+reopen on bump PR (don't abort on first CLOSED poll)

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -418,6 +418,11 @@ jobs:
           set -euo pipefail
           echo "Waiting for version-bump PR #$PR_NUMBER to merge (poll every 30s for up to 20 min)..."
 
+          # Track consecutive CLOSED polls so the documented "close+reopen
+          # to kick CI" workaround doesn't trip the abort path. See the
+          # CLOSED-branch comment further down for the full rationale.
+          CLOSED_STREAK=0
+
           # 40 attempts * 30s = 1200s (20 min) — enough for typical CI runs
           for i in $(seq 1 40); do
             STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
@@ -432,8 +437,24 @@ jobs:
               echo "BUMP_SHA=$BUMP_SHA" >> $GITHUB_ENV
               exit 0
             elif [[ "$STATE" == "CLOSED" ]]; then
-              echo "::error::Version-bump PR #$PR_NUMBER was closed without merging — aborting tag creation"
-              exit 1
+              # PR is CLOSED but NOT merged. This is the "close+reopen to kick
+              # CI" workaround documented in the PR body when RELEASE_TOKEN is
+              # not set. Don't abort on the first CLOSED observation — the
+              # maintainer is mid-reopen and the PR will flip back to OPEN
+              # within ~5s. Only give up after 3 consecutive CLOSED polls
+              # (~90s), which is well past any reasonable close+reopen window
+              # but still terminates the run if the PR was genuinely abandoned.
+              CLOSED_STREAK=$((CLOSED_STREAK + 1))
+              if [[ $CLOSED_STREAK -ge 3 ]]; then
+                echo "::error::Version-bump PR #$PR_NUMBER has been CLOSED (not merged) for $CLOSED_STREAK consecutive polls — aborting tag creation"
+                exit 1
+              fi
+              echo "[attempt $i/40] PR state: CLOSED (streak=$CLOSED_STREAK/3) — likely a close+reopen kick to fire CI; waiting 30s..."
+              sleep 30
+              continue
+            else
+              # Any non-CLOSED, non-MERGED state resets the streak.
+              CLOSED_STREAK=0
             fi
 
             echo "[attempt $i/40] PR state: $STATE — waiting 30s..."


### PR DESCRIPTION
## The bug

PR #882 added a documented \"close+reopen the bump PR to kick CI\" workaround for the case where \`RELEASE_TOKEN\` is not set (\`GITHUB_TOKEN\` suppresses CI on bot-authored PRs). The PR-body and timeout-error text both tell maintainers to do exactly that.

But the wait-for-merge poll loop in the **same workflow** treats *any* \`CLOSED\` state as a hard abort:

\`\`\`bash
elif [[ \"\$STATE\" == \"CLOSED\" ]]; then
  echo \"::error::Version-bump PR #\$PR_NUMBER was closed without merging — aborting tag creation\"
  exit 1
fi
\`\`\`

So if the maintainer's \`gh pr close && gh pr reopen\` happens to land between polls — exactly what just bit us on PR #887 (the v2.6.5 bump) — the parent workflow exits 1 within ~2 minutes, never waits to see the PR flip back to OPEN, and never tags the version-bump SHA. The maintainer is then stuck doing the manual \`git tag + git push\` dance that was supposed to be automated.

### Concrete failure timeline (run [25118446368](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/25118446368))

| time     | event |
|----------|-------|
| 15:37:23 | Bump PR #887 opened by parent workflow |
| 15:37:27 | Parent enters poll loop |
| 15:39:36 | Maintainer runs \`gh pr close 887\` (kicks CI workaround) |
| **15:39:29** | **Parent polls at attempt 4/40, sees \`STATE=CLOSED\`, exits 1** |
| 15:39:38 | Maintainer runs \`gh pr reopen 887\` (PR is back OPEN) |
| 15:42:55 | PR #887 auto-merges (CI passed) |

The whole thing was salvageable — CI passed, the PR merged at the squash SHA \`e2584bb9\` with the correct \`package.json\` version — but the parent workflow had already given up. v2.6.5 had to be tagged and published manually.

## The fix

Track a small \`CLOSED_STREAK\` counter. The first 1–2 consecutive \`CLOSED\` observations are treated as transient (a typical close+reopen completes in well under 5 seconds, so a 30-second poll might sample it once but almost never twice). Only after **3 consecutive CLOSED polls (~90 seconds)** do we treat the PR as genuinely abandoned and abort. Any non-CLOSED state resets the streak.

\`\`\`bash
elif [[ \"\$STATE\" == \"CLOSED\" ]]; then
  CLOSED_STREAK=\$((CLOSED_STREAK + 1))
  if [[ \$CLOSED_STREAK -ge 3 ]]; then
    echo \"::error::Version-bump PR #\$PR_NUMBER has been CLOSED (not merged) for \$CLOSED_STREAK consecutive polls — aborting tag creation\"
    exit 1
  fi
  echo \"[attempt \$i/40] PR state: CLOSED (streak=\$CLOSED_STREAK/3) — likely a close+reopen kick to fire CI; waiting 30s...\"
  sleep 30
  continue
else
  CLOSED_STREAK=0
fi
\`\`\`

### Why 3?

- close+reopen completes in <5s in practice; even a slow round-trip finishes in <30s.
- 3 consecutive 30s polls (~90s) gives a comfortable safety margin without meaningfully delaying genuine-abort detection.
- Genuine abandonment doesn't have a deadline — the maintainer can re-run the workflow if needed. We're optimizing for the common close+reopen path.

## Test plan

- [x] Static review: \`CLOSED_STREAK\` initialized to 0 outside the loop, incremented only on CLOSED, reset on every non-CLOSED-non-MERGED state. \`MERGED\` still wins (returns immediately). 20-min timeout still applies.
- [ ] Will be exercised end-to-end the next time a bump PR needs close+reopen (i.e., next release after this one merges, until \`RELEASE_TOKEN\` is configured).
- [ ] CI passes on this PR.

## Follow-up

The real long-term fix is still to set \`RELEASE_TOKEN\` (which makes the close+reopen workaround unnecessary in the first place — see #882). This PR just makes the documented workaround actually work.

Discovered while shipping #886 (regression-guard for #784). v2.6.5 has been manually tagged at the squash SHA \`e2584bb9\` and published. \`npm view mcp-adr-analysis-server dist-tags\` should show \`latest: 2.6.5\` once the in-flight publish run completes.

Made with [Cursor](https://cursor.com)