### PR TITLE
test(mcp): boot the server and speak MCP, replacing the grep-the-bundle guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,38 +112,16 @@ jobs:
             node scripts/validate-build.js
           fi
 
-          # Check that the built server contains expected MCP tools (basic validation)
-          echo "Checking for MCP tool implementations..."
-
-          # Check core tools
-          if grep -q "analyze_project" dist/src/index.js; then
-            echo "✅ analyze_project tool found"
-          else
-            echo "❌ analyze_project tool not found"
-            exit 1
-          fi
-
-          # Check new planning tools
-          if grep -q "mcp_planning" dist/src/index.js; then
-            echo "✅ mcp_planning tool found"
-          else
-            echo "❌ mcp_planning tool not found"
-            exit 1
-          fi
-
-          if grep -q "interactive_adr_planning" dist/src/index.js; then
-            echo "✅ interactive_adr_planning tool found"
-          else
-            echo "❌ interactive_adr_planning tool not found"
-            exit 1
-          fi
-
-          if grep -q "ListToolsRequestSchema" dist/src/index.js; then
-            echo "✅ ListToolsRequestSchema handler found"
-          else
-            echo "❌ ListToolsRequestSchema handler not found"
-            exit 1
-          fi
+          # The grep-the-bundle checks that lived here are replaced by
+          # tests/integration/mcp-protocol.test.ts, which boots the built server
+          # over stdio and speaks MCP to it. See #1413.
+          #
+          # Those greps could not detect the failure mode of the refactor they
+          # guarded (#1416) -- a string stays present in the bundle while
+          # dispatch breaks. Worse, one of them was simply wrong:
+          # `grep -q "analyze_project"` passed on the substring of
+          # `analyze_project_ecosystem`, so CI asserted a tool that does not
+          # exist and went green for it.
 
           echo "✅ MCP server functionality validated"
 

