### PR TITLE
docs: the monitoring.ts doc fixes #1520 described were never in the commit

### DIFF
--- a/docs/adrs/adr-023-tool-surface-scope.md
+++ b/docs/adrs/adr-023-tool-surface-scope.md
@@ -159,7 +159,7 @@ already computes exactly the per-tool counts this section needs:
 | complete per-tool count `Map`, sorted                   | `src/utils/knowledge-graph-manager.ts:406-416`                         | `.slice(0, 10)` truncates it **before persisting** — the full map is built and discarded                              |
 | every execution recorded                                | `trackToolExecution`, `src/index.ts:8219`, called at `:4201` / `:4208` | persists under `os.tmpdir()` (`knowledge-graph-manager.ts:44-52`) — wiped by OS temp cleanup, never survives a reboot |
 | distinct tools per session                              | `src/utils/conversation-memory-manager.ts:131,163`                     | same `os.tmpdir()` problem; a dedup'd list, no counts                                                                 |
-| complete `MonitoringManager` with `MetricCategory.TOOL` | `src/utils/monitoring.ts`                                              | **zero production call sites** — built, tested, never wired                                                           |
+| complete `MonitoringManager` with `MetricCategory.TOOL` | ~~`src/utils/monitoring.ts`~~ — **retired**, #1487                     | had zero production call sites and no persistence; it could not have served this need. Retired 2026-08-27             |
 
 And one blind spot that bears directly on this section: the CE-MCP directive path at
 `src/index.ts:3875-3888` returns before the dispatch switch and before

--- a/docs/how-to-guides/performance-testing.md
+++ b/docs/how-to-guides/performance-testing.md
@@ -175,41 +175,30 @@ async function analyzeLargeFile(filePath: string) {
 
 ## 📈 Monitoring Performance
 
-### 1. Enable Performance Monitoring
+> **This section previously documented an API that never existed.** It showed
+> `MonitoringManager.getInstance()`, `monitor.trackOperation(...)` and
+> `monitor.getPerformanceReport()` — none of which were ever methods on that class — plus
+> `ENABLE_MONITORING`, `MONITORING_LEVEL` and `PERFORMANCE_LOG_PATH` env vars and an
+> `npm run monitor:dashboard` script, none of which appear anywhere in `src/` or
+> `package.json`. The class itself was retired in #1487: 725 lines, zero production call
+> sites, no persistence, and a health-check registry that was an empty stub.
 
-```bash
-# .env
-ENABLE_MONITORING=true
-MONITORING_LEVEL=detailed
-PERFORMANCE_LOG_PATH=./logs/performance.json
-```
+What actually exists today, and is wired:
 
-### 2. Collect Metrics
+- **Structured logging with operation timing** — `src/utils/enhanced-logging.ts`, imported by
+  31 modules. `logOperationStart` / `logOperationComplete` / `logOperationFailure` are the
+  timing surface.
+- **Per-tool execution telemetry** — `trackToolExecution` in `src/index.ts` records every tool
+  call, including the CE-MCP directive path, into the knowledge graph at
+  `.mcp-adr-cache/knowledge-graph-snapshots.json`. Per-tool call counts survive a restart
+  (#1488, #1489).
+- **Cache hit/miss accounting** — `ResourceCache` in `src/resources/resource-cache.ts` tracks
+  hits, misses and hit rate live.
 
-```typescript
-import { MonitoringManager } from './utils/monitoring';
-
-const monitor = MonitoringManager.getInstance();
-
-// Track operation performance
-monitor.trackOperation('adr-analysis', async () => {
-  return await analyzeAdr(path);
-});
-
-// Get performance report
-const report = monitor.getPerformanceReport();
-console.log(report);
-```
-
-### 3. Performance Dashboard
-
-View real-time metrics:
-
-```bash
-npm run monitor:dashboard
-```
-
----
+**If you want real metrics — latency percentiles, error rates, traces — use OpenTelemetry.**
+Off-the-shelf instrumentation packages patch `StdioServerTransport`, which is the transport
+this server uses, and emit RPC spans and tool-latency histograms without any bespoke code.
+That is the supported path; nothing in this repository should be hand-rolled to replace it.
 
 ## 🔧 Profiling Tools
 


### PR DESCRIPTION
Follow-up to #1520 / #1487.

#1520 deleted `src/utils/monitoring.ts` and its tests correctly. Its PR body **also described two documentation fixes.** Those were not in the commit — the PR merged with exactly three files, all deletions.

**Cause:** I edited both docs with a script, which leaves changes unstaged, then committed only what `git rm` had already staged. No `git add` for the docs. The description described work the commit did not contain.

That is the claims-versus-reality defect this milestone existed to remove — committed by me, in the PR that closed it. Recording it rather than quietly folding the files in.

## What `main` says right now

```
performance-testing.md:192   MonitoringManager.getInstance()
                      :200   monitor.getPerformanceReport()
                      :182   ENABLE_MONITORING / MONITORING_LEVEL / PERFORMANCE_LOG_PATH
                      :209   npm run monitor:dashboard
adr-023:162                  cites src/utils/monitoring.ts as a live path
```

None of those methods, env vars or scripts have ever existed — zero matches in `src/`, no such npm script — and the module they document was deleted three commits ago. **So the docs were wrong before #1520, and are now wrong in a second way as well.**

## What this changes

`performance-testing.md`'s Monitoring section is replaced with what is actually wired:

- `enhanced-logging.ts` for operation timing — 31 importers
- `trackToolExecution` for per-tool telemetry — now durable per #1488/#1489
- `ResourceCache` for hit/miss accounting

plus a note that real metrics mean **OpenTelemetry**, whose off-the-shelf packages patch `StdioServerTransport` directly.

`adr-023:162`'s row now records that the disposition was taken, rather than describing a file that no longer exists.

Verified against `main` this time, not against my working tree — which is how the gap went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
