### PR TITLE
docs(adr): ADR-023 — which of the 75 tools should still exist

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -27,6 +27,7 @@ This directory contains the Architectural Decision Records for the MCP ADR Analy
 | [ADR-020](adr-020-mcp-tasks-integration-strategy.md)                   | MCP Tasks Integration Strategy                   | Accepted | 2025-12-16 | Architecture  |
 | [ADR-021](adr-021-ai-layer-disposition.md)                             | Disposition of the legacy AI execution layer     | Accepted | 2026-08-26 | Architecture  |
 | [ADR-022](adr-022-adopt-madr-format.md)                                | Adopt MADR as the default decision-record format | Proposed | 2026-08-26 | Documentation |
+| [ADR-023](adr-023-tool-surface-scope.md)                               | Which of the 75 tools should still exist         | Proposed | 2026-08-26 | Architecture  |
 
 > **This index is known to be out of date and is not corrected here.** It stops at
 > ADR-018, omits ADR-019 and ADR-020, and lists ADR-012, ADR-013 and ADR-014 as

--- a/docs/adrs/adr-023-tool-surface-scope.md
+++ b/docs/adrs/adr-023-tool-surface-scope.md
@@ -1,0 +1,203 @@
+---
+status: proposed
+date: 2026-08-26
+decision-makers: Tosin Akinosho
+consulted: Claude Code (measurement and external research)
+---
+
+# ADR-023: Which of the 75 tools should still exist
+
+> **The Decision section is deliberately unfilled.** This ADR measures, researches and
+> argues. The disposition is the owner's, as with ADR-021.
+
+## Context and Problem Statement
+
+This repository was first committed **2025-07-02** against `@modelcontextprotocol/sdk`
+`^1.0.0`. It is now thirteen months old and the SDK is at `^1.30.0`. It was designed
+around mid-2025 assumptions about what an MCP host could do for itself.
+
+Several of those assumptions no longer hold. The question this ADR asks is narrow and
+answerable: **of the 75 tools this server exposes, which should still exist?**
+
+It is asked _now_ because two pieces of queued work are both sized in tools — #1416
+collapses four registries into one, and ADR-021 option B migrates tools off the legacy
+AI layer. **Both do less work if fewer tools survive**, and both would otherwise spend
+effort on tools that should not exist.
+
+### Measured, on `main` at v2.7.0
+
+Every figure below is reproducible by the command beside it. Nothing is carried over
+from the v3.0 PRD or ADR-021 — both have already been found wrong once each.
+
+| measurement                         | value                          | how                                                   |
+| ----------------------------------- | ------------------------------ | ----------------------------------------------------- |
+| tools exposed over the wire         | **75**                         | MCP `tools/list` against the built server             |
+| `tools/list` payload                | **94,571 bytes (~24K tokens)** | same                                                  |
+| tools declaring `outputSchema`      | **0**                          | same                                                  |
+| tools with a real CE-MCP directive  | **12**                         | `grep -cE "^\s+case '" src/tools/ce-mcp-tools.ts`     |
+| tool modules importing the AI layer | **10**                         | `grep -rl 'prompt-execution\|ai-executor' src/tools/` |
+| tools absent from `TOOL_CATALOG`    | **4**                          | wire list minus catalog keys                          |
+
+The four uncatalogued tools are `get_gaps`, `search_codebase`, `set_project_path` and
+`update_knowledge`. They are dispatchable but invisible to `search_tools`. The v3.0 PRD
+identified them in June; they are still uncatalogued.
+
+## Decision Drivers
+
+- **The MCP spec now assigns to the host what this server built for itself.**
+- **The server is several times over the spec's own context threshold.**
+- **Market evidence says generation is commodity and drift is the unmet need.**
+- Fewer surviving tools makes #1416 and ADR-021 option B smaller.
+
+### The spec moved
+
+[Client Best Practices (2026-07-28)](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices)
+describes **progressive discovery as a host responsibility**: the host exposes a
+`search_tools` meta-tool, defers injecting definitions, and fetches full schemas on
+demand. It states plainly:
+
+> _"Some model providers already offer built-in tool search. For example, OpenAI and
+> Anthropic support this natively… When available, you may prefer the platform's tool
+> search over a custom implementation."_
+
+This server ships its own `search_tools` and `load_prompt` as CE-MCP meta-tools. That was
+a reasonable thing to build in 2025. It is now a reimplementation of a host feature.
+
+### The server is over the spec's own threshold
+
+The same document recommends switching to progressive discovery once tool definitions
+consume **1–5% of the context window**. At ~24K tokens this server is:
+
+```
+11.8% of a 200K context window
+ 2.4% of a 1M context window
+```
+
+Three to twelve times the recommended threshold. **This server does not merely benefit
+from progressive discovery — it forces the mitigation on every host that connects.**
+
+### Zero output schemas
+
+The same document describes programmatic tool calling ("code mode"), where the host
+generates a typed API from tool schemas and the model writes code against it. Precise
+types require `outputSchema`, and it says _"the real fix is for server authors to provide
+`outputSchema`."_
+
+This server declares **none**, on any of 75 tools. It opts out of that path entirely.
+
+### What the market actually wants
+
+Current ADR guidance ([adr.github.io](https://adr.github.io/),
+[Fowler](https://www.martinfowler.com/bliki/ArchitectureDecisionRecord.html), 2026
+practitioner guides) is consistent on two points:
+
+- Plain Markdown in `docs/adr/` is enough for most teams; tools get adopted only when a
+  specific pain appears that Markdown cannot solve.
+- The dominant pain is **staleness**: _"Decisions don't stay in the file — they change in
+  Slack, GitHub and Jira, and nobody updates the ADR."_ And _"there's no dominant tool,
+  which tells you the field is young."_
+
+Writing ADRs is not the hard part. **Noticing that an ADR stopped being true is.**
+
+This repository already proved that internally. `scripts/check-adr-drift.sh`, built in a
+few hours, found that ADR-001 claims SSE transport while the code is stdio-only, that
+ADR-006 claims grammars ADR-017 removed, and that ADR-018a forbids a pattern twelve files
+use. Twelve ADR-_generation_ tools found none of it.
+
+## Considered Options
+
+1. **Keep all 75.** Do #1416 and option B at full scope.
+2. **Remove only what the host now provides**, keep everything else.
+3. **Remove host-native duplicates and consolidate redundant clusters**, and record where
+   evidence is insufficient to decide.
+4. **Narrow to drift detection**, removing most generation tooling.
+
+## Proposed classification
+
+### REMOVE — the host now does this (11 tools)
+
+| tool(s)                                                       | now provided by                                                              |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `read_file`, `write_file`, `list_directory`, `read_directory` | host file tools in every major MCP client                                    |
+| `list_roots`                                                  | the MCP `roots` capability                                                   |
+| `llm_web_search`                                              | native web search in every frontier host                                     |
+| `llm_cloud_management`, `llm_database_management`             | prompt wrappers over host capability                                         |
+| `search_tools`, `load_prompt`                                 | **the spec assigns this to the host**; OpenAI and Anthropic ship it natively |
+| `get_current_datetime`                                        | host                                                                         |
+
+`search_tools` and `load_prompt` are the strongest case, because the argument is not
+"another tool does this too" but "the specification says this is not the server's job."
+
+Removing these eleven costs ~15% of the tool surface and a corresponding share of the 24K
+token payload, for no capability a modern host lacks.
+
+### OUT OF SCOPE — the aggregator (10 tools)
+
+ADR-021 already ruled the aggregator _"a separate commercial question"_. Unchanged here.
+
+### DIES WITH THE AI LAYER (1 tool)
+
+`check_ai_execution_status` exists solely to explain the legacy execution mode. Under
+ADR-021 option B it has nothing left to report.
+
+### REVIEW — insufficient evidence to classify (the remainder)
+
+**This is the honest gap in this ADR: there is no usage data.** Nothing in `src/`
+records which tools are actually called. Every classification below the line above is
+reasoning about code shape, not about use.
+
+Clusters that look consolidatable but should not be cut on inference alone:
+
+- **memory (6)** — `expand_memory`, `memory_loading`, `expand_analysis_section`,
+  `get_memory_stats`, `get_conversation_snapshot`, `query_conversation_history`
+- **workflow (5)** — `get_workflow_guidance` and `get_development_guidance` are
+  adjacent enough to question
+- **research (4 after removals)** — `create_research_template`,
+  `generate_research_questions`, `incorporate_research`, `perform_research`
+
+### KEEP — the reason the server exists
+
+The **12 ADR tools**, the **4 analysis tools**, **6 content-security** (masking is not a
+host capability), **7 deployment**, and **3 rules**. These are domain work a host cannot
+do, which is the test the spec's _"single responsibility: one clear domain"_ guidance
+implies.
+
+## Decision
+
+_Not yet recorded._ Awaiting the owner's disposition. See #1414's successor work.
+
+## Consequences
+
+To be completed once the decision is recorded. Two are worth stating in advance:
+
+**It resizes queued work.** Removing 11 host-native tools and excluding 10 aggregator
+tools leaves **54**. #1416 builds a registry for 54 entries rather than 75, and option B
+has fewer tools to consider.
+
+**It sharpens what the product is.** If the market's unmet need is drift detection and
+this repo has already built a working drift checker, then the ADR-generation surface is
+the commodity part and the verification surface is the differentiated part. That is a
+positioning consequence, not only a scope one.
+
+## Confirmation
+
+Verifiable now:
+
+- `bash scripts/check-adr-drift.sh` stays at its baseline with this ADR added.
+- Every measurement in the table above reproduces via the command beside it.
+
+Deliberately **not** claimed: that removing these tools is safe. `retirement.py` governs
+that, and it advertises `dynamic_references`, `runtime_usage`, `public_contracts` and
+`migration_obligations` as **false** — so it will return `RETIREMENT_REVIEW`, never
+`REMOVAL_READY`, from static analysis. Any removal needs its own admission.
+
+**And the largest gap is not technical.** Without usage data, the REVIEW section is
+opinion. Instrumenting tool calls before deleting anything in that section would convert
+guesswork into evidence.
+
+## More Information
+
+- [MCP Client Best Practices, 2026-07-28](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices)
+- [adr.github.io](https://adr.github.io/) · [Fowler, Architecture Decision Record](https://www.martinfowler.com/bliki/ArchitectureDecisionRecord.html)
+- ADR-021 (AI-layer disposition, Accepted) · ADR-022 (MADR adoption)
+- #1416 (registry collapse) · #1415 (ledger reconciliation)


### PR DESCRIPTION
Refs #1415, #1416 · **Decision section deliberately unfilled** — the disposition is yours, as with ADR-021.

Your hypothesis was that this was over-engineered for the models available when it was built. **The research supports it**, and it reorders the queued work.

The repo is **13 months old** — first commit 2025-07-02 against MCP SDK `^1.0.0`, now `^1.30.0`. Three things changed underneath it.

## 1. The spec moved — and assigns to the host what this server built

[MCP Client Best Practices (2026-07-28)](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices) makes progressive discovery a **host** responsibility: the host exposes `search_tools`, defers loading definitions, fetches schemas on demand. It says outright:

> *"OpenAI and Anthropic support this natively… you may prefer the platform's tool search over a custom implementation."*

This server ships its own `search_tools` and `load_prompt`.

That's the strongest removal case in the ADR, because the argument isn't *"something else does this too"* — it's *"the specification says this is not the server's job."*

## 2. The server is 3–12× over the spec's own threshold

Recommended switch-point for progressive discovery is **1–5% of the context window**:

```
tools/list = 94,571 bytes (~24K tokens)
             11.8% of a 200K window
              2.4% of a 1M window
```

It doesn't merely *benefit* from the mitigation — it **forces it on every host that connects**.

## 3. Zero `outputSchema`, on 75 tools

The same document says precise types for code mode require it, and *"the real fix is for server authors to provide `outputSchema`."* This server declares none.

## And the market may want the other half of the problem

Current ADR guidance is consistent: plain Markdown is enough for most teams, and the dominant pain is **staleness** — *"decisions don't stay in the file… nobody updates the ADR"* — with *"no dominant tool, which tells you the field is young."*

**Writing ADRs isn't the hard part. Noticing one stopped being true is.**

This repo proved that on itself last week. `scripts/check-adr-drift.sh`, built in hours, found ADR-001 claiming SSE against stdio-only code, ADR-006 claiming grammars ADR-017 removed, and ADR-018a forbidding a pattern 12 files use. **Twelve ADR-generation tools found none of it.**

## Proposed classification

| | n | |
|---|---|---|
| **REMOVE** — host-native | **11** | file tools (5), `llm_web_search`, `llm_cloud/database_management`, `search_tools`, `load_prompt`, `get_current_datetime` |
| **OUT OF SCOPE** — aggregator | 10 | already ruled a separate commercial question by ADR-021 |
| **DIES WITH THE AI LAYER** | 1 | `check_ai_execution_status` |
| **KEEP** | 32 | ADR, analysis, content-security, deployment, rules — domain work a host cannot do |
| **REVIEW** | remainder | memory, workflow, research clusters |

**75 → 54** after removals and aggregator exclusion. That resizes #1416 and ADR-021 option B *before* either starts.

## Two things stated rather than glossed

**There is no usage data.** Nothing in `src/` records which tools are actually called, so the REVIEW section is reasoning about code shape, not use. Instrumenting before deleting would convert guesswork into evidence — named in the ADR as its largest gap.

**Every measurement was re-run**, not carried over from the v3.0 PRD or ADR-021, both of which have been found wrong once each this week. The first draft said 12.0% of a 200K window; re-measurement gave 11.8%, corrected before commit.

## Verification

```
drift          8 / 8 OK  (index row added; the checker caught its absence)
suite          128 files | 3059 passed
test ratchet   290 / 290
#1415          CONTINUE / NO_CRITERIA_DECLARED — unchanged
```

No source changes. This is a decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)