### PR TITLE
docs: add the pull request template CONTRIBUTING already promises

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## What and why
+
+<!-- What changes, and what problem it solves. Link the issue: "Closes #123". -->
+
+## How this was verified
+
+<!--
+Say what you actually ran, not what should pass. If you changed behaviour, the most
+useful thing here is evidence it failed before and passes after.
+-->
+
+- [ ] `npm test` passes locally
+- [ ] `npm run typecheck` is clean
+
+## Before you open this
+
+- [ ] Branch is not `main` — CONTRIBUTING.md asks for `feature/…` or `fix/…`
+- [ ] Commits follow conventional format: `type(scope): description`
+      (`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`) — this is
+      validated automatically, so a non-conforming message will fail CI
+- [ ] Docs updated if behaviour changed
+
+## Ratchets that will run
+
+Three checks only allow their numbers to **fall**, never rise. If CI reports one went
+up, that is the check working — fix the increase rather than raising the baseline.
+
+| check          | where                 | what it means                                     |
+| -------------- | --------------------- | ------------------------------------------------- |
+| coverage floor | `vitest.config.ts`    | statements/branches/functions/lines must not drop |
+| test typecheck | `.tsc-test-baseline`  | type errors in `tests/` must not increase         |
+| ADR drift      | `.adr-drift-baseline` | ADRs must not contradict the code in new ways     |
+
+## If you touched an ADR
+
+- [ ] `docs/adrs/README.md` index row matches the file's status — the drift check
+      compares them and will fail if they diverge
+- [ ] New ADRs use MADR front matter (ADR-022), including `tags:`
+
+---
+
+<!--
+First time here? The useful starting points are issues labelled `good first issue`.
+If something in this template is wrong or unclear, say so in the PR — that is a
+valid contribution too.
+-->


### PR DESCRIPTION
`CONTRIBUTING.md:141` tells contributors to *"Use our PR template."* **There was no PR template.**

So a first-time contributor discovered the branch policy (`:136`) and the conventional-commit requirement (`:90`) only *after* CI rejected their work. That is the worst possible moment to learn a repo's rules.

## Kept short on purpose

Long templates get deleted rather than filled in. It covers only what a contributor cannot discover by reading the diff:

- **branch policy and conventional commits** — both enforced automatically
- **the three ratchets** — this repo's least obvious behaviour. Coverage, test typecheck (290), ADR drift (8). A rising number *looks* like a broken build unless you know the check exists to catch exactly that, so the template says so, and says to fix the increase rather than raise the baseline.
- **the ADR index/status pairing** — the drift check compares them, and it has already caught three PRs this week including two of mine

## Verified, not written from memory

Every claim was checked against the repo:

```
thresholds in vitest.config.ts   present
.tsc-test-baseline               290
.adr-drift-baseline              8
commitlint                       configured
`good first issue` label         5 open issues
```

The footer points newcomers at that label because GitHub surfaces it natively on the Contribute tab — the five issues are real, though four months old and worth refreshing separately.

## One deliberate wording choice

Under **How this was verified**, it asks contributors to *"say what you actually ran, not what should pass"*, and notes the most useful evidence is that something failed before and passes after.

A template that collects assertions is how unverified claims get into a repository — which is the failure mode this repo spent the week removing from its own docs, catalog, and CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)