### PR TITLE
fix(ci): MCP Registry publish fires on tag releases + manual dispatch

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,14 +1,20 @@
 name: Publish to MCP Registry
 
 on:
+  # Cascade from a successful "Publish to NPM" run. No branch filter:
+  # the NPM publish runs in tag context (e.g. refs/tags/v2.6.9), so its
+  # workflow_run head_branch is the tag, not "main" — a branches:[main]
+  # filter would (and previously did) silently drop tag-triggered releases.
   workflow_run:
     workflows: ['Publish to NPM']
     types: [completed]
-    branches: [main]
+  # Manual fallback to (re)publish the current main version to the registry.
+  workflow_dispatch:
 
 jobs:
   publish-mcp-registry:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run on manual dispatch, or when the upstream NPM publish succeeded.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem
`npm` published v2.6.9 but the **MCP Registry was not updated**. `publish-mcp-registry.yml` cascades from `Publish to NPM` via `workflow_run`, but filtered `branches: [main]`. The NPM publish runs in **tag context** (`refs/tags/v2.6.9`), so its `workflow_run` `head_branch` is the tag — the filter silently dropped every tag-triggered release. The workflow also had no `workflow_dispatch`, so it couldn't be triggered manually.

## Fix
- Drop the `branches: [main]` filter so tag-context NPM runs cascade to the registry.
- Add `workflow_dispatch` as a manual fallback (authenticates via `github-oidc` in CI — no tokens needed).
- Update the job `if:` to also run on `workflow_dispatch` (otherwise a manual run is skipped for lack of `workflow_run` context).

## Rollout
After merge, I'll `gh workflow run publish-mcp-registry.yml` once to publish the already-released **v2.6.9** to the registry (main's `package.json` is 2.6.9). Future tag releases will cascade automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)