### PR TITLE
chore: gitignore MCP registry publishing tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,8 @@ docs/api/
 
 .kiro
 mcp-shrimp-task-datavenv-ansible/
+
+# MCP Registry publishing tokens (NEVER commit — local secrets)
+.mcpregistry_github_token
+.mcpregistry_registry_token
+.mcpregistry_*token


### PR DESCRIPTION
## Summary
Adds the MCP Registry publishing token files to `.gitignore` so they can't be accidentally committed:
- `.mcpregistry_github_token`
- `.mcpregistry_registry_token`
- `.mcpregistry_*token` (catch-all pattern)

### Context
These local secret files were present untracked in the working directory and are **not** committed to `main` (verified — they only ever existed locally). This change is preventive: they were one `git add -A` away from being committed. Recommend rotating both tokens as a precaution since they were briefly present on disk during publishing.

### Verification
`git check-ignore` confirms both files are now ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)