### PR TITLE
test(ci): assert the four gh-aw validators run their agent to success

### DIFF
--- a/scripts/check-validator-activation.sh
+++ b/scripts/check-validator-activation.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Assert that the four gh-aw validators actually RAN THE AGENT and it SUCCEEDED.
+#
+# Why this exists (issue #1417, split out of #1410):
+#
+# These four presented as green for months while doing nothing. Their runs showed
+#   pre_activation: success
+#   activation / agent / detection / safe_outputs: skipped
+# and GitHub reports a run whose jobs all skipped as a SUCCESS. A green tick meant
+# "nothing ran", and nobody could tell the difference from the checks page.
+#
+# So this deliberately does NOT check the run conclusion, and does NOT merely
+# check that the agent job is "not skipped". An earlier draft of this bar asserted
+# not-skipped; at that moment the agent job was FAILING on every run, so that
+# check would have passed while all four validators were useless. The only
+# assertion worth making is that the `agent` job concluded `success`.
+#
+# Exit 0 only if all four have a most-recent run whose agent job succeeded.
+
+set -uo pipefail
+
+REPO="${REPO_OVERRIDE:-tosin2013/mcp-adr-analysis-server}"
+
+WORKFLOWS=(
+  "mcp-server-validation"
+  "esm-module-validation"
+  "knowledge-graph-validation"
+  "deployment-pattern-validation"
+)
+
+fail=0
+printf "%-32s %-12s %s\n" "VALIDATOR" "AGENT JOB" "RUN"
+printf "%-32s %-12s %s\n" "---------" "---------" "---"
+
+for w in "${WORKFLOWS[@]}"; do
+  run_id="$(gh run list --repo "$REPO" --workflow "$w.lock.yml" \
+              --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null)"
+
+  if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+    # No run at all is NOT a pass. An unexercised validator is exactly the
+    # condition this script exists to detect, and reporting it as "n/a — ok"
+    # would rebuild the false green in a new place.
+    printf "%-32s %-12s %s\n" "$w" "NO RUNS" "-"
+    fail=1
+    continue
+  fi
+
+  concl="$(gh run view "$run_id" --repo "$REPO" --json jobs \
+             --jq '.jobs[] | select(.name=="agent") | .conclusion' 2>/dev/null | head -1)"
+  [ -z "$concl" ] && concl="NO AGENT JOB"
+
+  printf "%-32s %-12s %s\n" "$w" "$concl" "$run_id"
+  [ "$concl" = "success" ] || fail=1
+done
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: at least one validator has not run its agent to success."
+  echo "A validator whose agent skips or fails reports the run as green while"
+  echo "reviewing nothing. Investigate before trusting these as a safety net."
+  exit 1
+fi
+
+echo "OK: all four validators ran their agent job to success."


### PR DESCRIPTION
Closes #1417 · unblocks #1410

The four validators presented as **green for months while doing nothing**:

```
pre_activation:                             success
activation / agent / detection / safe_outputs: skipped
```

GitHub reports a run whose jobs all skipped as a **success**. The green tick meant "nothing ran", and the checks page could not show the difference.

### What the script deliberately does not do

It does **not** check the run conclusion — that is the thing that was lying.

It also does **not** merely check that the agent job is "not skipped". That was this bar's first draft, written when I believed skipping was the problem. At that moment the agent job was *failing* on every run, so a not-skipped assertion would have passed while all four validators were useless — the exact false green #1417 exists to prevent. The only assertion worth making is that `agent` concluded `success`.

A workflow with **no runs at all is a FAIL**, not an n/a. An unexercised validator is precisely the condition this detects; excusing it would rebuild the false green somewhere new.

### Verified in all three directions

Not just the happy path:

| scenario | result |
|---|---|
| all four agents succeeded | `exit 0` |
| a workflow with no runs | `exit 1` — `NO RUNS` |
| agent ran and **failed** | `exit 1` — checked against real run [32882461825](https://github.com/tosin2013/mcp-adr-analysis-server/actions/runs/32882461825) |

### Current state — a real run of each

```
mcp-server-validation          success   32883056982
esm-module-validation          success   32883862037
knowledge-graph-validation     success   32883864920
deployment-pattern-validation  success   32883867627
```

First time all four have run their agent to completion.

### What actually fixed them

Not the recompile alone. `COPILOT_MODEL` was set to model ids that do not exist:

| value | result |
|---|---|
| `gpt-5.1-codex-mini` | 400 `model_not_supported` (original repo variable) |
| `auto` | 400 — **not a real model id**, so clearing the variables could never work |
| `claude-sonnet-4.6` | 400 — listed by the api-proxy, still refused by the CLI token |
| `gpt-4.1` | **success** |

The middle rows matter: the api-proxy enumerates 44 Copilot models, but **proxy visibility is not token entitlement**. The proxy lists the catalogue; the seat decides what is callable. Premium models are gated, `gpt-4.1` is not.

Repository variables now read:

```
GH_AW_MODEL_AGENT_COPILOT      gpt-4.1
GH_AW_MODEL_DETECTION_COPILOT  claude-haiku-4.5
```

**`gpt-4.1` is a capability downgrade** from what these workflows were written against. They will run, and may review less well. Restoring sonnet is a Copilot seat question, not a config one.

### Governance

```
#1417  AUTHORIZED / STOP_COMPLETE
#1410  AUTHORIZED / STOP_COMPLETE
       BAR_COVERS_PART_DISCHARGED — "the uncovered half was split and
       every part is complete: 1417=STOP_COMPLETE"
```

#1410 could not complete on its own: its bar declared the activation question uncovered and named #1417 in `covers.split_to`. The engine evaluated the child rather than trusting the pointer, and released the parent only once the child genuinely completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)