### PR TITLE
fix(research): perform_research wrote where it never said, and cited no ADRs

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,20 +1,26 @@
 # Research Documentation Index
 
-This directory contains research documentation for the project. Research files are generated dynamically and stored in `docs/context/research/`.
+This directory contains research documentation for the project, written by the
+`perform_research` MCP tool.
 
-**Last Updated**: 2025-12-15
+**Last Updated**: 2026-08-28
 
 ## Research Files Location
 
-All research documentation is stored in:
+- **Location**: `docs/research/` — this directory, and the tool's `researchDirectory` default
+- **Format**: `perform-research-{ISO timestamp}.md`, plus `latest.md` mirroring the most recent
+- **Configurable**: pass `researchDirectory` to `perform_research` to write elsewhere
 
-- **Location**: `docs/context/research/`
-- **Format**: `perform-research-{timestamp}.md`
-- **Example**: `perform-research-2025-12-15T16-45-17-448Z.md`
-
-## Available Research Files
-
-See the [context/research directory](../context/research/) for actual research files.
+> **Corrected 2026-08-28 (#1528).** This file previously stated that research lived in
+> `docs/context/research/`. That was true of the code and false of the tool schema, which
+> advertised `docs/research` — and `perform_research` accepted no output parameter at all, so
+> callers could neither choose nor discover the destination. 187 files accumulated in the
+> undocumented path, untracked by git, while this directory held only this README.
+>
+> The tool now honours `researchDirectory` and defaults to `docs/research/`. The files under
+> `docs/context/research/` are artifacts of the old behaviour; see #1528 for their disposition.
+> `docs/context/` remains in use by the _context-document_ system for other tools, which is a
+> different thing from research output.
 
 ## Research Process
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1484,6 +1484,12 @@ export class McpAdrAnalysisServer {
                   description: 'Directory containing ADR files',
                   default: 'docs/adrs',
                 },
+                researchDirectory: {
+                  type: 'string',
+                  description:
+                    'Directory the research document is written to. Previously unset and unsettable: output went to docs/context/research/ regardless (#1528).',
+                  default: 'docs/research',
+                },
                 confidenceThreshold: {
                   type: 'number',
                   description: 'Minimum confidence threshold (0-1) before suggesting web search',

--- a/src/tools/perform-research-tool.ts
+++ b/src/tools/perform-research-tool.ts
@@ -10,6 +10,7 @@ import type { ToolContext } from '../types/tool-context.js';
 import { ResearchOrchestrator } from '../utils/research-orchestrator.js';
 import { ToolContextManager, type ToolContextDocument } from '../utils/context-document-manager.js';
 import * as path from 'path';
+import { existsSync } from 'fs';
 
 /**
  * Perform research using the orchestrated multi-source approach
@@ -63,8 +64,14 @@ import * as path from 'path';
  * Derived from the project_files source rather than re-globbing the directory:
  * listing every ADR that exists would assert a link the research never made, and
  * an over-broad citation is worse than none -- it makes the link unfalsifiable.
+ *
+ * Exported for test. The citation rule is the whole substance of #1528 -- if it
+ * silently stopped matching, every generated document would go back to citing
+ * nothing and the file would still be written, so the failure is invisible from
+ * the outside. Reaching it through performResearch() would mean standing up the
+ * orchestrator, so the rule is tested directly.
  */
-function collectConsultedAdrs(
+export function collectConsultedAdrs(
   sources: Array<{ type: string; data?: any }>,
   projectPath: string,
   adrDirectory: string
@@ -77,10 +84,28 @@ function collectConsultedAdrs(
   const seen = new Set<string>();
   for (const f of files) {
     if (typeof f !== 'string') continue;
-    const abs = path.resolve(projectPath, f);
-    if (!abs.startsWith(adrRoot + path.sep)) continue;
-    if (!abs.endsWith('.md')) continue;
-    if (path.basename(abs).toLowerCase() === 'readme.md') continue;
+    if (!f.endsWith('.md')) continue;
+    if (path.basename(f).toLowerCase() === 'readme.md') continue;
+
+    // Two path conventions arrive in this one list, because the orchestrator
+    // builds it from two different roots:
+    //
+    //   PHASE 4  findFiles(projectPath, ['**/*<keyword>*'])  -> 'docs/adrs/adr-001.md'
+    //   PHASE 3  findFiles(adrPath,     ['**/*.md'])         -> 'adr-001.md'
+    //
+    // Resolving only against projectPath dropped every PHASE 3 entry -- the
+    // "Always include ADRs" pass, which is the source this citation was written
+    // to read. It looked correct against this repository only because PHASE 4's
+    // keyword search happens to match ADR filenames here.
+    //
+    // Existence is checked rather than inferred: the adrRoot-relative reading of
+    // an arbitrary 'docs/planning/x.md' also lands under adrRoot, so a path test
+    // alone would invent citations. A cited ADR is one that is on disk, which is
+    // also what the link check in #1527 will require.
+    const abs = [path.resolve(projectPath, f), path.resolve(adrRoot, f)].find(
+      candidate => candidate.startsWith(adrRoot + path.sep) && existsSync(candidate)
+    );
+    if (!abs) continue;
     seen.add(path.relative(projectPath, abs));
   }
   return [...seen].sort();

--- a/src/tools/perform-research-tool.ts
+++ b/src/tools/perform-research-tool.ts
@@ -57,11 +57,41 @@ import * as path from 'path';
  * @category Tools
  * @mcp-tool
  */
+/**
+ * Which ADR files did this research actually read?
+ *
+ * Derived from the project_files source rather than re-globbing the directory:
+ * listing every ADR that exists would assert a link the research never made, and
+ * an over-broad citation is worse than none -- it makes the link unfalsifiable.
+ */
+function collectConsultedAdrs(
+  sources: Array<{ type: string; data?: any }>,
+  projectPath: string,
+  adrDirectory: string
+): string[] {
+  const adrRoot = path.resolve(projectPath, adrDirectory);
+  const files = sources
+    .filter(s => s.type === 'project_files')
+    .flatMap(s => (Array.isArray(s.data?.files) ? (s.data.files as string[]) : []));
+
+  const seen = new Set<string>();
+  for (const f of files) {
+    if (typeof f !== 'string') continue;
+    const abs = path.resolve(projectPath, f);
+    if (!abs.startsWith(adrRoot + path.sep)) continue;
+    if (!abs.endsWith('.md')) continue;
+    if (path.basename(abs).toLowerCase() === 'readme.md') continue;
+    seen.add(path.relative(projectPath, abs));
+  }
+  return [...seen].sort();
+}
+
 export async function performResearch(
   args: {
     question: string;
     projectPath?: string;
     adrDirectory?: string;
+    researchDirectory?: string;
     confidenceThreshold?: number;
     performWebSearch?: boolean;
   },
@@ -71,6 +101,7 @@ export async function performResearch(
     question,
     projectPath = process.cwd(),
     adrDirectory = 'docs/adrs',
+    researchDirectory = 'docs/research',
     confidenceThreshold = 0.6,
     performWebSearch = true,
   } = args;
@@ -222,7 +253,11 @@ ${generateSearchQueries(question)
     // Save research context for future sessions
     try {
       const contextManager = new ToolContextManager(projectPath);
-      await contextManager.initialize();
+      // No initialize() call: it eagerly mkdir -p's every category under
+      // docs/context/, which left an empty docs/context/research/ in the user's
+      // tree even when the document was written to researchDirectory. saveContext
+      // creates its own target directory, so initialize() is redundant here and
+      // its only effect was the orphan. (#1528)
 
       const contextDoc: ToolContextDocument = {
         metadata: {
@@ -291,7 +326,17 @@ ${generateSearchQueries(question)
           environmentSpecific: [],
         },
         relatedDocuments: {
-          adrs: [],
+          // The ADRs this research actually consulted, not an empty array.
+          //
+          // research-orchestrator.ts PHASE 3 ("Always include ADRs") globs every
+          // file under adrDirectory into the project_files source, and this write
+          // site used to hardcode `adrs: []` -- discarding it. That single line is
+          // why 187 generated research documents cite zero ADRs between them,
+          // while docs/research/README.md has required since 2025-12 that "all
+          // research must link to relevant ADRs". The field existed, the renderer
+          // existed (context-document-manager.ts:431 emits "**ADRs**:"), and the
+          // data was gathered. Only the assignment was missing. (#1528)
+          adrs: collectConsultedAdrs(research.sources, projectPath, adrDirectory),
           configs: [],
           otherContexts: [],
         },
@@ -306,7 +351,11 @@ ${generateSearchQueries(question)
         },
       };
 
-      await contextManager.saveContext('research', contextDoc);
+      await contextManager.saveContext(
+        'research',
+        contextDoc,
+        path.resolve(projectPath, researchDirectory)
+      );
       context?.info('💾 Research context saved for future reference');
     } catch (contextError) {
       // Don't fail the research if context saving fails

--- a/src/utils/context-document-manager.ts
+++ b/src/utils/context-document-manager.ts
@@ -115,9 +115,26 @@ export class ToolContextManager {
    * @param document - Context document to save
    * @returns Path to the saved document
    */
-  async saveContext(category: string, document: ToolContextDocument): Promise<string> {
+  async saveContext(
+    category: string,
+    document: ToolContextDocument,
+    outputDir?: string
+  ): Promise<string> {
     try {
-      const categoryDir = path.join(this.contextDir, category);
+      // `outputDir` overrides the docs/context/<category> default entirely.
+      //
+      // Why the override exists (#1528): perform_research advertises no output
+      // path and wrote here regardless, so its user-facing artifacts landed in
+      // docs/context/research/ -- a directory no caller could set, discover from
+      // the tool schema, or predict from the docs. 187 files accumulated there,
+      // untracked, while docs/research/ (what the docs describe) held only a
+      // README. A tool's output belongs where the tool says it does.
+      //
+      // Callers that genuinely produce *context documents* -- bootstrap
+      // validation, for one -- pass nothing and keep docs/context/<category>.
+      const categoryDir = outputDir
+        ? path.resolve(outputDir)
+        : path.join(this.contextDir, category);
       await fs.mkdir(categoryDir, { recursive: true });
 
       // Generate filename with timestamp
@@ -132,7 +149,11 @@ export class ToolContextManager {
       await fs.writeFile(filePath, markdown, 'utf-8');
 
       // Update latest.md symlink
-      await this.updateLatestSymlink(category, filePath);
+      // latest.md follows the document. Without passing categoryDir this wrote to
+      // docs/context/<category>/latest.md while the document went elsewhere --
+      // caught by a clean-fixture dogfood run, which produced a research file in
+      // docs/research/ AND an orphan docs/context/research/latest.md (#1528).
+      await this.updateLatestSymlink(category, filePath, categoryDir);
 
       this.logger.info(`Context document saved: ${filePath}`, 'ToolContextManager');
 
@@ -243,9 +264,11 @@ export class ToolContextManager {
    * @param category - Category directory
    * @param filePath - Path to the latest context document
    */
-  async updateLatestSymlink(category: string, filePath: string): Promise<void> {
+  async updateLatestSymlink(category: string, filePath: string, outputDir?: string): Promise<void> {
     try {
-      const latestPath = path.join(this.contextDir, category, 'latest.md');
+      const latestPath = outputDir
+        ? path.join(path.resolve(outputDir), 'latest.md')
+        : path.join(this.contextDir, category, 'latest.md');
 
       // Remove existing latest.md
       try {

--- a/src/utils/context-document-manager.ts
+++ b/src/utils/context-document-manager.ts
@@ -67,9 +67,11 @@ export interface ToolContextDocument {
  */
 export class ToolContextManager {
   private contextDir: string;
+  private projectPath: string;
   private logger: EnhancedLogger;
 
   constructor(projectPath: string) {
+    this.projectPath = path.resolve(projectPath);
     this.contextDir = path.join(projectPath, 'docs', 'context');
     this.logger = new EnhancedLogger();
   }
@@ -143,7 +145,18 @@ export class ToolContextManager {
       const filePath = path.join(categoryDir, filename);
 
       // Generate markdown content
-      const markdown = this.generateMarkdown(document);
+      // The document tells its reader where to find itself. Before #1528 that
+      // sentence was built from the tool name -- docs/context/perform_research/,
+      // a directory that has never existed for any tool -- so every generated
+      // document pointed at nothing. Same defect as the write path, one line
+      // further on: it must name the file that was actually written.
+      const markdown = this.generateMarkdown(
+        document,
+        path
+          .relative(this.projectPath, path.join(categoryDir, 'latest.md'))
+          .split(path.sep)
+          .join('/')
+      );
 
       // Write the file
       await fs.writeFile(filePath, markdown, 'utf-8');
@@ -328,7 +341,7 @@ export class ToolContextManager {
    * @param document - Context document to convert
    * @returns Markdown string
    */
-  generateMarkdown(document: ToolContextDocument): string {
+  generateMarkdown(document: ToolContextDocument, latestPath?: string): string {
     const lines: string[] = [];
 
     // Title and metadata
@@ -441,7 +454,9 @@ export class ToolContextManager {
     lines.push('');
     lines.push('```text');
     lines.push('Example prompt:');
-    lines.push(`"Using the context from docs/context/${document.metadata.toolName}/latest.md,`);
+    lines.push(
+      `"Using the context from ${latestPath ?? `docs/context/${document.metadata.toolName}/latest.md`},`
+    );
     lines.push('continue the work from the previous session"');
     lines.push('```');
     lines.push('');

--- a/src/utils/research-orchestrator.ts
+++ b/src/utils/research-orchestrator.ts
@@ -430,7 +430,10 @@ export class ResearchOrchestrator {
       }
 
       // PHASE 4: Use glob-based file discovery (tree-sitter will analyze content)
-      // Note: Ripgrep removed per ADR-016 - deterministic tools, LLM reasoning
+      // Note: ripgrep was replaced by tree-sitter + glob discovery. The decision
+      // was implemented but never recorded -- this comment cited ADR-016, which
+      // has never existed. See ADR-006 for the tree-sitter rationale; the missing
+      // record is tracked in #1415.
       if (keywords.length > 0) {
         this.logger.info('Using file discovery for keyword-based search', 'ResearchOrchestrator');
 

--- a/src/utils/research-orchestrator.ts
+++ b/src/utils/research-orchestrator.ts
@@ -421,12 +421,24 @@ export class ResearchOrchestrator {
       }
 
       // PHASE 3: Always include ADRs
-      const adrPath = path.join(this.projectPath, this.adrDirectory);
+      //
+      // Scanned from the project root, not from the ADR directory. findFiles
+      // returns paths relative to the root it was given, so scanning adrPath
+      // yielded bare 'adr-001.md' where every other phase yields
+      // 'docs/adrs/adr-001.md'. PHASE 5 then read those bare names -- against
+      // process.cwd(), see below -- they failed, and the relevance filter
+      // dropped them. "Always include ADRs" has therefore included none of
+      // them; any ADR that reached a research document arrived via PHASE 4's
+      // keyword search, by accident of filename. (#1528)
+      const adrGlob = `${this.adrDirectory.replace(/\\/g, '/').replace(/\/+$/, '')}/**/*.md`;
       try {
-        const adrResults = await findFiles(adrPath, ['**/*.md']);
+        const adrResults = await findFiles(this.projectPath, [adrGlob]);
         relevantFiles.push(...adrResults.files.map(f => f.path));
       } catch {
-        this.logger.warn(`ADR directory not found: ${adrPath}`, 'ResearchOrchestrator');
+        this.logger.warn(
+          `ADR directory not found: ${path.join(this.projectPath, this.adrDirectory)}`,
+          'ResearchOrchestrator'
+        );
       }
 
       // PHASE 4: Use glob-based file discovery (tree-sitter will analyze content)
@@ -468,7 +480,14 @@ export class ResearchOrchestrator {
       for (const file of results.files.slice(0, 50)) {
         // Limit to 50 files for performance
         try {
-          const content = await fs.readFile(file, 'utf-8');
+          // Resolved against the project, not the process. These paths are
+          // relative to projectPath, but fs.readFile resolves a relative path
+          // against process.cwd() -- so researching a project other than the
+          // server's own working directory read the wrong files entirely, and
+          // silently: a temp project with no README produced a document quoting
+          // this repository's README.md. It only looked correct because
+          // projectPath and cwd coincide when researching this repo. (#1528)
+          const content = await fs.readFile(path.resolve(this.projectPath, file), 'utf-8');
 
           // Calculate text-based relevance
           const relevance = this.calculateRelevanceLegacy(content, question);

--- a/tests/tools/perform-research-output.test.ts
+++ b/tests/tools/perform-research-output.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Where perform_research writes, and what it cites (#1528).
+ *
+ * The tool advertised no output path and wrote to docs/context/research/ --
+ * a directory no caller could set, discover from the tool schema, or predict
+ * from the docs -- while every document it produced cited zero ADRs.
+ *
+ * Both halves are user-visible facts about files on disk, so both are asserted
+ * against a real run over a throwaway project rather than against the shape of
+ * the source. The orchestrator does no network work here: the answer comes from
+ * project files and an empty knowledge graph.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { performResearch } from '../../src/tools/perform-research-tool.js';
+
+describe('perform_research output (#1528)', () => {
+  let projectPath: string;
+
+  const listFiles = async (dir: string): Promise<string[]> => {
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+    return entries.filter(e => e.isFile()).map(e => e.name);
+  };
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'perform-research-'));
+    await fs.mkdir(path.join(projectPath, 'docs', 'adrs'), { recursive: true });
+    // The filename deliberately does not contain the question's keywords. The
+    // orchestrator's PHASE 4 keyword search matches on filename, so an ADR
+    // called adr-001-caching.md would be found by accident even with PHASE 3
+    // ("Always include ADRs") broken -- which is exactly why the break went
+    // unnoticed. Only PHASE 3 can reach this file.
+    await fs.writeFile(
+      path.join(projectPath, 'docs', 'adrs', 'adr-001-storage-layer.md'),
+      '# ADR-001: Storage Layer\n\n## Status\n\nAccepted\n\n' +
+        'Research results are cached in memory, so caching is handled here.\n'
+    );
+    await fs.writeFile(path.join(projectPath, 'docs', 'adrs', 'README.md'), '# ADR Index\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('writes the research document to docs/research/, and nothing to docs/context/', async () => {
+    await performResearch({ question: 'how is caching handled', projectPath });
+
+    const written = await listFiles(path.join(projectPath, 'docs', 'research'));
+    expect(written.filter(f => f.startsWith('perform-research-'))).toHaveLength(1);
+    expect(written).toContain('latest.md');
+
+    // The orphan a clean-fixture run caught: an empty docs/context/research/
+    // left behind by an eager initialize() at this call site.
+    await expect(fs.access(path.join(projectPath, 'docs', 'context'))).rejects.toThrow();
+  }, 60_000);
+
+  it('honours an explicit researchDirectory', async () => {
+    await performResearch({
+      question: 'how is caching handled',
+      projectPath,
+      researchDirectory: 'notes/spikes',
+    });
+
+    const written = await listFiles(path.join(projectPath, 'notes', 'spikes'));
+    expect(written.filter(f => f.startsWith('perform-research-'))).toHaveLength(1);
+    await expect(fs.access(path.join(projectPath, 'docs', 'research'))).rejects.toThrow();
+  }, 60_000);
+
+  it('cites the ADRs it consulted, and no dead links', async () => {
+    await performResearch({ question: 'how is caching handled', projectPath });
+
+    const doc = await fs.readFile(path.join(projectPath, 'docs', 'research', 'latest.md'), 'utf-8');
+
+    expect(doc).toContain('**ADRs**:');
+    expect(doc).toContain('docs/adrs/adr-001-storage-layer.md');
+    // The index is not a decision.
+    expect(doc).not.toContain('docs/adrs/README.md');
+
+    // Every path under **ADRs**: must exist -- a citation that cannot be opened
+    // is worse than none, and is what the repository-wide check will forbid.
+    const cited = [...doc.matchAll(/^- `(.+\.md)`$/gm)].map(m => m[1]!);
+    expect(cited.length).toBeGreaterThan(0);
+    for (const c of cited) {
+      await expect(fs.access(path.join(projectPath, c))).resolves.toBeUndefined();
+    }
+  }, 60_000);
+
+  it('points the reader at the file it just wrote', async () => {
+    await performResearch({ question: 'how is caching handled', projectPath });
+
+    const doc = await fs.readFile(path.join(projectPath, 'docs', 'research', 'latest.md'), 'utf-8');
+    expect(doc).toContain('docs/research/latest.md');
+  }, 60_000);
+});

--- a/tests/tools/perform-research-tool.test.ts
+++ b/tests/tools/perform-research-tool.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The ADR citation rule (#1528).
+ *
+ * `perform_research` wrote `adrs: []` at its only write site, so every generated
+ * research document cited zero ADRs while docs/research/README.md had required
+ * since 2025-12 that "all research must link to relevant ADRs". The data was
+ * gathered, the renderer existed, the assignment was missing.
+ *
+ * The repair is one function. If it stops matching, the tool keeps writing
+ * documents and they silently go back to citing nothing -- a regression with no
+ * outward symptom, which is why it is pinned here rather than left to the
+ * integration test, which only exercises the CE-MCP directive path.
+ *
+ * These use a real temp project because the rule requires the ADR to exist on
+ * disk. That is not incidental: without it, the ADR-directory-relative reading
+ * of an arbitrary `docs/planning/x.md` also lands under the ADR root, and the
+ * function would invent citations.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { collectConsultedAdrs } from '../../src/tools/perform-research-tool.js';
+
+/** Shape of what research-orchestrator puts in `research.sources`. */
+const filesSource = (files: unknown[]) => ({ type: 'project_files', data: { files } });
+
+const rel = (...parts: string[]) => path.join(...parts);
+
+describe('collectConsultedAdrs (#1528)', () => {
+  let projectPath: string;
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'consulted-adrs-'));
+    const write = async (p: string, body = '# stub\n') => {
+      await fs.mkdir(path.dirname(path.join(projectPath, p)), { recursive: true });
+      await fs.writeFile(path.join(projectPath, p), body);
+    };
+    await write('docs/adrs/adr-001-caching.md');
+    await write('docs/adrs/adr-023-tool-surface-scope.md');
+    await write('docs/adrs/README.md');
+    await write('docs/adrs/index.json', '{}\n');
+    await write('docs/adrs-archive/adr-000-retired.md');
+    await write('docs/planning/roadmap.md');
+    await write('decisions/adr-007-elsewhere.md');
+    await write('src/index.ts', 'export {};\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('cites an ADR reached by a project-relative path (orchestrator PHASE 4)', () => {
+    const sources = [filesSource(['docs/adrs/adr-023-tool-surface-scope.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([
+      rel('docs', 'adrs', 'adr-023-tool-surface-scope.md'),
+    ]);
+  });
+
+  it('cites an ADR reached by an ADR-directory-relative path (orchestrator PHASE 3)', () => {
+    // PHASE 3 is `findFiles(adrPath, ['**/*.md'])` -- the "Always include ADRs"
+    // pass. Its entries are bare filenames. Resolving only against projectPath
+    // dropped all of them, silently, which is the bug this test exists for.
+    const sources = [filesSource(['adr-001-caching.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([
+      rel('docs', 'adrs', 'adr-001-caching.md'),
+    ]);
+  });
+
+  it('returns project-relative paths whichever convention it was given', () => {
+    const sources = [
+      // Deliberately reverse-sorted on input: the citation list must not depend
+      // on the order the orchestrator's phases happened to run in.
+      filesSource([
+        'adr-023-tool-surface-scope.md',
+        'docs/adrs/adr-001-caching.md',
+        path.join(projectPath, 'docs/adrs/adr-001-caching.md'),
+      ]),
+    ];
+
+    const cited = collectConsultedAdrs(sources, projectPath, 'docs/adrs');
+    expect(cited.every(c => !path.isAbsolute(c))).toBe(true);
+    // The same ADR by three spellings collapses to one entry, sorted -- an
+    // unstable list would churn the generated document on every run.
+    expect(cited).toEqual([
+      rel('docs', 'adrs', 'adr-001-caching.md'),
+      rel('docs', 'adrs', 'adr-023-tool-surface-scope.md'),
+    ]);
+  });
+
+  it('does not invent a citation for a markdown file outside the ADR directory', () => {
+    // Under the ADR-relative reading, 'docs/planning/roadmap.md' resolves to
+    // <adrRoot>/docs/planning/roadmap.md -- inside the root by path, absent from
+    // disk. Existence is what separates the two readings.
+    const sources = [filesSource(['docs/planning/roadmap.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([]);
+  });
+
+  it('honours a non-default adrDirectory', () => {
+    const sources = [
+      filesSource(['decisions/adr-007-elsewhere.md', 'docs/adrs/adr-001-caching.md']),
+    ];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'decisions')).toEqual([
+      rel('decisions', 'adr-007-elsewhere.md'),
+    ]);
+  });
+
+  it('excludes the ADR index README', () => {
+    // Every run reads it; citing it as a decision is noise.
+    const sources = [filesSource(['docs/adrs/README.md', 'README.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([]);
+  });
+
+  it('excludes non-markdown files under the ADR directory', () => {
+    const sources = [filesSource(['docs/adrs/index.json', 'docs/adrs/adr-001-caching.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([
+      rel('docs', 'adrs', 'adr-001-caching.md'),
+    ]);
+  });
+
+  it('does not treat a sibling directory with a shared prefix as the ADR directory', () => {
+    const sources = [filesSource(['docs/adrs-archive/adr-000-retired.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([]);
+  });
+
+  it('does not cite an ADR that no longer exists on disk', () => {
+    // A stale entry in a cached source must not produce a dead link -- the same
+    // rule the research-link check will enforce repository-wide (#1527).
+    const sources = [filesSource(['docs/adrs/adr-016-never-written.md'])];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([]);
+  });
+
+  it('ignores sources that are not project_files', () => {
+    const sources = [
+      { type: 'web_search', data: { files: ['docs/adrs/adr-001-caching.md'] } },
+      { type: 'knowledge_graph', data: {} },
+    ];
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([]);
+  });
+
+  it('survives a malformed source rather than throwing mid-write', () => {
+    // saveContext runs inside the tool's try/catch, so a throw here would
+    // discard the whole research document over one bad entry.
+    const sources = [
+      { type: 'project_files' },
+      { type: 'project_files', data: {} },
+      { type: 'project_files', data: { files: 'docs/adrs/adr-001-caching.md' } },
+      filesSource([null, 42, undefined, '', 'docs/adrs/adr-001-caching.md']),
+    ] as Array<{ type: string; data?: any }>;
+
+    expect(collectConsultedAdrs(sources, projectPath, 'docs/adrs')).toEqual([
+      rel('docs', 'adrs', 'adr-001-caching.md'),
+    ]);
+  });
+
+  it('returns an empty list when no ADRs were read, rather than inventing them', () => {
+    // The failure this replaces was `adrs: []` unconditionally. An empty list is
+    // still correct when it is true; what matters is that it is derived.
+    expect(collectConsultedAdrs([filesSource(['src/index.ts'])], projectPath, 'docs/adrs')).toEqual(
+      []
+    );
+    expect(collectConsultedAdrs([], projectPath, 'docs/adrs')).toEqual([]);
+  });
+});

--- a/tests/utils/context-document-manager.test.ts
+++ b/tests/utils/context-document-manager.test.ts
@@ -411,4 +411,96 @@ describe('ToolContextManager', () => {
       expect(markdown).not.toContain('## Raw Data');
     });
   });
+  /**
+   * The output-path override (#1528).
+   *
+   * perform_research advertised no output path and wrote to
+   * docs/context/research/ regardless -- a directory no caller could set,
+   * discover from the tool schema, or predict from the docs. 187 files
+   * accumulated there while docs/research/, which the docs describe, held only
+   * a README. Callers that genuinely produce context documents still pass
+   * nothing and keep the default, so both paths are pinned.
+   */
+  describe('saveContext with an explicit outputDir', () => {
+    const minimalDoc = (): ToolContextDocument => ({
+      metadata: {
+        toolName: 'perform_research',
+        toolVersion: '1.0.0',
+        generated: new Date().toISOString(),
+        projectPath: testProjectPath,
+        projectName: 'test-project',
+        status: 'success',
+      },
+      quickReference: 'Research reference',
+      executionSummary: { status: 'Success', keyFindings: ['Finding'] },
+      detectedContext: {},
+    });
+
+    it('writes the document to outputDir, not docs/context/<category>', async () => {
+      const outputDir = path.join(testProjectPath, 'docs', 'research');
+
+      const filePath = await manager.saveContext('research', minimalDoc(), outputDir);
+
+      expect(path.dirname(filePath)).toBe(outputDir);
+      await expect(fs.readFile(filePath, 'utf-8')).resolves.toContain(
+        '# Tool Context: perform_research'
+      );
+    });
+
+    it('leaves no orphan under docs/context/ when outputDir is given', async () => {
+      // saveContext must not touch the default location as a side effect. The
+      // other half of the orphan -- perform_research calling initialize(), which
+      // mkdir -p'd every category -- is fixed at that call site, not here.
+      const outputDir = path.join(testProjectPath, 'docs', 'research');
+
+      await manager.saveContext('research', minimalDoc(), outputDir);
+
+      await expect(fs.access(path.join(contextDir, 'research'))).rejects.toThrow();
+    });
+
+    it('puts latest.md beside the document it points at', async () => {
+      const outputDir = path.join(testProjectPath, 'docs', 'research');
+
+      await manager.saveContext('research', minimalDoc(), outputDir);
+
+      const latest = await fs.readFile(path.join(outputDir, 'latest.md'), 'utf-8');
+      expect(latest).toContain('# Tool Context: perform_research');
+    });
+
+    it('tells the reader where the document actually is', async () => {
+      // The "How to Reference This Context" line was built from the tool name --
+      // docs/context/perform_research/latest.md -- a path that has never existed
+      // for any tool. A document that misdirects its reader is the same defect
+      // as writing to an undocumented directory, one line further on.
+      const outputDir = path.join(testProjectPath, 'docs', 'research');
+
+      const filePath = await manager.saveContext('research', minimalDoc(), outputDir);
+      const content = await fs.readFile(filePath, 'utf-8');
+
+      expect(content).toContain('docs/research/latest.md');
+      expect(content).not.toContain('docs/context/perform_research');
+    });
+
+    it('resolves a relative outputDir rather than writing one literally', async () => {
+      const outputDir = path.join(testProjectPath, 'docs', '..', 'docs', 'research');
+
+      const filePath = await manager.saveContext('research', minimalDoc(), outputDir);
+
+      expect(filePath).toBe(
+        path.join(testProjectPath, 'docs', 'research', path.basename(filePath))
+      );
+    });
+
+    it('still uses docs/context/<category> when no outputDir is passed', async () => {
+      const filePath = await manager.saveContext('research', minimalDoc());
+
+      expect(path.dirname(filePath)).toBe(path.join(contextDir, 'research'));
+      await expect(fs.readFile(filePath, 'utf-8')).resolves.toContain(
+        'docs/context/research/latest.md'
+      );
+      await expect(
+        fs.readFile(path.join(contextDir, 'research', 'latest.md'), 'utf-8')
+      ).resolves.toContain('# Tool Context: perform_research');
+    });
+  });
 });


### PR DESCRIPTION
Closes #1528.

## The mismatch

| tool | advertised path | actually writes |
|---|---|---|
| `perform_research` | **none** | `docs/context/research/` |
| `incorporate_research` | `docs/research` | **nothing** — prompts |
| `create_research_template` | `docs/research` | **nothing** — static string |

**The tool that writes never advertised a path; the two that advertise one never write.** `ToolContextManager` hardcodes `docs/context` (`context-document-manager.ts:73`), so output landed where no caller could set, discover from the schema, or predict from the docs. 187 files accumulated there, untracked, while `docs/research/` held only a README.

## What changed

- `perform_research` takes `researchDirectory`, default `docs/research`, and honours it
- `saveContext(category, doc, outputDir?)` — explicit override; `bootstrap-validation-loop` passes nothing and is unaffected
- `relatedDocuments.adrs` populated from the ADRs the research **actually consulted**, derived from the `project_files` source rather than re-globbing. Citing all 22 would assert a link the research never made — an over-broad citation is worse than none, because it can't be falsified.
- The generated document's "How to Reference This Context" line was built from the tool name — `docs/context/perform_research/latest.md`, a path that has **never existed for any tool**. It now names the file that was actually written. Same defect as the write path, one line further on.

## Dogfooding caught two bugs in my own fix

Ran the built tool against this repo, then a clean fixture:

1. **`latest.md` still went to the old location** while the document went to `researchDirectory` — an orphan. `updateLatestSymlink` now takes the same `outputDir`.
2. **`initialize()` eagerly `mkdir -p`'d every category under `docs/context/`**, leaving an empty `docs/context/research/` even when writing elsewhere. `saveContext` creates its own target, so the call was redundant and its only effect was the orphan.

**Neither appeared against the real repo**, where `docs/context/` already exists. Only the clean fixture exposed them.

---

# Second pass: Codecov was right, and it found more than coverage

Patch coverage came back **28%** — `perform-research-tool.ts` at **0.00%**, because no test file for it existed at all. Writing the missing tests showed the untested lines were also **wrong**.

## Two claims from the first pass, withdrawn

> *"The data was gathered. Only the assignment was missing."*

**False.** PHASE 3 gathered the ADRs into a form nothing downstream could read, and they were pruned before `results.files` was returned. The assignment was missing *and* the data was never there.

> *"clean fixture — 0 files analyzed → 0 ADRs cited. The second is correct, not a regression."*

**False.** That empty result was the bug, and I explained it away instead of asking why it was empty.

## `collectConsultedAdrs` dropped its main input

Two path conventions arrive in one list, because the orchestrator builds it from two roots:

```
PHASE 4  findFiles(projectPath, ['**/*<keyword>*'])  ->  docs/adrs/adr-001.md
PHASE 3  findFiles(adrPath,     ['**/*.md'])         ->  adr-001.md
```

Resolving everything against `projectPath` dropped **every PHASE 3 entry** — the "Always include ADRs" pass, which is the source this citation was written to read. It looked correct against this repository only because PHASE 4's keyword search happens to match ADR filenames here. Give the fixture an ADR whose name does *not* contain the question's keywords and **neither phase cites it**.

## Two more one-line defects behind it

| where | was | effect |
|---|---|---|
| PHASE 3 | scanned from the ADR directory | paths relative to a root nothing downstream used |
| PHASE 5 | `fs.readFile(file)` on those relative paths | resolved against `process.cwd()`, not the project |

The second is the one that matters outside this repo. Researching any project other than the server's own working directory read **the wrong files**: a temp project containing no README produced a research document quoting *this repository's* `README.md`. `PROJECT_PATH` is configured independently of the server's cwd, so that is the normal deployment, not an edge case.

## Citations must exist on disk

The ADR-relative reading of an arbitrary `docs/planning/x.md` also lands under the ADR root, so a path test alone would **invent** links. Existence is what separates the two readings — and is what the repository-wide check in #1527 will require.

## Verification

**16 new tests.** 12 unit tests for the citation rule against a real temp project; 4 end-to-end tests that run `perform_research` over a throwaway project and assert where the file landed and what it cites.

Every assertion was **mutation-checked** — each fix reverted in turn must fail a test:

| mutation | tests failed |
|---|---|
| `adrs: []` (the original bug) | 6 |
| resolve against `projectPath` only | 1 |
| no existence check | 4 |
| prefix match instead of boundary match | 1 |
| unsorted | 1 |
| README not excluded | 1 |
| PHASE 3 scanned from the ADR dir | 1 |
| PHASE 5 reads against `process.cwd()` | 1 |

The first draft of the sort assertion **passed** its mutation — the fixture happened to be in order. Fixed by reversing the input, which is the only reason that assertion means anything.

Full suite: **3046 passed, 70 skipped, 0 failed**, twice — once locally and once in the pre-push hook after rebasing onto `main`.

## Also

- `research-orchestrator.ts:433` cited **ADR-016** for the ripgrep removal. ADR-016 has never existed; the decision was implemented and never recorded. Corrected to ADR-006, gap tracked in #1415.
- `docs/research/README.md` described the old path. Corrected, with the reason.

## Still open, not in this PR

`research-index-resource.ts` parses `docs/research/` filenames by splitting on `_`, so it cannot classify anything the live tool writes — its own documented example is a leaked test fixture. Filed as **#1530**.

## A claim I withdraw (first pass)

I reported that `create_research_template`'s `adrDirectory` was described as *"Path to research directory."* **It is not** — both occurrences of that string belong to `researchPath` params, where it's correct. I misread a `sed` range and annotated the wrong parameter. No change was needed and none was made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
