### PR TITLE
fix(ci): repair broken version step in MCP Registry publish

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Get current version
         id: version
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update server.json version
         run: |


### PR DESCRIPTION
## Problem
The first real run of the MCP Registry publish (dispatched for v2.6.9) failed immediately at the **Get current version** step:
```
syntax error near unexpected token `('
```
The step used an escaped-quote one-liner — `echo "version=$(node -p \"require('./package.json').version\")"` — which bash rejects. The step had never executed before (the only prior registry run was skipped), so the bug was latent.

## Fix
Rewrite as a multi-line block with normal quoting:
```yaml
run: |
  VERSION=$(node -p "require('./package.json').version")
  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
```

After merge I'll re-dispatch the registry publish to ship **v2.6.9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)