### PR TITLE
docs(adr): record ADR-023's Decision — the supported tool surface is 54

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -27,7 +27,7 @@ This directory contains the Architectural Decision Records for the MCP ADR Analy
 | [ADR-020](adr-020-mcp-tasks-integration-strategy.md)                   | MCP Tasks Integration Strategy                   | Accepted | 2025-12-16 | Architecture  |
 | [ADR-021](adr-021-ai-layer-disposition.md)                             | Disposition of the legacy AI execution layer     | Accepted | 2026-08-26 | Architecture  |
 | [ADR-022](adr-022-adopt-madr-format.md)                                | Adopt MADR as the default decision-record format | Proposed | 2026-08-26 | Documentation |
-| [ADR-023](adr-023-tool-surface-scope.md)                               | Which of the 75 tools should still exist         | Proposed | 2026-08-26 | Architecture  |
+| [ADR-023](adr-023-tool-surface-scope.md)                               | Which of the 75 tools should still exist         | Accepted | 2026-08-27 | Architecture  |
 
 > **This index is known to be out of date and is not corrected here.** It stops at
 > ADR-018, omits ADR-019 and ADR-020, and lists ADR-012, ADR-013 and ADR-014 as

--- a/docs/adrs/adr-023-tool-surface-scope.md
+++ b/docs/adrs/adr-023-tool-surface-scope.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-26
 decision-makers: Tosin Akinosho
 consulted: Claude Code (measurement and external research)
@@ -195,20 +195,85 @@ implies.
 
 ## Decision
 
