### PR TITLE
chore(adr): tag ADR-023, completing the corpus

### DIFF
--- a/docs/adrs/adr-023-tool-surface-scope.md
+++ b/docs/adrs/adr-023-tool-surface-scope.md
@@ -3,6 +3,9 @@ status: proposed
 date: 2026-08-26
 decision-makers: Tosin Akinosho
 consulted: Claude Code (measurement and external research)
+tags:
+  - architecture
+  - process
 ---
 
 # ADR-023: Which of the 75 tools should still exist


### PR DESCRIPTION
Refs #1415

#1475 tagged 22 ADRs. ADR-023 was on a different branch at the time (#1474) and merged after, so it arrived untagged — `discover_existing_adrs` reported `uncategorized: 2`.

Tagged `architecture` / `process`, matching the mapping used in #1475.

```
before:  uncategorized 2 · architecture 5
after:   uncategorized 1 · architecture 6
```

The remaining `uncategorized: 1` is **`docs/adrs/README.md` being counted as an ADR** by `discoverAdrs` — a separate defect recorded in #1475, deliberately not patched here.

Drift 8/8. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)