### PR TITLE
fix(ci): give actions/checkout the same token as create-pull-request

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -33,7 +33,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # MUST match the token given to peter-evans/create-pull-request below.
+          #
+          # checkout@v6 persists credentials for whichever token it is given. If
+          # create-pull-request is handed a *different* token, it hides checkout's
+          # credential file and configures its own auth — and that handoff breaks
+          # against v6's credential-file/includeIf mechanism, leaving the branch push
+          # with no usable credential:
+          #
+          #   fatal: could not read Username for 'https://github.com': No such device
+          #   ##[error]The process '/usr/bin/git' failed with exit code 128
+          #
+          # This stayed hidden while RELEASE_TOKEN was unset, because both sides then
+          # resolved to GITHUB_TOKEN. It surfaced the moment RELEASE_TOKEN was added.
+          #
+          # Using RELEASE_TOKEN here also matters for the tag push below: tags pushed
+          # with GITHUB_TOKEN do NOT fire publish.yml's `push: tags` trigger, which is
+          # why v2.6.11 had to be published by re-pushing its tag by hand.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Why

Adding the `RELEASE_TOKEN` secret **broke** version-bump PR creation. Run [`31021694134`](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/31021694134) — the first auto-release run after the secret landed — failed at *Create version-bump PR*:

```
Configuring credential for HTTPS authentication
[command] git push --force-with-lease origin chore/version-bump-v2.6.12:refs/heads/...
fatal: could not read Username for 'https://github.com': No such device or address
##[error]The process '/usr/bin/git' failed with exit code 128
```

## Cause

`actions/checkout@v6` persisted credentials for `GITHUB_TOKEN`, while `peter-evans/create-pull-request@v8` was handed `RELEASE_TOKEN`.

When those tokens differ, the action hides checkout's credential file (`Temporarily hiding checkout credential file: git-credentials-*.config`) and configures its own auth. That handoff does not survive checkout v6's credential-file / `includeIf` mechanism — the push ends up with no usable credential and git falls back to prompting for a username.

**This was latent, not new.** While `RELEASE_TOKEN` was unset, both sides resolved to `GITHUB_TOKEN` through the `||` fallback and the push worked fine — bump PRs #1332, #1334 and #1259 were all created that way. Adding the secret made the two tokens diverge for the first time and exposed it.

## Fix

One line: give checkout the same `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` expression, so the two always agree whether or not the secret is set.

## It also fixes the tag push

The tag push (`git push origin "$TAG_NAME"`) relies on the same persisted credentials. **Tags pushed with `GITHUB_TOKEN` do not fire `publish.yml`'s `push: tags: 'v*'` trigger** — GitHub suppresses workflow triggers from that token.

That is exactly why v2.6.11 was tagged but never published: all three auto-release runs completed, the tag existed at the right commit, and `publish.yml` simply never started. It had to be released by deleting and re-pushing the tag by hand.

With `RELEASE_TOKEN`, the tag is pushed by a PAT and triggers publishing normally. So this closes the last manual step in the release chain.

## Expected end state

With this, #1340, and the `RELEASE_TOKEN` secret all in place, a Dependabot merge should run unattended for the first time:

```
PR merges → bump PR opened (gets CI) → auto-merges → tag at bump commit
          → GitHub Release → npm via OIDC → MCP Registry
```

Deliberately **not** labeled `no-release` — merging this should trigger a real release, which is the end-to-end verification.

Refs #1335, #1336.