-_Not yet recorded._ Awaiting the owner's disposition. See #1414's successor work.
+**The supported tool surface is 54.** Recorded 2026-08-27 (#1490).
+
+Read the verb precisely, because it is doing work: these tools are **removed from the
+supported surface**, not deleted. Nothing here authorises a deletion, and the
+Confirmation section below explains why it cannot.
+
+### Out of the supported surface — the host now does this (11)
+
+`read_file`, `write_file`, `list_directory`, `read_directory`, `list_roots`,
+`llm_web_search`, `llm_cloud_management`, `llm_database_management`, `search_tools`,
+`load_prompt`, `get_current_datetime`.
+
+`search_tools` and `load_prompt` decide the rest of the list. The argument for them is
+not "a host tool does this too" — it is that the specification assigns progressive
+discovery to the host, and OpenAI and Anthropic ship it natively. A server implementing
+it is reimplementing a host feature, and this server is 3–12× over the threshold at which
+the spec says to stop.
+
+### Dies with the AI layer (1)
+
+`check_ai_execution_status` exists to explain the legacy execution mode. Under ADR-021
+option B it has nothing left to report. It goes when the layer does, not before.
+
+### Out of scope (10)
+
+The aggregator. ADR-021 ruled it "a separate commercial question" and that stands
+unchanged here.
+
+### Deferred — memory (6), workflow (5), research (4)
+
+**Not classified.** This ADR said plainly that this section "is reasoning about code
+shape, not about use", and that limit is respected rather than overridden. Deferred to
+**ADR-024**, whose precondition is usage data.
+
+That precondition is now satisfiable. The correction in #1486 established that the
+evidence was being computed and discarded, and #1488 and #1489 fixed all three losses:
+the `.slice(0, 10)` before persistence, the `os.tmpdir()` store the OS clears, and the
+CE-MCP directive path that recorded nothing for twelve tools. Counts now accumulate in
+`.mcp-adr-cache/` and survive a restart.
+
+So ADR-024 is not blocked on building anything. It is blocked on **elapsed use** — which
+is an honest thing for an ADR to wait on, and a different thing from the indefinite
+deferral this section originally implied.
+
+### What this does not decide
+
+Whether any of the 11 is ever deleted. That is `retirement.py`'s question, asked per
+asset, each with its own admission under the CE-MCP migration milestone.
 
 ## Consequences
 
-To be completed once the decision is recorded. Two are worth stating in advance:
-
-**It resizes queued work.** Removing 11 host-native tools and excluding 10 aggregator
-tools leaves **54**. #1416 builds a registry for 54 entries rather than 75, and option B
-has fewer tools to consider.
+**It resizes queued work.** 75 − 11 host-native − 10 aggregator = **54**. #1416 builds a
+`ToolDefinition[]` for 54 entries rather than 75, and ADR-021 option B has fewer tools to
+migrate. Both were explicitly waiting on this number.
 
 **It sharpens what the product is.** If the market's unmet need is drift detection and
 this repo has already built a working drift checker, then the ADR-generation surface is
 the commodity part and the verification surface is the differentiated part. That is a
 positioning consequence, not only a scope one.
+
+**It unblocks five issues** that were gated on nothing but this section: #1416, #1477,
+#759, #750, and #1461's rule half.
+
+**It creates a deprecation obligation.** Eleven tools are advertised over the wire today
+and clients may be calling them. Removal from the surface means: excluded from #1416's
+registry, marked deprecated in `TOOL_CATALOG` and the docs, and announced in
+`CHANGELOG.md` — before any of them stops responding. `public_contracts` is one of the
+dimensions `retirement.py` deliberately leaves blind, so this obligation is a human one
+and is recorded here rather than assumed.
+
+**It leaves `outputSchema` unaddressed.** This ADR measured zero output schemas across 75
+tools and did not decide anything about them. A 54-tool registry is the moment to add
+them, and #1416 should not close without a position — but that position is not taken
+here, and pretending otherwise would be the same overreach this ADR declined elsewhere.
+
+**Four tools remain uncatalogued** — `get_gaps`, `search_codebase`, `set_project_path`,
+`update_knowledge`. They are dispatchable and absent from `TOOL_CATALOG`, so this
+Decision does not cover them: they are not in the 11, not in the aggregator 10, and not in
+a deferred cluster. #1416 must classify them as it derives the single registry.
 
 ## Confirmation
 


### PR DESCRIPTION
Closes #1490.

ADR-023 measured, researched and argued across 75 tools, then stopped at:

```
## Decision
_Not yet recorded._ Awaiting the owner's disposition. See #1414's successor work.
```

"#1414's successor work" resolved to no issue in any milestone. The single item blocking five pieces of queued work was never on the board.

## The disposition

| | count | |
|---|---|---|
| out of the supported surface | **11** | host-native duplicates |
| dies with the AI layer | **1** | `check_ai_execution_status` (ADR-021 option B) |
| out of scope | **10** | aggregator — ADR-021: *"a separate commercial question"* |
| deferred | **15** | memory 6, workflow 5, research 4 → ADR-024 |
| **supported surface** | **54** | 75 − 11 − 10 |

`search_tools` and `load_prompt` decide the rest of the list. The argument isn't "a host tool does this too" — it's that the spec **assigns progressive discovery to the host**, and OpenAI and Anthropic ship it natively.

## Declassification, not deletion

The verb matters. These tools leave the **supported surface** — excluded from #1416's registry, deprecated in the catalog and docs.

Nothing here authorises a deletion, because ADR-023's own Confirmation says `retirement.py` returns `RETIREMENT_REVIEW` and never `REMOVAL_READY` from static analysis, and any removal needs its own admission. A Decision reading *"remove 11 tools"* would contradict its own ADR two sections later and authorise nothing.

## The deferral is now bounded

The original text deferred three clusters *"pending usage data"* on the belief none was recorded. #1486 established that was false; #1488 and #1489 fixed all three ways it was being discarded. **Verified on `main` before writing this** — the slice is gone, the store is project-local, CE-MCP calls are tracked.

So ADR-024 isn't blocked on building anything. It's blocked on **elapsed use** — an honest thing for an ADR to wait on, and a different thing from the indefinite deferral this section originally implied.

## Three consequences the ADR did not previously state

**A deprecation obligation.** Eleven tools are advertised over the wire and clients may be calling them. `public_contracts` is a dimension `retirement.py` leaves deliberately blind, so this obligation is a human one — written down rather than assumed.

**`outputSchema` is left undecided.** Zero across 75 tools was measured and nothing concluded. A 54-tool registry is the moment to fix it and #1416 shouldn't close without a position — but taking that position here would be the same overreach this ADR declined elsewhere.

**Four tools are uncatalogued** — `get_gaps`, `search_codebase`, `set_project_path`, `update_knowledge` — and fall in none of the buckets above. Verified still uncatalogued today. #1416 must classify them.

## Every claim checked before writing

- All 12 named tools confirmed present on the wire
- **75 − 11 − 10 = 54** confirmed by counting, not asserted
- Instrumentation confirmed merged on `main`

Recording a decision on unchecked claims is the failure this milestone exists to end, and it would have been a poor way to end it.

## One thing the drift checker caught on me

The ADR index still said `Proposed` while the file said `Accepted`. `check-adr-drift.sh` went **8 → 9**. Fixed the index rather than raising the baseline; back to **8/8**.

Decision gate: **5 failing → 3**. Unblocks #1416, #1477, #759, #750 and #1461's rule half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
