### PR TITLE
docs(adr-023): retirement admissions route to Cleanup, not CE-MCP

### DIFF
--- a/docs/adrs/adr-023-tool-surface-scope.md
+++ b/docs/adrs/adr-023-tool-surface-scope.md
@@ -244,6 +244,20 @@ deferral this section originally implied.
 Whether any of the 11 is ever deleted. That is `retirement.py`'s question, asked per
 asset, each with its own admission under the CE-MCP migration milestone.
 
+> **Correction (2026-08-28).** That routing was unworkable as written. The CE-MCP
+> migration milestone's own description says it _"stays empty until #1416 lands: the
+> batches are defined BY the registry"_ — so a retirement admitted there would have
+> been blocked behind an unassigned issue. Acting on the sentence above, #1537 and
+> #1538 were filed into that milestone and broke its precondition within the hour.
+>
+> Retirement admissions now go to the **Cleanup** milestone, which has no such
+> precondition. The CE-MCP milestone keeps only what ADR-021 requires of it: the
+> per-batch migration, still empty until #1416.
+>
+> The substance is unchanged — per asset, `retirement.py` first, its own admission,
+> and `RETIREMENT_REVIEW` is the expected verdict rather than a blocker. Only the
+> container moves.
+
 ## Consequences
 
 **It resizes queued work.** 75 − 11 host-native − 10 aggregator = **54**. #1416 builds a


### PR DESCRIPTION
## The conflict

ADR-023 sends per-asset retirement admissions *"under the CE-MCP migration milestone"* (`:244-245`).

That milestone's own description says:

> Stays empty until #1416 lands: the batches are defined BY the registry.

So the routing pointed retirements at a container that cannot accept them, behind an issue nobody is assigned to.

## How it surfaced

I acted on the sentence. #1537 and #1538 were filed into milestone 5 on ADR-023's authority and broke its precondition within the hour. The conflict was not theoretical.

## The fix

Retirements go to the new **Cleanup — delete what does not work** milestone, which has no such precondition. Milestone 5 keeps only what ADR-021 requires of it — the per-batch CE-MCP migration — and is back to empty.

Substance is unchanged: per asset, `retirement.py` first, its own admission, and `RETIREMENT_REVIEW` expected rather than treated as a blocker. Only the container moves.

Written as an inline **Correction** block rather than an edit to the original sentence, so the record shows both what was decided and what was found wrong — the same shape `check-adr-drift.sh` already understands (`adr_live_text()` strips Correction sections before checking drift).

`bash scripts/check-adr-drift.sh` — `drift: 1  baseline: 1  OK`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev