### PR TITLE
fix: usage evidence was computed, truncated, and written where the OS deletes it

### DIFF
--- a/scripts/check-decision-gate.sh
+++ b/scripts/check-decision-gate.sh
@@ -195,10 +195,37 @@ if have "$KG" "usage evidence persisted"; then
   # os.tmpdir() is wiped by OS temp cleanup and never survives a reboot, which
   # is almost certainly why ADR-023's author found no usage data. config.ts:17
   # already defines a project-local .mcp-adr-cache for this.
-  if grep -qF 'os.tmpdir()' "$KG"; then
-    bad "#1488: knowledge graph persists to os.tmpdir(), not the project cache"
-  else
+  #
+  # ASSERTS THE WRITE TARGET, not the absence of the string. The first version
+  # of this check was `! grep -qF 'os.tmpdir()'`, which is a false positive on a
+  # read-only migration path -- and on a comment explaining the fix. Migrating
+  # the existing store is worth doing (there was 96KB of real knowledge-graph
+  # state in tmpdir when #1488 landed), so the check has to distinguish "reads
+  # the old location once" from "persists there". Two conditions, both required:
+  #
+  #   1. cacheDir is assigned from getCacheDirectoryPath() -- the positive form,
+  #      which a bare absence check never had, so deleting the line entirely
+  #      used to pass.
+  #   2. every remaining os.tmpdir() mention is confined to a `legacy` binding.
+  #
+  # This is strictly stronger than what it replaces. It is also me editing my own
+  # gate, which is the move this milestone exists to prevent -- so it is recorded
+  # here rather than done quietly, and it tightened the assertion, not loosened it.
+  kg_writes_project_cache=0
+  grep -qE 'this\.cacheDir *= *getCacheDirectoryPath\(' "$KG" && kg_writes_project_cache=1
+  # Comment forms stripped: //, /*, /**, and continuation *. An earlier version
+  # listed only `*` and `//` and therefore flagged a JSDoc line opening `/**`,
+  # which is a comment describing the migration -- prose, not persistence.
+  kg_stray_tmpdir="$(grep -n 'os\.tmpdir()' "$KG" \
+      | grep -vi 'legacy' \
+      | grep -vE '^[0-9]+: *(/\*+|\*|//)' || true)"
+
+  if [ "$kg_writes_project_cache" -eq 1 ] && [ -z "$kg_stray_tmpdir" ]; then
     pass "#1488: knowledge graph persists to the project-local cache"
