### PR TITLE
fix(ci): revert checkout to GITHUB_TOKEN — RELEASE_TOKEN is being rejected

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -50,7 +50,22 @@ jobs:
           # Using RELEASE_TOKEN here also matters for the tag push below: tags pushed
           # with GITHUB_TOKEN do NOT fire publish.yml's `push: tags` trigger, which is
           # why v2.6.11 had to be published by re-pushing its tag by hand.
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          #
+          # REVERTED to GITHUB_TOKEN for now. Pointing checkout at RELEASE_TOKEN made
+          # run 31038689356 fail at the *checkout* step itself, on all three retries:
+          #
+          #   fatal: could not read Username for 'https://github.com': terminal prompts disabled
+          #
+          # checkout's credential setup was correct (credential file + includeIf entries
+          # all written), and this repository is public — so the header was sent and the
+          # server rejected it, meaning the RELEASE_TOKEN value is expired, malformed, or
+          # not granted access to this repo. Until that is confirmed, checkout must use a
+          # credential that is always valid, otherwise a bad secret breaks every release
+          # run at step 2 instead of failing later with a clearer error.
+          #
+          # NOTE: an invalid RELEASE_TOKEN is worse than an absent one — `||` treats any
+          # non-empty string as truthy, so it never falls back. See #1336.
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## What happened

#1346 pointed `actions/checkout` at `RELEASE_TOKEN` so the tag push would come from a PAT and fire `publish.yml`. That made things **worse**. Run [`31038689356`](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/31038689356), triggered by merging #1346, failed at **step 2, Checkout code** — before anything else could run:

```
##[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled
##[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled
##[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled
##[error]The process '/usr/bin/git' failed with exit code 128
```

## Why this points at the token, not the wiring

Checkout's own credential setup was correct — it wrote the credential file and all four `includeIf` entries:

```
git config --file .../git-credentials-*.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
git config --local includeIf.gitdir:.../.git.path .../git-credentials-*.config
git config --local includeIf.gitdir:.../.git/worktrees/*.path ...
```

And **this repository is public** — an anonymous fetch would have succeeded outright. The only way to reach this error is for the auth header to be sent and the server to reject it, after which git falls back to prompting.

So the `RELEASE_TOKEN` value is expired, malformed, or not granted access to this repository. A fine-grained PAT must have the repo explicitly selected and `Contents: Read & Write` — it is easy to create one that looks correct but grants nothing here.

## The change

Revert checkout to `secrets.GITHUB_TOKEN`, which is always valid. `peter-evans/create-pull-request` keeps its `RELEASE_TOKEN` preference — if the token is genuinely bad it will now fail *there*, with a clearer error, instead of taking out every release run at step 2.

## The trap worth recording

**An invalid `RELEASE_TOKEN` is strictly worse than an absent one.**

`${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` keys off emptiness, not validity. Any non-empty value — working or not — wins and never falls back. Before the secret existed, this expression silently resolved to `GITHUB_TOKEN` and everything worked; bump PRs #1259, #1332 and #1334 were all created that way.

## What still needs doing

The token has to be verified or deleted before hands-off releases can work. Until then the release path is back to its pre-#1346 behaviour: the bump PR gets created, and completing the release needs `gh pr merge <n> --squash --admin` plus a manual tag re-push.

Refs #1336.