### PR TITLE
chore(governance): acceptance bar for #1415 — the only umbrella issue without one

### DIFF
--- a/.repo-governor/acceptance/1415.json
+++ b/.repo-governor/acceptance/1415.json
@@ -1,0 +1,39 @@
+{
+  "authority_id": "1415",
+  "criteria": [
+    {
+      "check": "command_exit",
+      "target": "bash scripts/check-adr-drift.sh"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'test $(ls docs/adrs/adr-018*.md | wc -l) -eq 1'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -rE \"@see .*adr-016-replace-ripgrep\" src/'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -qx \"Accepted\" <(sed -n \"/^## Status/,/^## /p\" docs/adrs/adr-001-*.md)'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -qiE \"hcl|dockerfile\" <(awk \"/^#+ Corrections/{s=1} /^## Related/{s=0} !s\" docs/adrs/adr-006-*.md)'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -q \"is known to be out of date and is not corrected here\" docs/adrs/README.md'"
+    },
+    {
+      "check": "file_exists",
+      "target": "docs/adrs/README.md"
+    }
+  ],
+  "covers": {
+    "declared": "The ledger's own internal consistency: one file claims ADR-018, no source @see points at the ADR-016 that was never written, ADR-001's retired SSE decision is no longer Accepted, ADR-006 makes no live HCL/Dockerfile claim, and the index no longer carries a staleness note that had itself gone stale. Plus the ratchet: drift may not rise.",
+    "uncovered": "THREE DRIFT FINDINGS REMAIN AND ARE NOT THIS ISSUE'S. `check-adr-drift.sh` passing at baseline 3 does NOT mean zero drift -- the baseline contains exactly the three delegated below. Anyone reading criterion 1 as 'the ledger is clean' would be reading a false green, which is why the specific checks 2-6 exist alongside it: they establish #1415's own outcome, and criterion 1 only guarantees nothing regressed while doing so. Also uncovered: whether the ADR corpus is CORRECT, as opposed to self-consistent. A ledger can agree with itself and still describe a system nobody built. Only the code-vs-claim checks test that, and only for ADR-001, ADR-006, ADR-018a and ADR-019 -- four ADRs out of twenty-two. The rest have never been checked against anything.",
+    "split_to": ["1461", "1462", "1463"]
+  },
+  "$comment": "Written 2026-08-27 under #1415, which is the only umbrella issue in this repo without an acceptance bar -- envelope.py reported 0 of 5 dimensions filled, THIN, NO_CRITERIA_DECLARED. That is why a necessity claim for the drift-checker work failed closed to CAPTURE_ONLY and had to become its own issue (#1507): with no declared in_scope, no claim can be substantiated against it. Criterion 3 is anchored to `@see` rather than the bare filename on purpose. The first draft grepped for 'adr-016-replace-ripgrep' anywhere in src/ and FAILED, because the comment explaining that the ADR does not exist mentions it by name -- the same mentions-vs-claims confusion #1507 had just removed from the drift checker, reproduced one file away while writing the bar for it."
+}


### PR DESCRIPTION
Advances #1415.

#1415 was the only umbrella issue in this repo with no acceptance criteria. Eight others have one; it didn't.

```
envelope.py 1415  ->  0 of 5 dimensions filled, THIN, NO_CRITERIA_DECLARED
completion.py     ->  CONTINUE, and always would have been
```

## That absence had already cost something

When I asked whether the drift-checker work was in scope for #1415, the engine failed closed:

```
"necessity was claimed but is unsupported: the target is outside declared in_scope"
"no in_scope was declared at all, so no necessity claim can be substantiated"
```

With no declared scope there's nothing to substantiate a claim against, so the checker fix had to become its own issue (#1507). That was the right outcome — but it was reached by the bar's *absence* rather than by its content.

## Seven criteria, all satisfied on this commit

| | |
|---|---|
| drift at or below baseline | one file claims ADR-018 |
| no `@see` to the never-written ADR-016 | ADR-001 is not `Accepted` |
| ADR-006 makes no live HCL claim | the stale index self-note is gone |
| the index exists | |

## What `covers` admits matters more than the criteria

**Criterion 1 passing does not mean the ledger is clean.** The baseline is 3, and it contains exactly the three findings delegated to #1461, #1462 and #1463. Reading a green ratchet as "no drift" would be a false green of the kind this milestone exists to remove — so criteria 2-6 establish #1415's *own* outcome, and criterion 1 only guarantees nothing regressed while doing so.

The second uncovered half is bigger and worth saying out loud:

> This bar tests whether the ledger agrees with **itself**, not whether it is **correct**. A ledger can be perfectly self-consistent and still describe a system nobody built. Only the code-vs-claim checks test that, and only for ADR-001, ADR-006, ADR-018a and ADR-019 — **four ADRs out of twenty-two.** The other eighteen have never been checked against anything.

## The engine now refuses to close it, correctly

```
decision: CONTINUE   BAR_COVERS_PART
"the uncovered half was split, and has not landed: 1461, 1462, 1463"
```

All seven criteria pass and it still won't say `STOP_COMPLETE`, because `split_to` names three open authorities. It flips automatically when they land.

That's the bar working in both directions: it makes the eventual close **mechanical**, and it prevents a **premature** one. Neither outcome needed my judgement, which was the entire point of writing it instead of closing #1415 on "I looked and it seems done."

## One thing I got wrong first

Criterion 3 is anchored to `@see`, not the bare filename. The first draft grepped `src/` for `adr-016-replace-ripgrep` anywhere and **failed** — because the comment explaining that the ADR doesn't exist mentions it by name.

That's the same mentions-vs-claims confusion #1507 had just removed from the drift checker, reproduced one file away while writing the bar for it. Anchored to `@see` (what the checker actually scans) and proven to fail when the bad `@see` is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
