### PR TITLE
chore(governance): fold #742 into #1416's acceptance bar

### DIFF
--- a/.repo-governor/acceptance/1416.json
+++ b/.repo-governor/acceptance/1416.json
@@ -24,6 +24,11 @@
     {
       "check": "tests_pass",
       "target": "npm test"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'test $(grep -c \"conversationContext: CONVERSATION_CONTEXT_SCHEMA\" src/index.ts) -le 1'"
     }
-  ]
+  ],
+  "$comment": "The conversationContext criterion is #742, folded in here 2026-08-27 rather than fixed standalone. #742's finding: 8 tools advertise a 10-field conversationContext in their MCP input schema and exactly 1 (suggest_adrs, via utils/adr-suggestions.ts:165) consumes it; trackToolExecution reads only .humanRequest, generically, for any tool. Four of the seven that ignore it -- get_architectural_context, generate_adr_bootstrap, bootstrap_validation_loop, review_existing_adrs -- are OUT OF THE SUPPORTED SURFACE under ADR-023, so fixing them individually would be work on tools that are leaving. A single ToolDefinition[] is the only place where 'advertised but not consumed' becomes checkable at all, which is why it belongs here. The threshold is <=1, not 0: suggest_adrs genuinely uses it and should keep it."
 }


### PR DESCRIPTION
Closes #742 by relocating it, not by fixing it standalone.

## The finding

| | |
|---|---|
| **advertised** | **8** tools — `index.ts:308, 330, 378, 717, 811, 877, 983, 2574` |
| **consumed** | **1** — `suggest_adrs`, via `utils/adr-suggestions.ts:165` |

The schema has ten fields: `humanRequest`, `userGoals`, `focusAreas`, `constraints`, `previousContext`, `projectPhase`, `userRole`, `requirements`, `timeline`, `budget`.

One partial exception so the count isn't overstated: `trackToolExecution` (`index.ts:8248`) reads `.humanRequest` generically for *any* tool, to name a knowledge-graph intent. So 1 of 10 fields has a universal effect; the other nine are discarded by seven of the eight.

## Why it belongs in #1416 rather than on its own

**Four of the seven that ignore it are out of the supported surface** under ADR-023's recorded Decision — `get_architectural_context`, `generate_adr_bootstrap`, `bootstrap_validation_loop`, `review_existing_adrs`. Wiring context into tools that are being removed is rework by definition.

And *"advertised but not consumed"* is only checkable where advertisement and implementation are the same record. Across four hand-maintained registries there's nowhere to assert it. A single `ToolDefinition[]` is that place.

## The threshold is `<= 1`, not `0`

`suggest_adrs` genuinely consumes `conversationContext` and should keep it. A bar demanding zero would force removing a working feature to satisfy a checker.

Proven both directions before committing:

```
8 advertisers today          -> exit 1  (correctly fails)
7 declarations removed       -> exit 0  (passes at 1)
```

Milestone 4: **4 open → 3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