--- a/tests/integration/mcp-protocol.test.ts
+++ b/tests/integration/mcp-protocol.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Protocol-level test: boot the real server over stdio and talk MCP to it.
+ *
+ * Why this exists (#1413):
+ *
+ * CI's only guard against regressions in src/index.ts -- 9,700+ lines at 0.0%
+ * coverage -- was test.yml grepping the BUILT BUNDLE for four string literals:
+ *
+ *     grep -q "analyze_project"        dist/src/index.js
+ *     grep -q "mcp_planning"           dist/src/index.js
+ *     grep -q "interactive_adr_planning" dist/src/index.js
+ *     grep -q "ListToolsRequestSchema" dist/src/index.js
+ *
+ * That guard cannot detect the failure mode of the refactor it guards (#1416).
+ * Splitting the 111-arm dispatch switch into modules keeps every one of those
+ * strings present in the bundle while silently breaking dispatch, and CI stays
+ * green. A string being present is not a tool being callable.
+ *
+ * So this asserts behaviour over the wire instead: the server starts, speaks
+ * MCP, lists tools, and actually dispatches calls.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SERVER = resolve(process.cwd(), 'dist/src/index.js');
+
+let client: Client;
+let transport: StdioClientTransport;
+let toolNames: string[] = [];
+
+describe('MCP protocol', () => {
+  beforeAll(async () => {
+    // The built server is the artifact under test. Testing src/ via tsx would
+    // check something users never run.
+    if (!existsSync(SERVER)) {
+      throw new Error(
+        `${SERVER} not found. Run \`npm run build\` before this test -- it exercises ` +
+          `the BUILT server, which is the thing shipped to npm.`
+      );
+    }
+
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER],
+      env: {
+        ...(process.env as Record<string, string>),
+        PROJECT_PATH: process.cwd(),
+        ADR_DIRECTORY: 'docs/adrs',
+        // Keep the server off any AI path: this test is about protocol
+        // behaviour, and must not depend on a key or make a network call.
+        EXECUTION_MODE: 'prompt-only',
+        LOG_LEVEL: 'error',
+      },
+      stderr: 'pipe',
+    });
+
+    client = new Client({ name: 'protocol-test', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+  }, 120_000);
+
+  afterAll(async () => {
+    await client?.close().catch(() => {});
+    await transport?.close().catch(() => {});
+  });
+
+  it('completes the MCP handshake over stdio', () => {
+    // connect() resolving means initialize succeeded. stdio is the only
+    // transport this server implements (src/index.ts:12).
+    const version = client.getServerVersion();
+    expect(version).toBeDefined();
+    expect(version?.name).toBeTruthy();
+  });
+
+  it('answers tools/list with a non-trivial tool set', async () => {
+    const res = await client.listTools();
+    toolNames = res.tools.map(t => t.name);
+
+    expect(Array.isArray(res.tools)).toBe(true);
+    // Guards against a refactor that wires up an empty or near-empty registry.
+    // The exact count is deliberately not asserted -- #1416 will change it, and
+    // a test that must be edited to let the refactor pass is not a guard.
+    expect(res.tools.length).toBeGreaterThan(20);
+  }, 60_000);
+
+  it('gives every tool a name, description and object input schema', async () => {
+    const res = await client.listTools();
+    for (const tool of res.tools) {
+      expect(tool.name, `tool has no name: ${JSON.stringify(tool)}`).toBeTruthy();
+      expect(tool.description, `${tool.name} has no description`).toBeTruthy();
+      expect(tool.inputSchema, `${tool.name} has no inputSchema`).toBeDefined();
+      expect(tool.inputSchema.type, `${tool.name} inputSchema is not an object`).toBe('object');
+    }
+  }, 60_000);
+
+  it('exposes no duplicate tool names', async () => {
+    // Four hand-maintained registries feed this list today (#1416). A merge that
+    // double-registers a tool is invisible to a grep and breaks dispatch.
+    const dupes = toolNames.filter((n, i) => toolNames.indexOf(n) !== i);
+    expect(dupes).toEqual([]);
+  });
+
+  it('still exposes the tools the old grep guard checked for', async () => {
+    // The literals test.yml grepped the bundle for, asserted as real registry
+    // entries rather than as strings that happen to appear in a file.
+    //
+    // NOTE: the guard's fourth literal was `analyze_project`, and NO SUCH TOOL
+    // EXISTS. `grep -q "analyze_project" dist/src/index.js` passed only because
+    // it is a substring of `analyze_project_ecosystem`. CI has been asserting
+    // the presence of a tool this server has never exposed, and passing.
+    // That is not a hypothetical weakness in the grep guard -- it is the guard
+    // being wrong today, found by the first run of this test.
+    for (const name of ['mcp_planning', 'interactive_adr_planning']) {
+      expect(toolNames, `${name} is missing from tools/list`).toContain(name);
+    }
+    // The real tool the guard was presumably reaching for.
+    expect(toolNames).toContain('analyze_project_ecosystem');
+    // And the tool it literally named does not exist -- pinned so that if it is
+    // ever added, this test says so rather than quietly passing.
+    expect(toolNames).not.toContain('analyze_project');
+  });
+
+  it('dispatches tools/call and returns a well-formed result', async () => {
+    // One call that actually reaches a handler. This is what the grep could
+    // never do: prove the name resolves to something that runs.
+    const res: any = await client.callTool({
+      name: 'get_current_datetime',
+      arguments: {},
+    });
+
+    expect(res).toBeDefined();
+    expect(Array.isArray(res.content), 'result.content must be an array').toBe(true);
+    expect(res.content.length).toBeGreaterThan(0);
+    expect(res.content[0]).toHaveProperty('type');
+  }, 180_000);
+
+  it('rejects an unknown tool instead of failing silently', async () => {
+    // A dispatcher that quietly returns success for an unrouted name is the
+    // exact regression the #1416 refactor could introduce.
+    let threw = false;
+    try {
+      const res: any = await client.callTool({
+        name: 'a_tool_that_does_not_exist',
+        arguments: {},
+      });
+      // Some servers signal errors in-band rather than throwing.
+      if (res?.isError === true) threw = true;
+    } catch {
+      threw = true;
+    }
+    expect(threw, 'unknown tool was accepted without error').toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #1413 · unblocks #1416

CI's only guard against regressions in `src/index.ts` — **9,700+ lines at 0.0% coverage** — was `test.yml` grepping the built bundle for four string literals:

```bash
grep -q "analyze_project"          dist/src/index.js
grep -q "mcp_planning"             dist/src/index.js
grep -q "interactive_adr_planning" dist/src/index.js
grep -q "ListToolsRequestSchema"   dist/src/index.js
```

That guard cannot detect the failure mode of the refactor it guards. Splitting the 111-arm dispatch switch into modules (#1416) keeps every one of those strings in the bundle while silently breaking dispatch, and CI stays green.

## The guard was also wrong, today

**There is no `analyze_project` tool.** This server exposes 75 tools and that is not one of them. The closest is `analyze_project_ecosystem` — and `grep -q "analyze_project"` matched it as a **substring**.

So CI has been asserting the presence of a tool that has never existed, and passing on it. That is not a hypothetical weakness in the grep approach; it is the guard being wrong right now. **The first run of this test found it.**

## What replaces it

`tests/integration/mcp-protocol.test.ts` boots the built server over stdio and talks MCP to it:

| assertion | why |
|---|---|
| handshake completes | stdio is the only transport (`src/index.ts:12`) |
| `tools/list` returns a non-trivial set | catches a refactor wiring up an empty registry |
| every tool has name + description + object `inputSchema` | catches half-migrated entries |
| **no duplicate tool names** | four hand-maintained registries feed this list; a double registration is invisible to a grep |
| the old guard's literals, as **real registry entries** | `analyze_project` pinned as *absent*, so adding it later says so rather than quietly passing |
| `tools/call` actually dispatches | the thing a grep can never do — prove a name resolves to something that runs |
| unknown tool is rejected | a dispatcher that silently succeeds on an unrouted name is exactly the #1416 regression |

## Two deliberate choices

**It tests the built server, not `src/` via tsx.** The built server is what users run — and this is the same distinction that let the `openai` bug ship in 2.6.13. `make node-compat` builds before `make test-ci` in `test.yml`, so `dist/` exists when the suite runs; locally it fails with an explicit *"run npm run build first"* rather than a confusing import error.

**It does not assert an exact tool count.** #1416 will change it, and a test that must be edited to let the refactor pass is not a guard.

## Verification

```
tests/integration/mcp-protocol.test.ts   7 passed
full suite                               127 files | 3055 tests passed
typecheck ratchet                        290 / 290 OK
```

## Governance

```
#1413  AUTHORIZED / STOP_COMPLETE   3/3
```

This is the last of #1416's four blockers — #1410, #1411, #1412 are already closed. Merging this clears the registry refactor to start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)