### PR TITLE
fix(ci): make the validator check assert capability, not the latest run

### DIFF
--- a/scripts/check-validator-activation.sh
+++ b/scripts/check-validator-activation.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Assert that the four gh-aw validators actually RAN THE AGENT and it SUCCEEDED.
+# Assert that each of the four gh-aw validators has DEMONSTRATED it can run its
+# agent to success.
 #
 # Why this exists (issue #1417, split out of #1410):
 #
@@ -8,19 +9,35 @@
 #   pre_activation: success
 #   activation / agent / detection / safe_outputs: skipped
 # and GitHub reports a run whose jobs all skipped as a SUCCESS. A green tick meant
-# "nothing ran", and nobody could tell the difference from the checks page.
+# "nothing ran", and the checks page could not show the difference.
 #
-# So this deliberately does NOT check the run conclusion, and does NOT merely
-# check that the agent job is "not skipped". An earlier draft of this bar asserted
-# not-skipped; at that moment the agent job was FAILING on every run, so that
-# check would have passed while all four validators were useless. The only
-# assertion worth making is that the `agent` job concluded `success`.
+# WHAT THIS ASSERTS, precisely: each validator has at least one run in recent
+# history whose `agent` job concluded `success`.
 #
-# Exit 0 only if all four have a most-recent run whose agent job succeeded.
+# WHAT IT DOES NOT ASSERT: that the most recent run reviewed anything. That was
+# this script's first implementation and it was wrong twice over:
+#
+#   1. A run still in flight has no `agent` job yet, so "latest run" reported
+#      NO AGENT JOB and failed spuriously. It did exactly that within minutes of
+#      landing on main, while three runs were in progress.
+#   2. Validators legitimately skip when a commit touches none of their filtered
+#      paths. Asserting the latest run's agent succeeded would fail after any
+#      docs-only merge -- and a check that oscillates gets muted, which is how
+#      the original false green survived.
+#
+# Capability is the stable, checkable property. A validator that has NEVER run
+# its agent to success is broken; one that skipped this morning is not.
+#
+# It also does NOT check the run conclusion -- that is the value that was lying.
+# And it does not merely check "not skipped": an earlier draft of this bar
+# asserted not-skipped at a moment when the agent was FAILING on every run, so it
+# would have passed while all four validators were useless.
 
 set -uo pipefail
 
 REPO="${REPO_OVERRIDE:-tosin2013/mcp-adr-analysis-server}"
