### PR TITLE
docs(adr): ADR-023 claimed no usage data is recorded — it is recorded and discarded

### DIFF
--- a/docs/adrs/adr-023-tool-surface-scope.md
+++ b/docs/adrs/adr-023-tool-surface-scope.md
@@ -145,9 +145,37 @@ ADR-021 option B it has nothing left to report.
 
 ### REVIEW — insufficient evidence to classify (the remainder)
 
-**This is the honest gap in this ADR: there is no usage data.** Nothing in `src/`
-records which tools are actually called. Every classification below the line above is
-reasoning about code shape, not about use.
+**This is the honest gap in this ADR: there is no usage data reaching a durable
+store.** Every classification below the line above is reasoning about code shape, not
+about use.
+
+An earlier revision of this ADR said _"nothing in `src/` records which tools are actually
+called."_ That was wrong, and the correction matters, because it changes the gap from a
+project into three edits. Two mechanisms already record every call by name, and one
+already computes exactly the per-tool counts this section needs:
+
+| what exists                                             | where                                                                  | why no usable evidence comes out                                                                                      |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| complete per-tool count `Map`, sorted                   | `src/utils/knowledge-graph-manager.ts:406-416`                         | `.slice(0, 10)` truncates it **before persisting** — the full map is built and discarded                              |
+| every execution recorded                                | `trackToolExecution`, `src/index.ts:8219`, called at `:4201` / `:4208` | persists under `os.tmpdir()` (`knowledge-graph-manager.ts:44-52`) — wiped by OS temp cleanup, never survives a reboot |
+| distinct tools per session                              | `src/utils/conversation-memory-manager.ts:131,163`                     | same `os.tmpdir()` problem; a dedup'd list, no counts                                                                 |
+| complete `MonitoringManager` with `MetricCategory.TOOL` | `src/utils/monitoring.ts`                                              | **zero production call sites** — built, tested, never wired                                                           |
+
+And one blind spot that bears directly on this section: the CE-MCP directive path at
+`src/index.ts:3875-3888` returns before the dispatch switch and before
+`trackToolExecution`, so **all twelve `CE_MCP_DIRECTIVE_TOOLS` are unrecorded** whenever
+CE-MCP mode is on. `perform_research` is one of them — a tool whose disposition this
+section defers _pending data that this bug guarantees will never exist for it_.
+
+So the evidence is computed and thrown away, not absent. Ten entries survive out of 75,
+into a directory the OS deletes. Every cluster below falls beyond that cut.
+
+> Every line reference in the table above was verified against `0d3817b7` on 2026-08-27
+> and will drift. #1416 collapses four registries and removes roughly 4,000 lines from
+> `src/index.ts`; the `:3875`, `:4201`, `:8219` citations will all be wrong afterwards.
+> They are given because they are checkable **today** and the argument depends on being
+> checkable. When #1416 lands, re-anchor them to symbol names — which is #1463's whole
+> point about ADR-014, and the reason this note exists rather than the same mistake.
 
 Clusters that look consolidatable but should not be cut on inference alone:
 
@@ -195,8 +223,15 @@ that, and it advertises `dynamic_references`, `runtime_usage`, `public_contracts
 `REMOVAL_READY`, from static analysis. Any removal needs its own admission.
 
 **And the largest gap is not technical.** Without usage data, the REVIEW section is
-opinion. Instrumenting tool calls before deleting anything in that section would convert
-guesswork into evidence.
+opinion. Converting it to evidence does not require instrumenting anything — the
+instrumentation exists. It requires lifting a `.slice(0, 10)`, moving a store out of
+`os.tmpdir()` into the project-local `.mcp-adr-cache` that `src/utils/config.ts:17`
+already defines, and recording the CE-MCP directive path. Tracked as #1487, #1488 and
+#1489.
+
+That correction is itself an instance of what this ADR argues. The claim that no usage
+data was recorded went unchecked into a document meant to decide the fate of 75 tools,
+and it was wrong in the direction that made the problem look bigger than it is.
 
 ## More Information
 


### PR DESCRIPTION
Closes #1486.

ADR-023 said, in the section its entire REVIEW deferral rests on:

> **This is the honest gap in this ADR: there is no usage data.** Nothing in `src/` records which tools are actually called.

The second sentence is false.

## What actually exists

| what exists | where | why no usable evidence comes out |
|---|---|---|
| complete per-tool count `Map`, sorted | `src/utils/knowledge-graph-manager.ts:406-416` | `.slice(0, 10)` truncates it **before persisting** |
| every execution recorded | `trackToolExecution`, `src/index.ts:8219`, called at `:4201`/`:4208` | persists under `os.tmpdir()` — wiped by OS temp cleanup |
| distinct tools per session | `src/utils/conversation-memory-manager.ts:131,163` | same tmpdir problem; no counts |
| complete `MonitoringManager` with `MetricCategory.TOOL` | `src/utils/monitoring.ts` | **zero production call sites** |

Plus a blind spot that bears directly on the deferral: the CE-MCP directive path at `src/index.ts:3875-3888` returns before the dispatch switch and before `trackToolExecution`, so **all twelve `CE_MCP_DIRECTIVE_TOOLS` go unrecorded** in CE-MCP mode. `perform_research` is one of them — a tool whose disposition that section defers *pending data this bug guarantees will never exist for it*.

Ten entries survive out of 75, into a directory the OS deletes.

## Why this is worth a commit, not a typo fix

The claim was wrong **in the direction that made the problem look bigger**. "No instrumentation exists" reads as a project. "The counts are truncated and written to tmpdir" is three edits — #1487, #1488, #1489.

An ADR deciding the fate of 75 tools deferred three clusters indefinitely on the strength of one sentence nobody checked. The Confirmation section stated the same thing a second way — *"instrumenting tool calls would convert guesswork into evidence"* — and is corrected too.

## About the ten line numbers I just added

This is the uncomfortable part. I added ten line-number citations to an ADR, in the same milestone as **#1463**, which exists precisely because ADR-014's five line references are all stale.

So they carry a note pinning them to `0d3817b7`, stating plainly that #1416 will invalidate the `src/index.ts` ones when it removes ~4,000 lines, and saying to re-anchor to symbol names then. Checkable-today beats durable-and-vague for an argument that depends on being checked — but only if the expiry date is written down.

## Verification

- All nine cited locations confirmed live before commit
- `bash scripts/check-adr-drift.sh` unchanged at **8/8**
- Decision gate (#1485): **12 failing → 11**; the `#1486` assertion flips PASS

Note the gate assertion for this issue was one of the two that falsely passed on its first run — the sentence wraps across lines 148/149, so a line-oriented grep never matched it. Fixed in #1496 before this landed, which is how this correction is actually verified rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
