### PR TITLE
fix(deps): patch axios high-sev advisories via firecrawl 4.25.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.6.8",
       "license": "MIT",
       "dependencies": {
-        "@mendable/firecrawl-js": "^4.4.1",
+        "@mendable/firecrawl-js": "^4.25.2",
         "@modelcontextprotocol/sdk": "^1.19.1",
         "fast-glob": "^3.3.2",
         "tree-sitter": "^0.21.1",
@@ -2459,12 +2459,12 @@
       }
     },
     "node_modules/@mendable/firecrawl-js": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-4.25.0.tgz",
-      "integrity": "sha512-Dxk85bNe/IEVPvND0w3Peenvg08TgLuaN8fYHi3ShDdivc0jJpXEB8rgczOD8gKsz18CzaV/YnPnj6TL/SCQdw==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-4.25.2.tgz",
+      "integrity": "sha512-1dRs5qpfjfievBsUAxAWtnhtNiIVdXshAXdhAUQVmFUFOrOKR4XWs/76CxDIcEPQ44iD8ckInLwyewo6EIs+iQ==",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.15.2",
+        "axios": "1.16.1",
         "firecrawl": "4.16.0",
         "typescript-event-target": "^1.1.1",
         "zod": "^3.23.8",
@@ -5594,6 +5594,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -5753,13 +5765,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -8261,6 +8274,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "docs:clean": "rm -rf docs/api"
   },
   "dependencies": {
-    "@mendable/firecrawl-js": "^4.4.1",
+    "@mendable/firecrawl-js": "^4.25.2",
     "@modelcontextprotocol/sdk": "^1.19.1",
     "fast-glob": "^3.3.2",
     "tree-sitter": "^0.21.1",


### PR DESCRIPTION
## Summary
Resolves **2 high-severity axios advisories** pulled in transitively through `@mendable/firecrawl-js@4.25.0`. Bumps firecrawl **4.25.0 → 4.25.2** (the vulnerable range was 4.18.1–4.25.1), which in turn resolves **axios 1.15.2 → 1.16.1**.

### Why this matters
`make check-deps` runs `npm audit --omit=dev --audit-level=moderate` (Makefile:119). The axios advisories were tripping this gate, failing the `test (20)`, `test (22)`, and `security-scan` jobs **repo-wide** — including on `main` and on every open Dependabot PR. This change unblocks all of them.

### Advisories resolved
- GHSA-pjwm-pj3p-43mv — NO_PROXY bypass (IPv4-mapped IPv6)
- GHSA-898c-q2cr-xwhg — DoS & header injection via prototype pollution
- GHSA-654m-c8p4-x5fp / GHSA-35jp-ww65-95wh — proxy-auth / MitM prototype pollution
- GHSA-hfxv-24rg-xrqf — ReDoS via cookie name injection
- GHSA-777c-7fjr-54vf — unbounded resource allocation
- GHSA-p92q-9vqr-4j8v / GHSA-j5f8-grm9-p9fc — proxy-auth credential leak on redirect

### Verification
- `npm audit --omit=dev --audit-level=moderate` → **0 vulnerabilities**
- `npm run typecheck` → **pass**
- Diff limited to `package.json` + `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)