+# How far back to look for a successful agent run.
+DEPTH="${DEPTH:-20}"
 
 WORKFLOWS=(
   "mcp-server-validation"
@@ -30,36 +47,45 @@ WORKFLOWS=(
 )
 
 fail=0
-printf "%-32s %-12s %s\n" "VALIDATOR" "AGENT JOB" "RUN"
-printf "%-32s %-12s %s\n" "---------" "---------" "---"
+printf "%-32s %-10s %s\n" "VALIDATOR" "AGENT" "EVIDENCE"
+printf "%-32s %-10s %s\n" "---------" "-----" "--------"
 
 for w in "${WORKFLOWS[@]}"; do
-  run_id="$(gh run list --repo "$REPO" --workflow "$w.lock.yml" \
-              --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null)"
+  # Completed runs only: an in-flight run has not created its agent job yet.
+  runs="$(gh run list --repo "$REPO" --workflow "$w.lock.yml" \
+            --status completed --limit "$DEPTH" \
+            --json databaseId --jq '.[].databaseId' 2>/dev/null)"
 
-  if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
-    # No run at all is NOT a pass. An unexercised validator is exactly the
-    # condition this script exists to detect, and reporting it as "n/a — ok"
-    # would rebuild the false green in a new place.
-    printf "%-32s %-12s %s\n" "$w" "NO RUNS" "-"
+  if [ -z "$runs" ]; then
+    # No completed run at all is NOT a pass. An unexercised validator is exactly
+    # the condition this exists to detect, and excusing it as "n/a" would rebuild
+    # the false green somewhere new.
+    printf "%-32s %-10s %s\n" "$w" "NONE" "no completed runs in last $DEPTH"
     fail=1
     continue
   fi
 
-  concl="$(gh run view "$run_id" --repo "$REPO" --json jobs \
-             --jq '.jobs[] | select(.name=="agent") | .conclusion' 2>/dev/null | head -1)"
-  [ -z "$concl" ] && concl="NO AGENT JOB"
+  found=""
+  for r in $runs; do
+    c="$(gh run view "$r" --repo "$REPO" --json jobs \
+           --jq '.jobs[] | select(.name=="agent") | .conclusion' 2>/dev/null | head -1)"
+    if [ "$c" = "success" ]; then found="$r"; break; fi
+  done
 
-  printf "%-32s %-12s %s\n" "$w" "$concl" "$run_id"
-  [ "$concl" = "success" ] || fail=1
+  if [ -n "$found" ]; then
+    printf "%-32s %-10s %s\n" "$w" "success" "run $found"
+  else
+    printf "%-32s %-10s %s\n" "$w" "NEVER" "no agent success in last $DEPTH runs"
+    fail=1
+  fi
 done
 
 echo
 if [ "$fail" -ne 0 ]; then
-  echo "FAIL: at least one validator has not run its agent to success."
-  echo "A validator whose agent skips or fails reports the run as green while"
-  echo "reviewing nothing. Investigate before trusting these as a safety net."
+  echo "FAIL: at least one validator has never run its agent to success."
+  echo "Such a validator reports its runs as green while reviewing nothing."
+  echo "Investigate before trusting these as a safety net."
   exit 1
 fi
 
-echo "OK: all four validators ran their agent job to success."
+echo "OK: all four validators have run their agent to success."


### PR DESCRIPTION
Refs #1417, #1410

The check merged in #1437 went red **within minutes of landing on main**:

```
mcp-server-validation          NO AGENT JOB   32886113315
esm-module-validation          NO AGENT JOB   32886113344
knowledge-graph-validation     NO AGENT JOB   32886033768
deployment-pattern-validation  NO AGENT JOB   32886033675
```

Not a regression in the validators — a **defect in the check I wrote**, wrong in two independent ways.

### 1. It read runs that had not finished

A run still in flight has not created its `agent` job yet, so every in-progress run reports `NO AGENT JOB`. Three were in progress when this fired. The check was racing the thing it measured.

### 2. It asked a question with an oscillating answer

Validators **legitimately skip** when a commit touches none of their filtered paths — that is correct behaviour, established earlier in #1417. Asserting "the latest run's agent succeeded" would go red after any docs-only merge.

A check that flaps gets muted. That is precisely how the original false green survived for months, and I had rebuilt the mechanism in the artifact meant to prevent it.

### The property that is actually stable

**Capability.** Has each validator ever run its agent to success? One that skipped this morning is fine; one that has *never* succeeded is broken.

It now scans recent completed runs (`DEPTH=20`, early exit on first success) and prints the run id as evidence:

```
VALIDATOR                        AGENT      EVIDENCE
mcp-server-validation            success    run 32883056982
esm-module-validation            success    run 32883862037
knowledge-graph-validation       success    run 32883864920
deployment-pattern-validation    success    run 32883867627
```

This is **narrower** than the first version and the header says so: it proves the four *can* review, not that the last commit *was* reviewed. Overclaiming there is what produced the original problem.

### Still fails where it must — verified, not assumed

| scenario | result |
|---|---|
| validator with no completed runs | `exit 1` — `NONE` |
| validator whose agent never succeeded | `exit 1` — `NEVER`, checked against real `ai-executor-integration` history |
| all four with a success on record | `exit 0` |

The second case matters most: without it this rewrite would be an always-green check, which is strictly worse than the flaky one it replaces.

### Governance note

The engine caught this. Re-evaluating on `main` after the merge dropped #1417 to `[1/2]`, which pulled #1410 back from `STOP_COMPLETE` to `CONTINUE` through `covers.split_to`. A completion that had been declared was withdrawn on evidence — the firewall running in the direction people usually forget to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)