+  elif [ "$kg_writes_project_cache" -ne 1 ]; then
+    bad "#1488: cacheDir is not assigned from getCacheDirectoryPath()"
+  else
+    bad "#1488: os.tmpdir() used outside a legacy-migration binding: ${kg_stray_tmpdir%%$'\n'*}"
   fi
 fi
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3881,7 +3881,30 @@ export class McpAdrAnalysisServer {
           const directive = getCEMCPDirective(name, safeArgs);
           if (directive) {
             this.logger.info(`[CE-MCP] Returning directive for tool: ${name}`);
-            return formatDirectiveResponse(directive);
+            const directiveResponse = formatDirectiveResponse(directive);
+
+            // Record BEFORE returning. This early return skips the dispatch
+            // switch below and, with it, the trackToolExecution call on the
+            // success path -- so every tool in CE_MCP_DIRECTIVE_TOOLS was
+            // invisible to usage tracking whenever CE-MCP mode was on. All
+            // twelve of them, including `perform_research`, whose disposition
+            // ADR-023 defers *pending usage data*. See #1489.
+            //
+            // Deliberately not fatal: a directive is the tool's real answer, and
+            // failing to record it must never withhold it. trackToolExecution
+            // already swallows and warns internally; the catch here covers a
+            // throw before that boundary.
+            try {
+              await this.trackToolExecution(name, args, directiveResponse, true);
+            } catch (trackingError) {
+              this.logger.warn(
+                `[CE-MCP] Usage tracking failed for ${name}: ${
+                  trackingError instanceof Error ? trackingError.message : String(trackingError)
+                }`
+              );
+            }
+
+            return directiveResponse;
           }
           // Fall through to legacy execution if no directive available
           this.logger.info(`[CE-MCP] No directive available for ${name}, using legacy path`);

--- a/src/utils/knowledge-graph-manager.ts
+++ b/src/utils/knowledge-graph-manager.ts
@@ -11,7 +11,7 @@ import {
   TodoSyncStateSchema,
   KnowledgeGraphSnapshotSchema,
 } from '../types/knowledge-graph-schemas.js';
-import { loadConfig } from './config.js';
+import { loadConfig, getCacheDirectoryPath } from './config.js';
 // Using new MemoryHealthScoring instead of deprecated ProjectHealthScoring
 import { MemoryHealthScoring, MemoryHealthScore } from './memory-health-scoring.js';
 
@@ -36,6 +36,8 @@ export class KnowledgeGraphManager {
   private cacheDir: string;
   private snapshotsFile: string;
   private syncStateFile: string;
+  /** Pre-#1488 location under os.tmpdir(); read once for migration, never written. */
+  private legacyCacheDir: string;
   private memoryScoring: MemoryHealthScoring;
 
   /**
@@ -43,11 +45,18 @@ export class KnowledgeGraphManager {
    */
   constructor() {
     const config = loadConfig();
-    // Use OS temp directory for cache
-    const projectName = path.basename(config.projectPath);
-    this.cacheDir = path.join(os.tmpdir(), projectName, 'cache');
+    // Project-local, NOT os.tmpdir(). This store holds the only record of which
+    // tools are actually called, and os.tmpdir() is cleared by the OS -- so the
+    // evidence never survived a reboot. ADR-023 deferred three tool clusters
+    // "pending usage data" partly because of this; see #1488.
+    //
+    // Several docstrings already documented `.mcp-adr-cache/knowledge-graph-
+    // snapshots.json` as the location (adr-suggestion-tool.ts, mcp-planning-tool.ts,
+    // index.ts). They described the fix rather than the code. Now they are right.
+    this.cacheDir = getCacheDirectoryPath(config);
     this.snapshotsFile = path.join(this.cacheDir, 'knowledge-graph-snapshots.json');
     this.syncStateFile = path.join(this.cacheDir, 'todo-sync-state.json');
+    this.legacyCacheDir = path.join(os.tmpdir(), path.basename(config.projectPath), 'cache');
     this.memoryScoring = new MemoryHealthScoring();
   }
 
@@ -59,6 +68,37 @@ export class KnowledgeGraphManager {
       await fs.access(this.cacheDir);
     } catch {
       await fs.mkdir(this.cacheDir, { recursive: true });
+    }
+    // Outside the try/catch on purpose. On the first run after #1488 the new
+    // directory does not exist, so a migration hooked into the success branch
+    // would never fire on the one run that needs it.
+    await this.migrateLegacyCache();
+  }
+
+  /**
+   * One-time move of pre-#1488 state out of os.tmpdir() into the project cache.
+   *
+   * Best-effort and non-fatal by design: this runs on the read path of every
+   * knowledge-graph operation, and a server that cannot start because an old
+   * temp file is unreadable would be a worse bug than the one being fixed.
+   * A missing legacy directory is the common case, not an error.
+   */
+  private async migrateLegacyCache(): Promise<void> {
+    if (this.legacyCacheDir === this.cacheDir) return;
+    for (const file of ['knowledge-graph-snapshots.json', 'todo-sync-state.json']) {
+      const from = path.join(this.legacyCacheDir, file);
+      const to = path.join(this.cacheDir, file);
+      try {
+        await fs.access(to);
+        continue; // destination already populated -- never overwrite live state
+      } catch {
+        /* not yet migrated */
+      }
+      try {
+        await fs.copyFile(from, to);
+      } catch {
+        /* no legacy file, or unreadable: nothing to carry forward */
+      }
     }
   }
 
@@ -410,10 +450,14 @@ export class KnowledgeGraphManager {
       });
     });
 
+    // Every tool, not a top-10. This used to truncate before persisting, which
+    // discarded the full map it had just built -- and every cluster ADR-023 defers
+    // (memory 6, workflow 5, research 4) falls beyond a 10-entry cut of 75 tools.
+    // Display caps belong at the read path: server-context-generator.ts:557 already
+    // does its own .slice(0, 5). See #1488.
     kg.analytics.mostUsedTools = Array.from(toolUsage.entries())
       .map(([toolName, usageCount]) => ({ toolName, usageCount }))
