### PR TITLE
fix(ce-mcp): stop the AI layer misreporting its own state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4628,8 +4628,24 @@ export class McpAdrAnalysisServer {
 - **AI Model**: ${status.model}
 
 ${
-  status.reason
-    ? `## ⚠️ Issue Detected
+  // CE-MCP is the DEFAULT mode and needs no API key. Reporting the absence of
+  // one as an "Issue Detected" -- immediately after saying no external API call
+  // is needed -- told every new user to go and buy a key they do not need.
+  // Legacy configuration is only a problem for someone who asked for it. (#1414)
+  status.executionMode === 'ce-mcp'
+    ? `## ✅ Running in CE-MCP mode
+
+No API key is required. Tools return orchestration directives that your host LLM
+executes directly, which is why **AI Execution Enabled: NO** above is expected and
+correct rather than a fault.
+
+Note that only some tools currently return a directive; the rest return their
+result directly. See ADR-014 and ADR-021.
+
+Legacy OpenRouter execution is off by design. You only need the configuration
+below if you deliberately want that older path.`
+    : status.reason
+      ? `## ⚠️ Issue Detected
 **Problem**: ${status.reason}
 
 ## Solution
@@ -4672,7 +4688,7 @@ ${
 `
       : ''
 }`
-    : `## ✅ Configuration Looks Good!
+      : `## ✅ Configuration Looks Good!
 
 AI execution is properly configured. Tools should return actual results instead of prompts.
 

--- a/src/tools/ce-mcp-tools.ts
+++ b/src/tools/ce-mcp-tools.ts
@@ -1370,6 +1370,33 @@ export function shouldUseCEMCPDirective(toolName: string, config: { mode: string
 /**
  * Get CE-MCP directive for a tool
  */
+/**
+ * The tools that `getCEMCPDirective()` below actually implements.
+ *
+ * This exists because `TOOL_CATALOG` carried a hand-maintained
+ * `hasCEMCPDirective` boolean that drifted badly: 70 tools claimed a directive
+ * while 12 had one. That field is surfaced to callers by `search_tools`, the
+ * tool-catalog resource, and the dispatcher's tool list, so the discovery
+ * surface advertised a capability most tools did not have.
+ *
+ * Keep this in sync with the switch below. `tests/tools/ce-mcp-directives.test.ts`
+ * fails if they diverge, and if the catalog disagrees with either.
+ */
+export const CE_MCP_DIRECTIVE_TOOLS: ReadonlySet<string> = new Set([
+  'analyze_environment',
+  'analyze_project_ecosystem',
+  'deployment_readiness',
+  'generate_adrs_from_prd',
+  'generate_rules',
+  'interactive_adr_planning',
+  'mcp_planning',
+  'perform_research',
+  'smart_score',
+  'suggest_adrs',
+  'tool_chain_orchestrator',
+  'troubleshoot_guided_workflow',
+]);
+
 export function getCEMCPDirective(
   toolName: string,
   args: Record<string, unknown>

--- a/src/tools/tool-catalog.ts
+++ b/src/tools/tool-catalog.ts
@@ -167,7 +167,7 @@ TOOL_CATALOG.set('get_architectural_context', {
   category: 'analysis',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 5000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - context assembly
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - context assembly
   relatedTools: ['analyze_project_ecosystem', 'discover_existing_adrs'],
   keywords: ['architecture', 'context', 'knowledge', 'graph'],
   requiresAI: false,
@@ -261,7 +261,7 @@ TOOL_CATALOG.set('generate_adr_from_decision', {
   category: 'adr',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 4000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - document generation
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - document generation
   relatedTools: ['suggest_adrs', 'validate_adr'],
   keywords: ['adr', 'generate', 'decision', 'document'],
   requiresAI: true,
@@ -305,7 +305,7 @@ TOOL_CATALOG.set('discover_existing_adrs', {
   category: 'adr',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - file discovery operation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - file discovery operation
   relatedTools: ['validate_all_adrs', 'analyze_adr_timeline'],
   keywords: ['adr', 'discover', 'find', 'index'],
   requiresAI: false,
@@ -326,7 +326,7 @@ TOOL_CATALOG.set('validate_adr', {
   category: 'adr',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - single validation operation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - single validation operation
   relatedTools: ['validate_all_adrs', 'suggest_adrs'],
   keywords: ['adr', 'validate', 'check', 'structure'],
   requiresAI: false,
@@ -347,7 +347,7 @@ TOOL_CATALOG.set('validate_all_adrs', {
   category: 'adr',
   complexity: 'moderate',
   tokenCost: { min: 1000, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - batch validation
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - batch validation
   relatedTools: ['validate_adr', 'discover_existing_adrs'],
   keywords: ['adr', 'validate', 'all', 'batch'],
   requiresAI: false,
@@ -366,7 +366,7 @@ TOOL_CATALOG.set('analyze_adr_timeline', {
   category: 'adr',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - timeline analysis
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - timeline analysis
   relatedTools: ['discover_existing_adrs', 'compare_adr_progress'],
   keywords: ['adr', 'timeline', 'history', 'evolution'],
   requiresAI: true,
@@ -386,7 +386,7 @@ TOOL_CATALOG.set('compare_adr_progress', {
   category: 'adr',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 4000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - progress comparison
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - progress comparison
   relatedTools: ['analyze_adr_timeline', 'validate_all_adrs'],
   keywords: ['adr', 'compare', 'progress', 'implementation'],
   requiresAI: true,
@@ -405,7 +405,7 @@ TOOL_CATALOG.set('review_existing_adrs', {
   category: 'adr',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 4000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - ADR review
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - ADR review
   relatedTools: ['validate_all_adrs', 'suggest_adrs'],
   keywords: ['adr', 'review', 'analyze', 'update'],
   requiresAI: true,
@@ -426,7 +426,7 @@ TOOL_CATALOG.set('generate_adr_bootstrap', {
   category: 'adr',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - setup/initialization
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - setup/initialization
   relatedTools: ['suggest_adrs', 'generate_adr_from_decision'],
   keywords: ['adr', 'bootstrap', 'setup', 'initialize'],
   requiresAI: false,
@@ -473,7 +473,7 @@ TOOL_CATALOG.set('analyze_content_security', {
   category: 'content-security',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - security analysis
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - security analysis
   relatedTools: ['generate_content_masking', 'validate_content_masking'],
   keywords: ['security', 'content', 'analyze', 'secrets', 'sensitive'],
   requiresAI: true,
@@ -494,7 +494,7 @@ TOOL_CATALOG.set('generate_content_masking', {
   category: 'content-security',
   complexity: 'moderate',
   tokenCost: { min: 1000, max: 2500 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - masking rule generation
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - masking rule generation
   relatedTools: ['analyze_content_security', 'apply_basic_content_masking'],
   keywords: ['masking', 'generate', 'rules', 'protection'],
   requiresAI: true,
@@ -515,7 +515,7 @@ TOOL_CATALOG.set('apply_basic_content_masking', {
   category: 'content-security',
   complexity: 'simple',
   tokenCost: { min: 200, max: 500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - single masking operation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - single masking operation
   relatedTools: ['generate_content_masking', 'configure_custom_patterns'],
   keywords: ['masking', 'apply', 'basic', 'content'],
   requiresAI: false,
@@ -535,7 +535,7 @@ TOOL_CATALOG.set('configure_custom_patterns', {
   category: 'content-security',
   complexity: 'simple',
   tokenCost: { min: 200, max: 500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - pattern configuration
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - pattern configuration
   relatedTools: ['apply_basic_content_masking', 'validate_content_masking'],
   keywords: ['patterns', 'configure', 'custom', 'masking'],
   requiresAI: false,
@@ -556,7 +556,7 @@ TOOL_CATALOG.set('validate_content_masking', {
   category: 'content-security',
   complexity: 'simple',
   tokenCost: { min: 300, max: 800 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - validation operation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - validation operation
   relatedTools: ['apply_basic_content_masking', 'analyze_content_security'],
   keywords: ['validate', 'masking', 'check', 'verify'],
   requiresAI: false,
@@ -577,7 +577,7 @@ TOOL_CATALOG.set('configure_output_masking', {
   category: 'content-security',
   complexity: 'simple',
   tokenCost: { min: 200, max: 400 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - settings configuration
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - settings configuration
   relatedTools: ['apply_basic_content_masking', 'configure_custom_patterns'],
   keywords: ['configure', 'output', 'masking', 'settings'],
   requiresAI: false,
@@ -624,7 +624,7 @@ TOOL_CATALOG.set('incorporate_research', {
   category: 'research',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 4000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - research integration
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - research integration
   relatedTools: ['perform_research', 'create_research_template'],
   keywords: ['research', 'incorporate', 'integrate', 'findings'],
   requiresAI: true,
@@ -645,7 +645,7 @@ TOOL_CATALOG.set('generate_research_questions', {
   category: 'research',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - question generation
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - question generation
   relatedTools: ['perform_research', 'create_research_template'],
   keywords: ['research', 'questions', 'generate', 'gaps'],
   requiresAI: true,
@@ -665,7 +665,7 @@ TOOL_CATALOG.set('create_research_template', {
   category: 'research',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1000 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - template generation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - template generation
   relatedTools: ['perform_research', 'incorporate_research'],
   keywords: ['research', 'template', 'create', 'structure'],
   requiresAI: false,
@@ -686,7 +686,7 @@ TOOL_CATALOG.set('llm_web_search', {
   category: 'research',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 5000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - LLM web search
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - LLM web search
   relatedTools: ['perform_research', 'llm_cloud_management'],
   keywords: ['search', 'web', 'llm', 'internet'],
   requiresAI: true,
@@ -707,7 +707,7 @@ TOOL_CATALOG.set('llm_cloud_management', {
   category: 'research',
   complexity: 'complex',
   tokenCost: { min: 3000, max: 6000 },
-  hasCEMCPDirective: true, // Phase 4.3: Complex tool - cloud management orchestration
+  hasCEMCPDirective: false, // Phase 4.3: Complex tool - cloud management orchestration
   relatedTools: ['llm_web_search', 'llm_database_management'],
   keywords: ['cloud', 'management', 'llm', 'aws', 'gcp', 'azure'],
   requiresAI: true,
@@ -728,7 +728,7 @@ TOOL_CATALOG.set('llm_database_management', {
   category: 'research',
   complexity: 'complex',
   tokenCost: { min: 2500, max: 5000 },
-  hasCEMCPDirective: true, // Phase 4.3: Complex tool - database management orchestration
+  hasCEMCPDirective: false, // Phase 4.3: Complex tool - database management orchestration
   relatedTools: ['llm_cloud_management', 'llm_web_search'],
   keywords: ['database', 'management', 'llm', 'sql', 'nosql'],
   requiresAI: true,
@@ -776,7 +776,7 @@ TOOL_CATALOG.set('release_tracking', {
   category: 'deployment',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 6000 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['deployment_readiness', 'discover_existing_adrs', 'smart_git_push'],
   keywords: [
     'release',
@@ -852,7 +852,7 @@ TOOL_CATALOG.set('smart_git_push', {
   category: 'deployment',
   complexity: 'moderate',
   tokenCost: { min: 1000, max: 2500 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - git operations
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - git operations
   relatedTools: ['deployment_readiness', 'analyze_deployment_progress'],
   keywords: ['git', 'push', 'smart', 'deployment'],
   requiresAI: false,
@@ -873,7 +873,7 @@ TOOL_CATALOG.set('bootstrap_validation_loop', {
   category: 'deployment',
   complexity: 'complex',
   tokenCost: { min: 3000, max: 6000 },
-  hasCEMCPDirective: true, // Phase 4.3: Complex tool - state machine validation
+  hasCEMCPDirective: false, // Phase 4.3: Complex tool - state machine validation
   relatedTools: ['deployment_readiness', 'generate_deployment_guidance'],
   keywords: ['bootstrap', 'validation', 'loop', 'deployment', 'patterns'],
   requiresAI: true,
@@ -894,7 +894,7 @@ TOOL_CATALOG.set('analyze_deployment_progress', {
   category: 'deployment',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - deployment tracking
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - deployment tracking
   relatedTools: ['deployment_readiness', 'generate_deployment_guidance'],
   keywords: ['deployment', 'progress', 'analyze', 'status'],
   requiresAI: false,
@@ -915,7 +915,7 @@ TOOL_CATALOG.set('generate_deployment_guidance', {
   category: 'deployment',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 4000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - guidance generation
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - guidance generation
   relatedTools: ['deployment_readiness', 'bootstrap_validation_loop'],
   keywords: ['deployment', 'guidance', 'generate', 'best-practices'],
   requiresAI: true,
@@ -961,7 +961,7 @@ TOOL_CATALOG.set('memory_loading', {
   category: 'memory',
   complexity: 'simple',
   tokenCost: { min: 500, max: 2000 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - memory retrieval
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - memory retrieval
   relatedTools: ['expand_memory', 'query_conversation_history'],
   keywords: ['memory', 'load', 'context', 'session'],
   requiresAI: false,
@@ -981,7 +981,7 @@ TOOL_CATALOG.set('expand_memory', {
   category: 'memory',
   complexity: 'simple',
   tokenCost: { min: 300, max: 800 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - memory storage
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - memory storage
   relatedTools: ['memory_loading', 'get_memory_stats'],
   keywords: ['memory', 'expand', 'add', 'context'],
   requiresAI: false,
@@ -1002,7 +1002,7 @@ TOOL_CATALOG.set('query_conversation_history', {
   category: 'memory',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - history query
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - history query
   relatedTools: ['get_conversation_snapshot', 'memory_loading'],
   keywords: ['conversation', 'history', 'query', 'search'],
   requiresAI: false,
@@ -1022,7 +1022,7 @@ TOOL_CATALOG.set('get_conversation_snapshot', {
   category: 'memory',
   complexity: 'simple',
   tokenCost: { min: 300, max: 800 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - state snapshot
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - state snapshot
   relatedTools: ['query_conversation_history', 'get_memory_stats'],
   keywords: ['conversation', 'snapshot', 'state'],
   requiresAI: false,
@@ -1041,7 +1041,7 @@ TOOL_CATALOG.set('get_memory_stats', {
   category: 'memory',
   complexity: 'simple',
   tokenCost: { min: 200, max: 400 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - stats retrieval
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - stats retrieval
   relatedTools: ['memory_loading', 'expand_memory'],
   keywords: ['memory', 'stats', 'statistics', 'usage'],
   requiresAI: false,
@@ -1060,7 +1060,7 @@ TOOL_CATALOG.set('expand_analysis_section', {
   category: 'memory',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - section expansion
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - section expansion
   relatedTools: ['analyze_project_ecosystem', 'memory_loading'],
   keywords: ['expand', 'analysis', 'section', 'detail'],
   requiresAI: true,
@@ -1085,7 +1085,7 @@ TOOL_CATALOG.set('read_file', {
   category: 'file-system',
   complexity: 'simple',
   tokenCost: { min: 100, max: 5000 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - file read operation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - file read operation
   relatedTools: ['write_file', 'read_directory'],
   keywords: ['file', 'read', 'contents'],
   requiresAI: false,
@@ -1105,7 +1105,7 @@ TOOL_CATALOG.set('write_file', {
   category: 'file-system',
   complexity: 'simple',
   tokenCost: { min: 100, max: 1000 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - file write operation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - file write operation
   relatedTools: ['read_file', 'list_directory'],
   keywords: ['file', 'write', 'save'],
   requiresAI: false,
@@ -1126,7 +1126,7 @@ TOOL_CATALOG.set('read_directory', {
   category: 'file-system',
   complexity: 'simple',
   tokenCost: { min: 100, max: 1000 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - directory read
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - directory read
   relatedTools: ['read_file', 'list_directory'],
   keywords: ['directory', 'read', 'list'],
   requiresAI: false,
@@ -1147,7 +1147,7 @@ TOOL_CATALOG.set('list_directory', {
   category: 'file-system',
   complexity: 'simple',
   tokenCost: { min: 100, max: 500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - directory listing
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - directory listing
   relatedTools: ['read_directory', 'read_file'],
   keywords: ['directory', 'list', 'files'],
   requiresAI: false,
@@ -1167,7 +1167,7 @@ TOOL_CATALOG.set('list_roots', {
   category: 'file-system',
   complexity: 'simple',
   tokenCost: { min: 50, max: 200 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - root listing
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - root listing
   relatedTools: ['read_directory', 'list_directory'],
   keywords: ['roots', 'list', 'directories'],
   requiresAI: false,
@@ -1210,7 +1210,7 @@ TOOL_CATALOG.set('validate_rules', {
   category: 'rules',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - rule validation
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - rule validation
   relatedTools: ['generate_rules', 'create_rule_set'],
   keywords: ['rules', 'validate', 'check', 'violations'],
   requiresAI: false,
@@ -1231,7 +1231,7 @@ TOOL_CATALOG.set('create_rule_set', {
   category: 'rules',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1000 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - rule set creation
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - rule set creation
   relatedTools: ['generate_rules', 'validate_rules'],
   keywords: ['rules', 'create', 'set', 'configuration'],
   requiresAI: false,
@@ -1256,7 +1256,7 @@ TOOL_CATALOG.set('get_workflow_guidance', {
   category: 'workflow',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - workflow guidance
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - workflow guidance
   relatedTools: ['get_development_guidance', 'mcp_planning'],
   keywords: ['workflow', 'guidance', 'help', 'process'],
   requiresAI: true,
@@ -1277,7 +1277,7 @@ TOOL_CATALOG.set('get_development_guidance', {
   category: 'workflow',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: true, // Phase 4.3: Moderate tool - development guidance
+  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - development guidance
   relatedTools: ['get_workflow_guidance', 'mcp_planning'],
   keywords: ['development', 'guidance', 'best-practices'],
   requiresAI: true,
@@ -1340,7 +1340,7 @@ TOOL_CATALOG.set('request_action_confirmation', {
   category: 'workflow',
   complexity: 'simple',
   tokenCost: { min: 100, max: 300 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - confirmation request
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - confirmation request
   relatedTools: ['tool_chain_orchestrator'],
   keywords: ['confirmation', 'request', 'action', 'approve'],
   requiresAI: false,
@@ -1365,7 +1365,7 @@ TOOL_CATALOG.set('manage_cache', {
   category: 'utility',
   complexity: 'simple',
   tokenCost: { min: 100, max: 500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - cache management
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - cache management
   relatedTools: ['get_server_context', 'get_memory_stats'],
   keywords: ['cache', 'manage', 'clear', 'cleanup'],
   requiresAI: false,
@@ -1386,7 +1386,7 @@ TOOL_CATALOG.set('check_ai_execution_status', {
   category: 'utility',
   complexity: 'simple',
   tokenCost: { min: 100, max: 300 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - status check
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - status check
   relatedTools: ['get_server_context'],
   keywords: ['ai', 'status', 'check', 'execution'],
   requiresAI: false,
@@ -1403,7 +1403,7 @@ TOOL_CATALOG.set('get_server_context', {
   category: 'utility',
   complexity: 'simple',
   tokenCost: { min: 200, max: 500 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - context retrieval
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - context retrieval
   relatedTools: ['check_ai_execution_status', 'manage_cache'],
   keywords: ['server', 'context', 'config', 'status'],
   requiresAI: false,
@@ -1422,7 +1422,7 @@ TOOL_CATALOG.set('get_current_datetime', {
   category: 'utility',
   complexity: 'simple',
   tokenCost: { min: 50, max: 100 },
-  hasCEMCPDirective: true, // Phase 4.3: Simple tool - datetime retrieval
+  hasCEMCPDirective: false, // Phase 4.3: Simple tool - datetime retrieval
   relatedTools: [],
   keywords: ['datetime', 'time', 'date', 'current'],
   requiresAI: false,
@@ -1444,7 +1444,7 @@ TOOL_CATALOG.set('load_prompt', {
   category: 'utility',
   complexity: 'simple',
   tokenCost: { min: 100, max: 500 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['search_tools', 'analyze_project_ecosystem'],
   keywords: ['prompt', 'load', 'lazy', 'ce-mcp', 'token', 'optimization'],
   requiresAI: false,
@@ -1491,7 +1491,7 @@ TOOL_CATALOG.set('sync_to_aggregator', {
   category: 'aggregator',
   complexity: 'moderate',
   tokenCost: { min: 1000, max: 3000 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_adr_context', 'get_staleness_report', 'discover_existing_adrs'],
   keywords: ['aggregator', 'sync', 'adr', 'dashboard', 'platform', 'push'],
   requiresAI: false,
@@ -1549,7 +1549,7 @@ TOOL_CATALOG.set('get_adr_context', {
   category: 'aggregator',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['sync_to_aggregator', 'get_staleness_report'],
   keywords: ['aggregator', 'context', 'adr', 'fetch', 'retrieve', 'pull'],
   requiresAI: false,
@@ -1603,7 +1603,7 @@ TOOL_CATALOG.set('get_staleness_report', {
   category: 'aggregator',
   complexity: 'simple',
   tokenCost: { min: 300, max: 800 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_adr_context', 'analyze_adr_timeline'],
   keywords: ['aggregator', 'staleness', 'report', 'governance', 'review', 'freshness'],
   requiresAI: false,
@@ -1631,7 +1631,7 @@ TOOL_CATALOG.set('get_adr_templates', {
   category: 'aggregator',
   complexity: 'simple',
   tokenCost: { min: 300, max: 1000 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['generate_adr_from_decision', 'suggest_adrs'],
   keywords: ['aggregator', 'templates', 'best-practices', 'domain', 'anti-patterns'],
   requiresAI: false,
@@ -1654,7 +1654,7 @@ TOOL_CATALOG.set('get_adr_diagrams', {
   category: 'aggregator',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_adr_context', 'sync_to_aggregator'],
   keywords: ['aggregator', 'diagrams', 'mermaid', 'visualization', 'pro', 'tier'],
   requiresAI: false,
@@ -1681,7 +1681,7 @@ TOOL_CATALOG.set('validate_adr_compliance', {
   category: 'aggregator',
   complexity: 'moderate',
   tokenCost: { min: 1000, max: 2500 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_adr_context', 'deployment_readiness'],
   keywords: ['aggregator', 'compliance', 'validation', 'ast', 'pro', 'tier', 'implementation'],
   requiresAI: false,
@@ -1715,7 +1715,7 @@ TOOL_CATALOG.set('get_knowledge_graph', {
   category: 'aggregator',
   complexity: 'moderate',
   tokenCost: { min: 1000, max: 3000 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_architectural_context', 'get_adr_context'],
   keywords: [
     'aggregator',
@@ -1756,7 +1756,7 @@ TOOL_CATALOG.set('update_implementation_status', {
   category: 'aggregator',
   complexity: 'simple',
   tokenCost: { min: 300, max: 800 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['sync_to_aggregator', 'get_adr_context', 'validate_adr_compliance'],
   keywords: [
     'aggregator',
@@ -1812,7 +1812,7 @@ TOOL_CATALOG.set('get_adr_priorities', {
   category: 'aggregator',
   complexity: 'simple',
   tokenCost: { min: 500, max: 1500 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_adr_context', 'update_implementation_status', 'analyze_gaps'],
   keywords: ['aggregator', 'priorities', 'roadmap', 'backlog', 'planning', 'score', 'dependencies'],
   requiresAI: false,
@@ -1841,7 +1841,7 @@ TOOL_CATALOG.set('analyze_gaps', {
   category: 'aggregator',
   complexity: 'moderate',
   tokenCost: { min: 800, max: 3000 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['get_adr_priorities', 'get_adr_context', 'suggest_adrs'],
   keywords: [
     'gaps',
@@ -1889,7 +1889,7 @@ TOOL_CATALOG.set('search_tools', {
   category: 'utility',
   complexity: 'simple',
   tokenCost: { min: 100, max: 300 },
-  hasCEMCPDirective: true,
+  hasCEMCPDirective: false,
   relatedTools: ['load_prompt'],
   keywords: ['search', 'discover', 'tools', 'catalog', 'ce-mcp', 'meta'],
   requiresAI: false,

--- a/tests/tools/ce-mcp-directives.test.ts
+++ b/tests/tools/ce-mcp-directives.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Guards the CE-MCP directive claims against drift (#1414).
+ *
+ * TOOL_CATALOG carried a hand-maintained `hasCEMCPDirective` boolean that had
+ * drifted badly: 70 tools claimed a directive while 12 had one. That field is
+ * surfaced to callers by `search_tools`, the tool-catalog resource, and the
+ * dispatcher's tool list -- so the discovery surface advertised a capability
+ * most tools did not have.
+ *
+ * These tests assert against the IMPLEMENTATION, not against a second list.
+ * getCEMCPDirective() returning non-null is the only thing that makes the claim
+ * true, so that is what is checked.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CE_MCP_DIRECTIVE_TOOLS, getCEMCPDirective } from '../../src/tools/ce-mcp-tools.js';
+import { TOOL_CATALOG } from '../../src/tools/tool-catalog.js';
+
+describe('CE-MCP directive claims', () => {
+  it('every tool in CE_MCP_DIRECTIVE_TOOLS actually returns a directive', () => {
+    const broken: string[] = [];
+    for (const name of CE_MCP_DIRECTIVE_TOOLS) {
+      let directive: unknown = null;
+      try {
+        directive = getCEMCPDirective(name, {});
+      } catch {
+        // A directive factory that throws on empty args still counts as
+        // implemented -- the switch routed the name. Only an unrouted name
+        // (which falls through to null) is a false claim.
+        continue;
+      }
+      if (directive === null) broken.push(name);
+    }
+    expect(broken, `listed as directive-backed but getCEMCPDirective returned null`).toEqual([]);
+  });
+
+  it('no tool outside the list is silently implemented', () => {
+    // Catches the opposite drift: a directive added to the switch without being
+    // declared, which would leave the catalog under-reporting.
+    const undeclared: string[] = [];
+    for (const name of TOOL_CATALOG.keys()) {
+      if (CE_MCP_DIRECTIVE_TOOLS.has(name)) continue;
+      let directive: unknown = null;
+      try {
+        directive = getCEMCPDirective(name, {});
+      } catch {
+        undeclared.push(name);
+        continue;
+      }
+      if (directive !== null) undeclared.push(name);
+    }
+    expect(undeclared, `implemented but missing from CE_MCP_DIRECTIVE_TOOLS`).toEqual([]);
+  });
+
+  it('the catalog claims exactly the tools that are implemented', () => {
+    const claimed = [...TOOL_CATALOG.entries()]
+      .filter(([, m]) => m.hasCEMCPDirective)
+      .map(([n]) => n)
+      .sort();
+    const actual = [...CE_MCP_DIRECTIVE_TOOLS].sort();
+
+    // The specific failure this exists to prevent: 70 claimed, 12 real.
+    expect(claimed).toEqual(actual);
+  });
+
+  it('does not over-claim across the catalog as a whole', () => {
+    const claimedCount = [...TOOL_CATALOG.values()].filter(m => m.hasCEMCPDirective).length;
+    expect(claimedCount).toBe(CE_MCP_DIRECTIVE_TOOLS.size);
+  });
+});


### PR DESCRIPTION
Refs #1414 · independent of #1455

Two defects that are **wrong under every option** in ADR-021, so they are fixed ahead of the decision rather than behind it.

## 1. The catalog claimed 70 directives. Twelve exist.

`hasCEMCPDirective` was a hand-maintained boolean per catalog entry, with no link to the `getCEMCPDirective()` switch that decides the truth. So it drifted.

Not cosmetic — three call sites surface it:

```
src/tools/tool-dispatcher.ts:211      appends "(CE-MCP)" to the tool list
src/tools/tool-catalog.ts:1971        the cemcpOnly filter in search_tools
src/resources/tool-catalog-resource.ts  the published catalog resource
```

The discovery surface advertised a capability **58 tools do not have**.

Corrected all 58 (`true → false`; none were wrong the other way), and exported `CE_MCP_DIRECTIVE_TOOLS` from `ce-mcp-tools.ts`, sitting next to the switch as the single declared source.

### The guard checks the implementation, not a second list

`tests/tools/ce-mcp-directives.test.ts` calls `getCEMCPDirective()` for every declared name and requires non-null, checks no *undeclared* tool is silently implemented, and requires the catalog to claim exactly that set.

A test comparing one list to another list would just be a third place to drift.

**Verified it fires:** injecting a single false claim fails 2 of its 4 tests.

## 2. The diagnostic told users to buy a key they don't need

On a clean checkout, `check_ai_execution_status` printed, in this order:

```
"In CE-MCP mode ... eliminating the need for external API calls."
"## ⚠️ Issue Detected — Problem: Missing OPENROUTER_API_KEY"
"1. Get an OpenRouter API key from https://openrouter.ai/keys"
```

The Issue-Detected branch fired whenever legacy execution was off — which is the **intended default state**.

Now CE-MCP reports as the healthy configuration it is, explains why `AI Execution Enabled: NO` is expected rather than a fault, and is honest that only some tools return a directive today. Legacy guidance is kept for anyone who deliberately wants that path.

Before / after, both observed over MCP:

```
- ## ⚠️ Issue Detected
- **Problem**: Missing OPENROUTER_API_KEY environment variable
+ ## ✅ Running in CE-MCP mode
+ No API key is required. ... which is why **AI Execution Enabled: NO** above
+ is expected and correct rather than a fault.
```

**Found by calling the tool, not by reading code.** The protocol client added in #1413 is what made it visible — one day after it merged. Fix verified the same way.

## Verification

```
suite       128 files | 3059 tests passed
typecheck   clean
ratchet     290 / 290 OK
```

## Scope

Deliberately does **not** touch the AI layer's disposition — that is #1414 / ADR-021 (#1455) and remains the owner's decision. This only stops the layer lying about what it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)