### PR TITLE
feat(adr): adopt MADR as the default format (ADR-022)

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -26,6 +26,7 @@ This directory contains the Architectural Decision Records for the MCP ADR Analy
 | [ADR-019](adr-019-vitest-migration.md)                                 | Migrate from Jest to Vitest for Testing          | Accepted | 2024-12-16 | Testing       |
 | [ADR-020](adr-020-mcp-tasks-integration-strategy.md)                   | MCP Tasks Integration Strategy                   | Accepted | 2025-12-16 | Architecture  |
 | [ADR-021](adr-021-ai-layer-disposition.md)                             | Disposition of the legacy AI execution layer     | Proposed | 2026-08-26 | Architecture  |
+| [ADR-022](adr-022-adopt-madr-format.md)                                | Adopt MADR as the default decision-record format | Proposed | 2026-08-26 | Documentation |
 
 > **This index is known to be out of date and is not corrected here.** It stops at
 > ADR-018, omits ADR-019 and ADR-020, and lists ADR-012, ADR-013 and ADR-014 as

--- a/docs/adrs/adr-022-adopt-madr-format.md
+++ b/docs/adrs/adr-022-adopt-madr-format.md
@@ -1,0 +1,121 @@
+---
+status: proposed
+date: 2026-08-26
+decision-makers: Tosin Akinosho
+consulted: Claude Code (evidence gathering)
+---
+
+# ADR-022: Adopt MADR as the default decision-record format
+
+> Written in MADR, deliberately: the first MADR file in this repository is the one
+> that adopts MADR. Merging this ADR is the act of accepting it; `status` moves to
+> `accepted` at that point.
+
+## Context and Problem Statement
+
+The ADR corpus has drifted, and `scripts/check-adr-drift.sh` (#1460) now measures it.
+Sixteen findings at the start, eight after the unambiguous fixes. Several of the
+remaining eight exist **because the format has nowhere to put the answer**:
+
+- **Two status dialects in one corpus.** 20 ADRs use `## Status` with the value on a
+  following line; 2 use inline `**Status**: X`. Any reader must handle both.
+- **ADR-001 decided SSE transport and is still `Accepted`.** The code is stdio-only:
+  zero `SSEServerTransport`, zero `sdk/server/sse`. There is no structured way to say
+  "superseded", so it says nothing.
+- **Two files claim ADR-018**, and `adr-020-mcp-tasks-integration-strategy.md`
+  re-issues one of them with **zero** "supersedes" mentions.
+- **`adr-001` and `adr-0001` collided** — the latter a `[ADR_CONTENT_PLACEHOLDER]` stub
+  written into `docs/adrs/` by `adr-suggestion-tool.ts:1101`.
+- **ADR-016 does not exist**, but two files reference
+  `adr-016-replace-ripgrep-with-tree-sitter.md` by name.
+
+This is not only a documentation problem. **This repository is a tool that parses ADRs** —
+`validate_adr`, `validate_all_adrs`, `discover_existing_adrs`, `analyze_adr_timeline` all
+read these files. An unparseable ledger is a product defect, not untidiness.
+
+## Decision Drivers
+
+- Machine-readability, because the product consumes its own artifacts.
+- A structured place to record supersession, which two live findings need.
+- A structured place to record **how a decision would be confirmed** — the recurring
+  lesson of the v3.0 work is that claims drift silently until something executes a check.
+- Emitting a recognised standard is worth more to users than a bespoke shape.
+
+## Considered Options
+
+1. **Keep Nygard, change nothing.**
+2. **Keep Nygard, add YAML front matter.**
+3. **Adopt MADR as the default for new ADRs; convert opportunistically.**
+4. **Adopt MADR and convert all 21 existing ADRs now.**
+
+## Decision Outcome
+
+**Option 3 — adopt MADR as the default for newly generated ADRs, convert the existing
+corpus opportunistically as other work touches each file.**
+
+`templateFormat` in `src/tools/adr-suggestion-tool.ts` already accepts
+`'nygard' | 'madr' | 'custom'`; the default moves from `'nygard'` to `'madr'`. No new
+capability is required to start.
+
+### Why not the others
+
+**Option 1** leaves five of the eight open drift findings unaddressable — the format has
+no slot for the answers.
+
+**Option 2** is the honest runner-up and captures most of the value: YAML front matter
+alone fixes the dialect problem and gives a machine-readable `status`. It was rejected
+because it invents a local convention where a recognised standard exists, and because a
+tool whose output other people consume benefits from emitting something they already know.
+
+**Option 4** was rejected on cost and risk. Twenty-one files rewritten in one pass is a
+large diff nobody can review meaningfully, and three of those ADRs are the subject of open
+decisions (#1461, #1462, #1463) that will rewrite them anyway.
+
+## Consequences
+
+**Good**
+
+- `status` becomes one machine-readable field. `scripts/check-adr-drift.sh` now handles
+  all four dialects observed across 439 real ADRs, so a mixed corpus is not a blocker
+  during the transition.
+- `superseded by ADR-NNNN` becomes a first-class status value, which is what ADR-001 and
+  the duplicate ADR-018 need.
+- MADR's `Confirmation` section gives each ADR a place to declare how it would be
+  verified. Today `check-adr-drift.sh` **hardcodes** each check in bash — ADR-001's SSE
+  test, ADR-006's grammar test. That does not scale and is a shadow copy of the ledger.
+  Declared confirmations would let the checker become generic.
+
+**Bad**
+
+- MADR asks for more sections than Nygard's five. A team that will not write five will not
+  write nine, and this corpus is already inconsistent partly because structure invites
+  omission. The minimal MADR template exists for small decisions and should be used.
+- The corpus is mixed-format until conversion completes, and may stay mixed indefinitely
+  if nothing forces it.
+
+**Neutral**
+
+- Existing ADRs remain valid and readable. Nothing is invalidated by this decision.
+
+## Confirmation
+
+Verifiable now:
+
+- `node -e "..."` — the default `templateFormat` in `adr-suggestion-tool.ts` is `'madr'`.
+- `bash scripts/check-adr-drift.sh` — parses this file's YAML front matter and does not
+  report it as unparseable; drift does not rise.
+- `head -1 docs/adrs/adr-022-adopt-madr-format.md` is `---`.
+
+Not verifiable by command, and deliberately not claimed: whether the corpus actually
+converges on MADR. That depends on future work touching each file, and a check asserting
+it would be green while nothing happened.
+
+## More Information
+
+- MADR: https://github.com/adr/madr
+- Repo Governor's `adapters/adr` already parses MADR 3.0 front matter; no change needed
+  there. Its measured dialect frequencies are the source of the four-dialect handling in
+  `check-adr-drift.sh`.
+- Converting an existing Nygard corpus to MADR is **not** a capability this tool has
+  today. `templateFormat` affects generation only. Tracked separately.
+- Related: #1415 (ledger reconciliation), #1461, #1462, #1463.

--- a/scripts/check-adr-drift.sh
+++ b/scripts/check-adr-drift.sh
@@ -36,14 +36,36 @@ drift=0
 ok()    { printf "  \033[32mOK   \033[0m %s\n" "$1"; }
 bad()   { printf "  \033[31mDRIFT\033[0m %s\n" "$1"; drift=$((drift + 1)); }
 
-# Read an ADR's declared status, handling BOTH formats. Prints empty if absent.
+# Read an ADR's declared status. Four dialects, in the frequency repo-governor's
+# adr adapter measured across 439 real ADRs in 34 collections -- not guessed:
+#
+#     heading  57%   ## Status \n\n Accepted      MADR / Nygard
+#     bullet   19%   - **Status:** Accepted        colon inside the bold
+#     inline   16%   **Status**: Accepted
+#     yaml      2%   --- \n status: accepted      MADR 3.0 front matter
+#
+# An earlier version of this function handled only `heading` and `inline`. That
+# was enough for this repository as it stood, and would have silently reported
+# the bullet form as unparseable -- and YAML front matter too, which matters now
+# that ADR-022 adopts MADR. Fixed rather than left as a latent trap.
+#
+# YAML is checked FIRST: a MADR file has front matter at the top and may also
+# carry a `## Status` heading later in prose.
 adr_status() {
-  local f="$1" s
-  s="$(sed -nE 's/^\*\*Status\*\*:[[:space:]]*(.*[^[:space:]])[[:space:]]*$/\1/p' "$f" | head -1)"
-  if [ -z "$s" ]; then
-    s="$(awk '/^## Status/{f=1;next} f&&NF{gsub(/\r/,"");print;exit}' "$f")"
+  local f="$1" s=""
+  # 1. YAML front matter, only within the leading --- ... --- block.
+  if [ "$(head -1 "$f" | tr -d "\r")" = "---" ]; then
+    s="$(awk 'NR>1{if($0=="---"||$0=="---\r")exit; print}' "$f" \
+          | sed -nE 's/^[[:space:]]*status[[:space:]]*:[[:space:]]*(.*[^[:space:]])[[:space:]]*$/\1/Ip' | head -1)"
   fi
-  printf '%s' "$s" | sed 's/^ *//;s/ *$//'
+  # 2. bullet or inline bold, with the colon inside or outside the asterisks.
+  [ -z "$s" ] && s="$(sed -nE 's/^[[:space:]]*[-*]?[[:space:]]*\*\*Status:?\*\*:?[[:space:]]*(.*[^[:space:]])[[:space:]]*$/\1/p' "$f" | head -1)"
+  # 3. `## Status` heading with the value on a following line.
+  [ -z "$s" ] && s="$(awk '/^#{1,4}[[:space:]]*Status[[:space:]]*$/{f=1;next} f&&NF{gsub(/\r/,"");print;exit}' "$f")"
+  # Normalise MADR's lowercase vocabulary to the corpus's Title Case so index
+  # comparison does not report false drift on `accepted` vs `Accepted`.
+  printf '%s' "$s" | sed 's/^ *//;s/ *$//' \
+    | awk '{ if (length($0)) { $1=toupper(substr($1,1,1)) substr($1,2) } print }'
 }
 
 echo "ADR ledger drift"
@@ -136,10 +158,14 @@ done < <(
   done | awk '{m[$1]=m[$1]" "$2; c[$1]++} END{for(k in m) if(c[k]>1) print k m[k]}' | sort
 )
 
-# 7. Leaked test fixtures.
+# 7. Placeholder stubs written by adr-suggestion-tool.ts:1101 in prompt-only mode.
+#    Must match a file that IS the placeholder, not one that MENTIONS it: ADR-022
+#    discusses the bug in prose and was reported as a 5,616-byte "fixture" by the
+#    first version of this check. Compare the whole body, whitespace stripped.
 for f in "$ADR_DIR"/*.md; do
-  if grep -q 'ADR_CONTENT_PLACEHOLDER' "$f" 2>/dev/null; then
-    bad "$(basename "$f") is a test fixture ($(wc -c < "$f" | tr -d ' ') bytes, ADR_CONTENT_PLACEHOLDER), not an ADR"
+  body="$(tr -d '[:space:]' < "$f" 2>/dev/null)"
+  if [ "$body" = "[ADR_CONTENT_PLACEHOLDER]" ]; then
+    bad "$(basename "$f") is an unfilled placeholder stub ($(wc -c < "$f" | tr -d ' ') bytes), not an ADR"
   fi
 done
 

--- a/src/tools/adr-suggestion-tool.ts
+++ b/src/tools/adr-suggestion-tool.ts
@@ -919,7 +919,7 @@ export async function generateAdrFromDecision(args: {
 }): Promise<any> {
   const {
     decisionData,
-    templateFormat = 'nygard',
+    templateFormat = 'madr', // ADR-022: MADR is the default emitted format
     existingAdrs = [],
     adrDirectory = 'docs/adrs',
     autoSave = true,

--- a/tests/tools/adr-suggestion-tool.test.ts
+++ b/tests/tools/adr-suggestion-tool.test.ts
@@ -11,6 +11,25 @@
 import { describe, expect, vi } from 'vitest';
 import { McpAdrError } from '../../src/types/index.js';
 
+// generateAdrFromDecision's prompt-only branch WRITES to disk
+// (adr-suggestion-tool.ts:1101 -> writeFileCompat(fullPath, '[ADR_CONTENT_PLACEHOLDER]')).
+// Tests that omit `adrDirectory` fall back to 'docs/adrs', so every full suite run
+// created docs/adrs/adr-0001-test-decision.md in THIS repository -- a 25-byte
+// placeholder that was then committed and mistaken for a leaked fixture (#1415).
+// It also broke scripts/check-adr-drift.sh on every run.
+//
+// These tests assert on the returned text, never on the file, so stubbing the
+// writes costs no coverage. The underlying tool behaviour -- writing a
+// placeholder into a real ADR directory -- is a separate product question.
+vi.mock('../../src/utils/file-system.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/utils/file-system.js')>();
+  return {
+    ...actual,
+    ensureDirectoryCompat: vi.fn().mockResolvedValue('mocked: ensureDirectory'),
+    writeFileCompat: vi.fn().mockResolvedValue('mocked: writeFile'),
+  };
+});
+
 import {
   suggestAdrs,
   generateAdrFromDecision,
@@ -203,7 +222,8 @@ describe('ADR Suggestion Tool', () => {
           decisionData,
         });
 
-        expect(result.content[0].text).toContain('NYGARD');
+        // ADR-022 changed the default emitted format from Nygard to MADR.
+        expect(result.content[0].text).toContain('MADR');
       });
 
       test('uses custom template format', async () => {
@@ -359,7 +379,8 @@ describe('ADR Suggestion Tool', () => {
         });
 
         expect(result.content[0].text).toContain('docs/adrs');
-        expect(result.content[0].text).toContain('NYGARD');
+        // ADR-022 changed the default emitted format from Nygard to MADR.
+        expect(result.content[0].text).toContain('MADR');
       });
     });
   });


### PR DESCRIPTION
Refs #1415 — merging this ADR is the act of accepting it; its `status` moves `proposed → accepted` at that point.

**Five of the eight remaining drift findings exist because Nygard has nowhere to put the answer.** Two status dialects in one corpus; ADR-001 still `Accepted` while claiming a transport the code does not use; ADR-020 re-issuing ADR-018 with no supersede marker; an `adr-001`/`adr-0001` collision.

MADR gives each a structured home — YAML front matter for `status`, `superseded by ADR-NNNN` as a first-class value, `nnnn-` numbering.

`templateFormat` already accepted `'nygard' | 'madr' | 'custom'`; the default moves to `'madr'`. Existing ADRs stay valid and convert opportunistically — rewriting 21 files in one pass is a diff nobody can review, and three are the subject of open decisions (#1461, #1462, #1463) that will rewrite them anyway.

**ADR-022 is itself written in MADR**, so the first MADR file in the repo is the one adopting MADR.

## The point of it is the `Confirmation` section

Today `check-adr-drift.sh` **hardcodes** each check in bash — ADR-001's SSE test, ADR-006's grammar test. That does not scale, and it is a shadow copy of the ledger living in a script. If each ADR declared its own confirmation, the checker becomes generic: parse front matter, run the declared check, report.

Same shape as `.repo-governor/acceptance/*.json` — declared, machine-checkable, next to the thing it describes.

## Three supporting changes, each forced by the adoption

**1. The drift checker now parses all four status dialects, not two.** Frequencies from repo-governor's `adapters/adr`, measured across **439 real ADRs in 34 collections**:

```
heading 57%   bullet 19%   inline 16%   yaml 2%
```

Mine handled `heading` and `inline`. The `bullet` form — second most common in the wild — would have reported unparseable, and so would MADR front matter. YAML is checked first, since a MADR file can carry front matter *and* a later `## Status` heading in prose.

**2. The placeholder detector matched any file _mentioning_ `[ADR_CONTENT_PLACEHOLDER]`.** ADR-022 discusses it and was reported as a 5,616-byte "fixture" — the third false positive I have found in my own checker. Now compares the whole body with whitespace stripped, and verified it still catches a real 26-byte stub.

**3. The test suite no longer writes into `docs/adrs/`.**

This is the one worth reading. `adr-suggestion-tool.ts:1101` writes `'[ADR_CONTENT_PLACEHOLDER]'` to a real path in prompt-only mode. Tests omitting `adrDirectory` fall back to `'docs/adrs'`, so **every full suite run created `docs/adrs/adr-0001-test-decision.md` in this repository.**

That file was committed at some point, and #1460 deleted it as a "leaked test fixture". **Deleting it was treating the symptom** — the next test run recreated it, and it broke *this* commit's own drift check. Stubbed the writes; the tests assert on returned text, never on the file, so no coverage is lost.

> The tool writing a placeholder into a user's real ADR directory is a **product** question and is not fixed here.

## Two tests changed

They asserted `'NYGARD'` as the default and now assert `'MADR'`. They were correct to pin it — ADR-022 changes what they pin.

## Verification

```
suite            3059 passed | 70 skipped
typecheck        clean
drift            8 / 8 OK
test ratchet     290 / 290
docs/adrs/       no longer polluted by a full suite run
```

## Not claimed

ADR-022's `Confirmation` deliberately does **not** assert that the corpus converges on MADR. That depends on future work touching each file, and a check asserting it would be green while nothing happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)