-      .sort((a, b) => b.usageCount - a.usageCount)
-      .slice(0, 10);
+      .sort((a, b) => b.usageCount - a.usageCount);
   }
 
   async calculateTodoMdHash(todoPath: string): Promise<string> {

--- a/tests/integration/cemcp-usage-tracking.test.ts
+++ b/tests/integration/cemcp-usage-tracking.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Protocol-level test: does a CE-MCP directive call get recorded? (#1489)
+ *
+ * Why this exists:
+ *
+ * ADR-023 deferred the disposition of three tool clusters -- memory (6),
+ * workflow (5), research (4) -- "pending usage data". `perform_research` is in
+ * that research cluster. It is also one of the twelve CE_MCP_DIRECTIVE_TOOLS,
+ * and the CE-MCP path in src/index.ts returned the directive BEFORE the dispatch
+ * switch and before `trackToolExecution`:
+ *
+ *     if (isCEMCPEnabled(aiConfig) && shouldUseCEMCPDirective(name, ...)) {
+ *       const directive = getCEMCPDirective(name, safeArgs);
+ *       if (directive) {
+ *         return formatDirectiveResponse(directive);   // <-- nothing recorded
+ *       }
+ *     }
+ *     switch (name) { ... }
+ *     await this.trackToolExecution(name, args, response, true);   // unreachable
+ *
+ * So a decision was deferred pending evidence that a bug guaranteed would never
+ * be collected for the tools it was deferred about. CE-MCP is also the DEFAULT
+ * execution mode (ai-config.ts:152), so this was the normal path, not an edge.
+ *
+ * This asserts the behaviour over the wire rather than the shape of the source.
+ * A unit test that greps for a call site would pass on a call placed after the
+ * return statement.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+const SERVER = resolve(process.cwd(), 'dist/src/index.js');
+
+/** One of CE_MCP_DIRECTIVE_TOOLS, and in ADR-023's deferred research cluster. */
+const DIRECTIVE_TOOL = 'perform_research';
+
+let client: Client;
+let transport: StdioClientTransport;
+let projectPath: string;
+
+describe('CE-MCP usage tracking (#1489)', () => {
+  beforeAll(async () => {
+    if (!existsSync(SERVER)) {
+      throw new Error(
+        `${SERVER} not found. Run \`npm run build\` before this test -- it exercises ` +
+          `the BUILT server, which is the thing shipped to npm.`
+      );
+    }
+
+    // A throwaway PROJECT_PATH so the knowledge graph this test writes cannot
+    // touch the repo's own .mcp-adr-cache.
+    projectPath = await mkdtemp(join(tmpdir(), 'cemcp-usage-'));
+    await mkdir(join(projectPath, 'docs', 'adrs'), { recursive: true });
+
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER],
+      env: {
+        ...(process.env as Record<string, string>),
+        PROJECT_PATH: projectPath,
+        ADR_DIRECTORY: 'docs/adrs',
+        // The condition under test. ce-mcp is already the default; naming it
+        // means this test keeps testing the directive path if the default moves.
+        EXECUTION_MODE: 'ce-mcp',
+        // No key: a directive is computed locally and must not need one.
+        OPENROUTER_API_KEY: '',
+      },
+    });
+
+    client = new Client({ name: 'cemcp-usage-test', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await client?.close();
+    } catch {
+      /* already gone */
+    }
+    if (projectPath) {
+      await rm(projectPath, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('records a directive-path call in the knowledge graph', async () => {
+    await client.callTool({
+      name: DIRECTIVE_TOOL,
+      arguments: { researchQuestion: 'what does this repository do', projectPath },
+    });
+
+    // Written by trackToolExecution -> KnowledgeGraphManager. Project-local
+    // since #1488; it used to land in os.tmpdir() and not survive a reboot.
+    const snapshotFile = join(projectPath, '.mcp-adr-cache', 'knowledge-graph-snapshots.json');
+
+    // The write happens after the response is returned, so allow the server a
+    // moment. Polling rather than a fixed sleep keeps this from being flaky in
+    // one direction and slow in the other.
+    let raw: string | undefined;
+    for (let attempt = 0; attempt < 40; attempt++) {
+      try {
+        raw = await readFile(snapshotFile, 'utf-8');
+        if (raw.includes(DIRECTIVE_TOOL)) break;
+      } catch {
+        /* not written yet */
+      }
+      await new Promise(r => setTimeout(r, 250));
+    }
+
+    expect(
+      raw,
+      `${snapshotFile} was never written -- the CE-MCP directive path returned before ` +
+        `trackToolExecution, so the call went unrecorded`
+    ).toBeDefined();
+
+    const kg = JSON.parse(raw!);
+    const recorded: string[] = (kg.analytics?.mostUsedTools ?? []).map(
+      (t: { toolName: string }) => t.toolName
+    );
+
+    expect(
+      recorded,
+      `${DIRECTIVE_TOOL} is one of CE_MCP_DIRECTIVE_TOOLS and was not recorded. ` +
+        `ADR-023 defers this tool's disposition pending exactly this data.`
+    ).toContain(DIRECTIVE_TOOL);
+  }, 90_000);
+});

--- a/tests/utils/knowledge-graph-manager.test.ts
+++ b/tests/utils/knowledge-graph-manager.test.ts
@@ -20,7 +20,12 @@ describe('KnowledgeGraphManager', () => {
     const projectName = 'test-kg-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
     process.env.PROJECT_PATH = path.join(os.tmpdir(), projectName);
     tempDir = path.join(os.tmpdir(), projectName);
-    cacheDir = path.join(tempDir, 'cache');
+    // '.mcp-adr-cache', not 'cache'. The store moved out of os.tmpdir() and into
+    // the project-local cache directory config.ts:17 already defined (#1488) --
+    // it was ephemeral, so the only record of which tools get called never
+    // survived a reboot. tempDir here is still under os.tmpdir() because it is
+    // this test's throwaway PROJECT_PATH, which is a different thing.
+    cacheDir = path.join(tempDir, '.mcp-adr-cache');
     snapshotsFile = path.join(cacheDir, 'knowledge-graph-snapshots.json');
 
     // Initialize manager
@@ -530,6 +535,97 @@ describe('KnowledgeGraphManager', () => {
 
       expect(planningIntents).toHaveLength(1);
       expect(planningIntents[0].intentId).toBe(intent2);
+    });
+  });
+
+  // ---------------------------------------------------------------- #1488
+  // ADR-023 deferred three tool clusters "pending usage data" on the claim that
+  // nothing in src/ recorded which tools are called. It did record them -- and
+  // then threw the record away twice over: truncated to ten entries before
+  // persisting, into a directory the OS deletes. Neither loss had a test.
+  describe('tool usage evidence (#1488)', () => {
+    it('persists usage counts for more than ten distinct tools', async () => {
+      const intentId = await kgManager.createIntent('Usage', ['Goal'], 'medium');
+
+      // Fifteen, deliberately: the old code sliced to ten before writing, so
+      // any count below eleven passes against the bug it is meant to catch.
+      const tools = Array.from({ length: 15 }, (_, i) => `tool_${String(i).padStart(2, '0')}`);
+      for (const name of tools) {
+        await kgManager.addToolExecution(intentId, name, {}, { success: true }, true, [], []);
+      }
+
+      const kg = await kgManager.loadKnowledgeGraph();
+      const recorded = kg.analytics.mostUsedTools.map(t => t.toolName);
+
+      expect(recorded).toHaveLength(15);
+      for (const name of tools) {
+        expect(recorded, `${name} missing -- counts truncated before persistence`).toContain(name);
+      }
+    });
+
+    it('keeps counts across a manager restart', async () => {
+      const intentId = await kgManager.createIntent('Durable', ['Goal'], 'medium');
+      await kgManager.addToolExecution(
+        intentId,
+        'perform_research',
+        {},
+        { success: true },
+        true,
+        [],
+        []
+      );
+      await kgManager.addToolExecution(
+        intentId,
+        'perform_research',
+        {},
+        { success: true },
+        true,
+        [],
+        []
+      );
+      await kgManager.addToolExecution(
+        intentId,
+        'smart_score',
+        {},
+        { success: true },
+        true,
+        [],
+        []
+      );
+
+      // A fresh instance reads from disk. Under the old os.tmpdir() location this
+      // still passed in-process; what it never survived was the OS clearing temp.
+      // Asserting the reload is the closest an in-process test gets, and it pins
+      // the store to a directory that is not swept.
+      const reopened = new KnowledgeGraphManager();
+      const kg = await reopened.loadKnowledgeGraph();
+
+      const counts = Object.fromEntries(
+        kg.analytics.mostUsedTools.map(t => [t.toolName, t.usageCount])
+      );
+      expect(counts['perform_research']).toBe(2);
+      expect(counts['smart_score']).toBe(1);
+    });
+
+    it('writes to the project cache, not the OS temp directory', async () => {
+      const intentId = await kgManager.createIntent('Location', ['Goal'], 'medium');
+      await kgManager.addToolExecution(
+        intentId,
+        'suggest_adrs',
+        {},
+        { success: true },
+        true,
+        [],
+        []
+      );
+
+      // cacheDir is <PROJECT_PATH>/.mcp-adr-cache. In this suite PROJECT_PATH is
+      // itself a throwaway under os.tmpdir(), so asserting "not under tmpdir"
+      // would be wrong -- assert the layout instead.
+      const stats = await fs.stat(snapshotsFile);
+      expect(stats.isFile()).toBe(true);
+      expect(snapshotsFile).toContain('.mcp-adr-cache');
+      expect(path.basename(path.dirname(snapshotsFile))).toBe('.mcp-adr-cache');
     });
   });
 });


### PR DESCRIPTION
Closes #1488. Closes #1489.

ADR-023 deferred three tool clusters — memory (6), workflow (5), research (4) — *"pending usage data."* The data was recorded, then discarded three separate ways.

## 1. Truncated before persistence

```ts
.sort((a, b) => b.usageCount - a.usageCount)
.slice(0, 10);          // <- the full map, just built, thrown away
```

Ten survivors out of 75 tools. **Every deferred cluster falls beyond that cut.** Removed; display caps belong at the read path, where `server-context-generator.ts:557` already does its own `.slice(0, 5)`.

## 2. Written to `os.tmpdir()`

```ts
this.cacheDir = path.join(os.tmpdir(), projectName, 'cache');
```

Cleared by the OS. The evidence never survived a reboot — the likeliest reason ADR-023's author looked and found nothing. Now `getCacheDirectoryPath()`, the project-local `.mcp-adr-cache` that `config.ts:17` already defined, and that three docstrings already *claimed* was the location. They described the fix; now they're accurate.

There was **96KB of real knowledge-graph state** in the old location, so this migrates rather than starting clean. Best-effort, never overwrites live state, and runs **outside** `ensureCacheDirectory`'s try/catch — a migration hooked to the success branch would never fire on the one run that needs it, the run where the new directory doesn't exist yet.

## 3. Not recorded at all, for twelve tools

The CE-MCP path returned the directive **before** the dispatch switch and before `trackToolExecution`, so every `CE_MCP_DIRECTIVE_TOOLS` member was invisible whenever CE-MCP was on — and **`ce-mcp` is the default mode** (`ai-config.ts:152`), so this was the normal path, not an edge case.

`perform_research` is one of the twelve: a tool whose disposition ADR-023 defers *pending evidence this bug guaranteed would never be collected about it.*

Tracking now runs before the return, non-fatally — a directive is the tool's real answer, and failing to record it must never withhold it.

## I edited my own gate, and I'm flagging it

`check-decision-gate.sh` asserted `! grep -q "os.tmpdir()"` on the manager. A correct migration must read the old location, so that assertion fails on the fix for it.

Loosening a gate to admit my own work is precisely the move this milestone exists to prevent. So the assertion was made **stricter** instead:

- **positive:** `cacheDir` must be assigned from `getCacheDirectoryPath()` — the old absence-check passed if the line were simply *deleted*
- **negative:** every remaining `os.tmpdir()` must sit in a `legacy` binding

Verified against three regressions the old check graded wrong, including a hardcoded `"/tmp/hardcoded"` it missed entirely. The reasoning is recorded in the script, not just here.

## Every test proven to fail first

| regression re-introduced | result |
|---|---|
| `.slice(0, 10)` | `persists usage counts for >10 tools` **fails** |
| the `os.tmpdir()` path | **5 tests fail**, incl. the new location assertion |
| the CE-MCP tracking | integration test **fails**: `expected [] to include 'perform_research'` |

That last one is an empty array — the symptom exactly.

The CE-MCP test is protocol-level: it boots the **built** server with `EXECUTION_MODE=ce-mcp` against a throwaway `PROJECT_PATH` and reads the knowledge graph off disk. A unit test grepping for a call site would pass on a call placed *after* the return statement.

## Verification

- Full suite **3070 passed, 70 skipped**
- `check-adr-drift.sh` **8/8**, unchanged
- Decision gate: **9 failing → 5**
- The existing suite hardcoded `<project>/cache` and needed updating to `<project>/.mcp-adr-cache` — it encoded the old layout, not a behaviour

> One caveat stated rather than buried: an early full-suite run showed 5 failures, while `dist/` was mid-rebuild from the revert proofs. Two subsequent clean runs were fully green, and both stdio-spawning integration tests pass together twice in a row. I believe it was the stale build, but I'm reporting it rather than claiming stability I haven't fully established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
