### PR TITLE
chore(governance): bind a retirement provider and commit the manifest

### DIFF
--- a/.repo-governor.json
+++ b/.repo-governor.json
@@ -1,0 +1,92 @@
+{
+  "$comment": "PROPOSAL in manifest shape. Review every line, then rename to .repo-governor.json and commit. The engine never reads this file (ADR-010 rule 1). Roles here are the ones a zero-install adapter can serve, plus any detection actually found. Roles absent -- execution, change_signals, retirement -- have no governance function here however reachable the system is (INV-013); add them as you bind them.",
+  "repo_governor": {
+    "version": 1,
+    "engine_min_version": "0.1.0"
+  },
+  "repository": {
+    "id": "tosin2013/mcp-adr-analysis-server"
+  },
+  "condition": {
+    "assessed": "L4",
+    "profile": "GOVERNOR_HIGH_ASSURANCE",
+    "$comment": "Assessed by engine/onboard.py, not defaulted. Floor indicators present (public_api_surface, release_branches, generated_consumers); per the engine's rule this may not be overridden downward."
+  },
+  "permissions": {
+    "$comment": "Deny by default (ADR-005). Read-only, with ONE exception stated here so it is not an escalation buried in generated JSON: decision_history has write=true. CAPTURE_ONLY is the default disposition for every discovery, and `envelope.py --record` cannot persist one without it. Recording a decision is the only act this grant permits; the engine still rules and never changes the repository. Remove it and captures are refused, which is a defensible choice -- it just means nothing remembers what was decided.",
+    "repository": {
+      "read": true,
+      "write": false
+    },
+    "roadmap_authority": {
+      "read": true,
+      "write": false
+    },
+    "acceptance_criteria": {
+      "read": true,
+      "write": false
+    },
+    "decision_history": {
+      "read": true,
+      "write": true
+    },
+    "retirement": {
+      "read": true,
+      "write": false
+    },
+    "architecture": {
+      "read": true,
+      "write": false
+    }
+  },
+  "providers": {
+    "repository": {
+      "type": "git",
+      "adapter": "adapters/git",
+      "contract_version": 1
+    },
+    "roadmap_authority": {
+      "type": "github-projects",
+      "adapter": "adapters/github-projects",
+      "contract_version": 1,
+      "admission": {
+        "signal": "milestone"
+      },
+      "transport": {
+        "kind": "cli",
+        "command": "gh"
+      },
+      "env": {
+        "REPO_GOVERNOR_GH_REPO": "tosin2013/mcp-adr-analysis-server",
+        "REPO_GOVERNOR_GH_ADMISSION": "milestone"
+      }
+    },
+    "acceptance_criteria": {
+      "type": "acceptance-file",
+      "adapter": "adapters/acceptance-file",
+      "contract_version": 1
+    },
+    "decision_history": [
+      {
+        "type": "decision-history-file",
+        "adapter": "adapters/decision-history-file",
+        "contract_version": 1
+      }
+    ],
+    "architecture": [
+      {
+        "type": "adr",
+        "adapter": "adapters/adr",
+        "contract_version": 1
+      }
+    ],
+    "retirement": [
+      {
+        "$comment": "Bound per ADR-021 (option B) and #1492. Read-only, deliberately: this adapter reports EVIDENCE, never deletion authority (INV-007). It implements static_references and leaves dynamic_references, runtime_usage, public_contracts and migration_obligations BLIND -- so static analysis yields RETIREMENT_REVIEW and can never reach REMOVAL_READY on its own. That is intended, not a limitation to route around. A RETIREMENT_REVIEW on an asset with zero static references is the correct result. Binding this does NOT authorise deleting anything; it only replaces a blocking NO_RETIREMENT_EVIDENCE with a verdict a human can act on.",
+        "type": "retirement-analysis",
+        "adapter": "adapters/retirement-analysis",
+        "contract_version": 1
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #1492. Closes #1491.

## Two faults, one of which was invisible

**1. `.repo-governor.json` was never tracked.** Not gitignored — simply never added:

```
$ git check-ignore -v .repo-governor.json
  (not ignored)
$ git ls-files --error-unmatch .repo-governor.json
  error: pathspec ... did not match any file(s) known to git
```

The repository's governance manifest existed on **one machine**. No reviewer could see what was bound; nobody else could run the engine against this repo at all. Every claim any document made about governance was uncheckable by anyone but its author.

**2. No retirement provider was bound.** Five roles — `repository`, `roadmap_authority`, `acceptance_criteria`, `decision_history`, `architecture`. ADR-021 driver #4 calls a retirement binding *"required for options B and C"*, and **B is what was accepted**.

## Why this also closes #1491

ADR-021 is **Accepted** and states, under a heading reading *"Verifiable now"*:

> A retirement provider is bound in `.repo-governor.json`, so `retirement.py` no longer returns a blocking `NO_RETIREMENT_EVIDENCE`.

That was false when written. #1491 proposed relabelling it to "Verifiable at completion" until it became true. **Making it true is strictly better than relabelling it**, so the sentence stays exactly where it is — now accurate, and now checkable by anyone, which fault 1 is precisely what prevented. ADR-021 needs no edit.

## Verified, not asserted

| command | result |
|---|---|
| `manifest.py` | `READY_FOR_GOVERNANCE` (6 bindings, 0 findings) |
| `manifest.py --validate` | contracts satisfied |
| `retirement.py src/prompts` | blocking `UNKNOWN` → **`RETIREMENT_REVIEW`** |
| `retirement.py src/utils/monitoring.ts` | blocking `UNKNOWN` → **`RETIREMENT_REVIEW`** |

The right-hand column is ADR-021's claim, executed rather than read. `src/prompts` is the ADR's own worked example.

## One advisory left alone, and not hidden

`GOVERNOR_HIGH_ASSURANCE` also wants an `execution` role, which is unbound:

```
[REQUIRED_ROLE_UNBOUND] execution -> (unbound)
```

It is an **advisory**, not a finding — nothing refuses to answer because of it — and the assessed level is a human's to change (ADR-006 rule 1). Recording it rather than quietly binding something to make a message disappear.

## Binding is not deletion authority

Stated in the manifest itself, because the opposite reading is the failure mode. The adapter implements `static_references` and leaves `dynamic_references`, `runtime_usage`, `public_contracts` and `migration_obligations` blind, so static analysis yields `RETIREMENT_REVIEW` and **can never reach `REMOVAL_READY`** on its own.

A `RETIREMENT_REVIEW` on an asset with zero references is the **correct** result, not a false positive to route around. What binding buys is a verdict a human can act on, in place of *"I cannot answer."*

Permissions are read-only — this adapter reports evidence, never authority (INV-007).

## Effect

Decision gate (#1485): **10 failing → 9**. Unblocks #1487's retirement half, which returned a blocking `UNKNOWN` an hour ago and now returns a real verdict.

> Note: `.claude/` (where the engine and adapters live) remains untracked. All six bindings use the same relative `adapters/…` convention, so that is the existing design — the engine is installed alongside, not vendored. Flagging it rather than changing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
