### PR TITLE
fix(ci): build before running tests in publish.yml — 22 releases have not shipped

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -308,10 +308,6 @@ jobs:
         if: ${{ !inputs.skip_tests && !github.event.inputs.skip_tests }}
         run: npm run lint
 
-      - name: Run tests
-        if: ${{ !inputs.skip_tests && !github.event.inputs.skip_tests }}
-        run: npm test
-
       - name: Build project
         run: |
           echo "Building project..."
@@ -334,6 +330,17 @@ jobs:
             echo "❌ Build failed - no dist directory created"
             exit 1
           fi
+
+      # Tests run AFTER the build, not before. tests/integration/mcp-protocol.test.ts
+      # exercises the BUILT server (dist/src/index.js) because that is what ships to npm,
+      # and it fails fast when the artifact is missing. This workflow used to test first,
+      # which broke every publish from v2.6.21 to v2.7.5 -- ten consecutive releases,
+      # none of which reached npm. test.yml already builds first (make node-compat depends
+      # on build); publish.yml did not, and that difference was not checked when the test
+      # was added.
+      - name: Run tests
+        if: ${{ !inputs.skip_tests && !github.event.inputs.skip_tests }}
+        run: npm test
 
       - name: Test MCP server functionality
         run: |


### PR DESCRIPTION
Closes #1484.

Nothing has reached npm since **v2.6.20**. Twenty-two versions — **v2.6.21 through v2.7.17** — are tagged in git and absent from the registry.

```
$ npm view mcp-adr-analysis-server version
2.6.20
$ node -p "require('./package.json').version"
2.7.17
```

## The cause is mine

`tests/integration/mcp-protocol.test.ts` (#1413) exercises the **built** server at `dist/src/index.js`, deliberately — that artifact is what ships to npm, and the gap between "source passes" and "package works" is how the `openai` bug reached users in 2.6.13. It fails fast when the artifact is missing.

`publish.yml` ran:

```
npm ci  ->  npm run lint  ->  npm test  ->  npm run build
                              ^^^^^^^^      ^^^^^^^^^^^^^
                              needs dist/   creates dist/
```

so the test threw the error I wrote:

```
dist/src/index.js not found. Run `npm run build` before this test
```

I verified this ordering in `test.yml`, where `make node-compat` depends on `build` and therefore builds first, and said so on #1453. **I never checked `publish.yml`**, which takes a different path. Verifying one workflow and assuming the other matched is the whole defect.

Reproduced both ways:

```
dist absent  ->  Test Files 1 failed   "dist/src/index.js not found"
after build  ->  Test Files 1 passed,  8 tests
```

## Why it's 22 and not the 10 I first reported

This commit was written yesterday, when the count was 10, and **sat unpushed for a day** while work continued. Auto-release and tagging were never broken — only publish — so every merge since added another stranded version.

Everything landed today is in that set: ADR-023's Decision, the retirement provider binding, the usage-evidence fix, the `monitoring.ts` retirement. **None of it is installable.**

## One publish supersedes all 22

npm publishes whatever `package.json` declares, so a single green run takes `latest` from 2.6.20 to the current version. The stranded tags remain tags with no npm counterpart — option B from #787's remediation list: forward-only, audit history intact. **No per-tag re-dispatch needed.**

## The follow-up that matters more than this fix

`publish.yml:524` already has a **"Verify NPM dist-tags"** step, written for **#787 — this same bug, in April.** It is a step in the same job as `npm test`, so a test failure aborts before it ever runs. It can only execute once publishing has already succeeded.

That is why April's bug recurred in August and cost 22 releases before anyone noticed. The check needs to live where a publish failure cannot skip it — a separate job with `if: always()`, or a scheduled comparison of the newest `v*` tag against `npm view`. Filing separately.

## Note on the branch

The original branch was a day stale; rebasing it would have reverted the day's work. This is the same single commit cherry-picked onto current `main` — **one file, +11 −4**. Structural check: `Build project` precedes `Run tests`, and `- name: Run tests` appears exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
