### PR TITLE
fix(deps): declare js-yaml as a runtime dependency

### DIFF
--- a/.repo-governor/acceptance/1468.json
+++ b/.repo-governor/acceptance/1468.json
@@ -1,0 +1,22 @@
+{
+  "authority_id": "1468",
+  "criteria": [
+    {
+      "check": "command_exit",
+      "target": "node -e \"const p=require('./package.json'); process.exit(p.dependencies && p.dependencies['js-yaml'] ? 0 : 1)\""
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'grep -rq \"from .js-yaml.\" src/ && node -e \"const p=require(process.cwd()+\\\"/package.json\\\"); process.exit(p.dependencies[\\\"js-yaml\\\"]?0:1)\"'"
+    },
+    {
+      "check": "command_exit",
+      "target": "npm run typecheck"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash scripts/verify-packaged-runtime.sh"
+    }
+  ],
+  "$comment": "Deliberately NOT declaring `covers`. An earlier draft claimed the uncovered half was 'no other undeclared dependency exists' and pointed at #1469 -- but that conflates two issues. #1468's outcome is that js-yaml ships and the packaged artifact resolves it, which these criteria establish. The systemic weakness in verify-packaged-runtime.sh is #1469's own issue, cross-linked in the issue text rather than made a completion dependency here."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mendable/firecrawl-js": "^4.25.2",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "fast-glob": "^3.3.2",
+        "js-yaml": "^4.1.0",
         "openai": "^6.1.0",
         "tree-sitter": "^0.21.1",
         "tree-sitter-bash": "^0.21.0",
@@ -2770,7 +2771,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/argue-cli": {
@@ -4898,7 +4898,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@mendable/firecrawl-js": "^4.25.2",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "fast-glob": "^3.3.2",
+    "js-yaml": "^4.1.0",
     "openai": "^6.1.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-bash": "^0.21.0",


### PR DESCRIPTION
Closes #1468 — **live in the published package.**

`js-yaml` was declared **nowhere**: not `dependencies`, not `devDependencies`. Only `@types/js-yaml` was, which is the tell — someone added typings for an import that never got a home.

Two production modules import it **statically, at the top level**:

```
src/utils/pattern-loader.ts:3       import * as yaml from 'js-yaml';
src/utils/system-card-manager.ts:3  import * as yaml from 'js-yaml';
```

## Reproduced against the packed tarball of 2.6.24

```
js-yaml present in clean install?  NO

FAIL  dist/src/utils/pattern-loader.js       ERR_MODULE_NOT_FOUND
FAIL  dist/src/utils/system-card-manager.js  ERR_MODULE_NOT_FOUND
```

That breaks `pattern-loader`, which reads `patterns/*.yaml` for the **Validated Patterns framework** behind `bootstrap_validation_loop_tool`. It worked locally only because something pulls `js-yaml` in transitively — it does not ship.

**Verified after:** `js-yaml` present, all three modules import cleanly from a clean `--omit=dev` install.

Pinned `^4.1.0` to match the already-declared `@types/js-yaml ^4.0.9`; resolves to the `4.3.1` already in the lock file.

## Same class as #1409, and worse

`openai` was at least declared *somewhere*. This was declared nowhere at all.

**And the check I wrote for #1409 missed it.** `scripts/verify-packaged-runtime.sh` checks a hand-picked list of seven modules, drawn from the modules involved in the bug already known about. Neither of these is on it.

Enumerating entry points instead of listing them is **#1469**, filed and cross-linked. **Deliberately not folded in here** — adding two more names to a hand-maintained list is the same anti-pattern in miniature, and it's the pattern behind #1416's four registries too.

## A bar correction worth recording

An earlier draft declared `covers` with the uncovered half as *"no other undeclared dependency exists"*, pointing `split_to` at #1469. **Removed** — that conflates two issues.

This issue's outcome is that `js-yaml` ships and the packaged artifact resolves it, which the criteria establish. The systemic weakness is #1469's own issue, linked in the text rather than made a completion dependency. Over-declaring `covers` would have blocked a verified fix behind unrelated work.

## Verification

```
#1468            AUTHORIZED / STOP_COMPLETE  4/4
clean install    js-yaml present, 3/3 modules import
suite            128 files | 3059 passed
typecheck        clean
drift            8 / 8
test ratchet     290 / 290
```

## How it surfaced

Not an audit. A question about whether MADR's YAML front matter lets `adr-discovery.ts` drop its four-dialect regex — checking which YAML parser was available found `js-yaml` in use and undeclared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)