### PR TITLE
fix(bootstrap): stop handing agents `kubectl delete` scoped to a guess

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -874,6 +874,11 @@ export class McpAdrAnalysisServer {
                     'Set to true to request deployment cleanup/teardown guidance (for CI/CD workflows that need to delete and restart deployments).',
                   default: false,
                 },
+                appSelector: {
+                  type: 'string',
+                  description:
+                    'Label selector scoping every destructive teardown command, e.g. "app=checkout-api". Required before any kubectl/oc delete is offered — the tool will not guess a selector, and without this it returns discovery instructions instead of a delete.',
+                },
                 conversationContext: CONVERSATION_CONTEXT_SCHEMA,
               },
             },

--- a/src/tools/bootstrap-validation-loop-tool.ts
+++ b/src/tools/bootstrap-validation-loop-tool.ts
@@ -2162,6 +2162,11 @@ async function generateGuidedExecutionInstructions(params: {
   previousExecutionOutput: string;
   previousExecutionSuccess: boolean;
   deploymentCleanupRequested: boolean;
+  /**
+   * Label selector scoping every destructive teardown command, e.g. `app=checkout-api`.
+   * Supplied by the caller; never guessed. Without it no delete is emitted. (#1536)
+   */
+  appSelector?: string | undefined;
 }): Promise<any> {
   const {
     projectPath,
@@ -2170,6 +2175,7 @@ async function generateGuidedExecutionInstructions(params: {
     currentIteration,
     previousExecutionOutput,
     previousExecutionSuccess,
+    appSelector,
   } = params;
 
   // PHASE 0: Environment Validation (Iteration 0)
@@ -2279,27 +2285,46 @@ ${platformDetection.evidence
     const platformDetection = await detectPlatforms(projectPath);
     const detectedPlatform = platformDetection.primaryPlatform || 'unknown';
 
+    // Every command below is handed to a calling agent to run, so scope is the
+    // whole safety property. Two rules, both learned the hard way (#1536):
+    //
+    //   1. A destructive selector is never guessed. The table used to hardcode
+    //      `app=myapp`, which for almost every user matched nothing -- deleting
+    //      nothing and reporting success, a false green in a validation tool --
+    //      and for anyone who did use that label, destroyed their workload.
+    //   2. Nothing reaches outside the project. `docker system prune -f` removed
+    //      stopped containers, unused networks and dangling images belonging to
+    //      every other project on the host.
+    //
+    // Without a selector the tool emits DISCOVERY steps instead of a delete. That
+    // is the deterministic contract the rest of this server follows: the server
+    // does not invent the input, it says how to obtain it.
+    const kubeCleanup = (cli: 'kubectl' | 'oc') =>
+      appSelector
+        ? {
+            teardown: `${cli} delete deployment,service,configmap,secret -l ${appSelector}`,
+            verify: `${cli} get all -l ${appSelector}`,
+            restart: './bootstrap.sh',
+          }
+        : {
+            teardown: `${cli} get all --show-labels`,
+            verify: `echo "No teardown run: re-invoke with appSelector once the label is known."`,
+            restart: './bootstrap.sh',
+          };
+
     const cleanupCommands: {
       [key: string]: { teardown: string; verify: string; restart: string };
     } = {
-      openshift: {
-        teardown:
-          'oc delete all --selector app=myapp && oc delete configmap --selector app=myapp && oc delete secret --selector app=myapp',
-        verify: 'oc get all --selector app=myapp',
-        restart: './bootstrap.sh',
-      },
-      kubernetes: {
-        teardown: 'kubectl delete deployment,service,configmap,secret -l app=myapp',
-        verify: 'kubectl get all -l app=myapp',
-        restart: './bootstrap.sh',
-      },
+      openshift: kubeCleanup('oc'),
+      kubernetes: kubeCleanup('kubectl'),
+      // `down -v` is scoped to the compose project; a bare `prune` is not.
       docker: {
-        teardown: 'docker-compose down -v && docker system prune -f',
+        teardown: 'docker-compose down -v',
         verify: 'docker ps -a',
         restart: 'docker-compose up -d',
       },
       'docker-compose': {
-        teardown: 'docker-compose down -v && docker system prune -f',
+        teardown: 'docker-compose down -v',
         verify: 'docker ps -a && docker volume ls',
         restart: 'docker-compose up -d',
       },
@@ -2310,6 +2335,8 @@ ${platformDetection.evidence
       verify: 'echo "Manual verification required"',
       restart: './bootstrap.sh',
     };
+
+    const needsSelector = !appSelector && ['kubernetes', 'openshift'].includes(detectedPlatform);
 
     return {
       content: [
@@ -2324,9 +2351,22 @@ ${platformDetection.evidence
 
 This workflow is designed for CI/CD pipelines that need to completely tear down and restart deployments.
 
-### Step 1: Teardown Current Deployment
+### Step 1: ${needsSelector ? 'Identify what to tear down' : 'Teardown Current Deployment'}
 
-**IMPORTANT**: This will DELETE all resources. Confirm with human before proceeding.
+${
+  needsSelector
+    ? `**No teardown command is offered yet.** This tool was not told which workload it may
+delete, and it will not guess a label selector: a guess either matches nothing and reports a
+successful cleanup that removed nothing, or matches somebody else's workload and destroys it.
+
+Run this to see what is deployed and how it is labelled:
+\`\`\`bash
+${cleanup.teardown}
+\`\`\`
+
+Then call this tool again with \`appSelector\` set, e.g. \`"appSelector": "app=checkout-api"\`,
+and the scoped delete command will be provided.`
+    : `**IMPORTANT**: This will DELETE all resources matching \`${appSelector}\`. Confirm with human before proceeding.
 
 Run:
 \`\`\`bash
@@ -2334,9 +2374,9 @@ ${cleanup.teardown}
 \`\`\`
 
 **What this does**:
-- Deletes all deployments, services, and resources
-- Removes configuration and secrets
-- Cleans up volumes and persistent data
+- Deletes deployments, services, configmaps and secrets matching \`${appSelector}\`
+- Leaves everything outside that selector untouched`
+}
 
 ### Step 2: Verify Cleanup
 
@@ -2525,6 +2565,11 @@ export async function bootstrapValidationLoop(args: {
   previousExecutionOutput?: string;
   previousExecutionSuccess?: boolean;
   deploymentCleanupRequested?: boolean;
+  /**
+   * Label selector scoping destructive teardown commands, e.g. `app=checkout-api`.
+   * Required before any delete is offered; never inferred from the project. (#1536)
+   */
+  appSelector?: string;
 }): Promise<any> {
   const {
     projectPath = process.cwd(),
@@ -2537,6 +2582,7 @@ export async function bootstrapValidationLoop(args: {
     previousExecutionOutput = '',
     previousExecutionSuccess = false,
     deploymentCleanupRequested = false,
+    appSelector,
   } = args;
 
   const loop = new BootstrapValidationLoop(projectPath, adrDirectory, maxIterations);
@@ -2556,6 +2602,7 @@ export async function bootstrapValidationLoop(args: {
     previousExecutionOutput,
     previousExecutionSuccess,
     deploymentCleanupRequested,
+    appSelector,
   });
 }
 

--- a/tests/tools/bootstrap-validation-loop-tool.test.ts
+++ b/tests/tools/bootstrap-validation-loop-tool.test.ts
@@ -119,6 +119,91 @@ describe('Bootstrap Validation Loop Tool', () => {
     });
   });
 
+  /**
+   * The teardown commands are handed to a calling agent to run (#1536).
+   *
+   * The tool registers itself as "GUIDED EXECUTION MODE ... it tells YOU what
+   * commands to run". Two things were wrong with what it told them:
+   *
+   *  - the Kubernetes/OpenShift selector was the literal `app=myapp`, derived
+   *    from nothing. For almost every user it matches nothing and the teardown
+   *    reports success having deleted nothing -- a false green in a validation
+   *    tool. For anyone who does label a workload `app=myapp`, an auto-approving
+   *    agent destroys their deployments, services, configmaps and secrets.
+   *  - the Docker teardown ran `docker system prune -f`, which is machine-wide.
+   *    It removes stopped containers, unused networks and dangling images
+   *    belonging to every other project on the host.
+   *
+   * Neither was caught because the tests asserted the strings the tool emitted.
+   * These assert the property instead: a destructive command is only emitted
+   * when its scope was supplied, and no emitted command reaches beyond it.
+   */
+  describe('emitted teardown commands are scoped (#1536)', () => {
+    const cleanup = async (platform: string, extra: Record<string, unknown> = {}) => {
+      mockDetectPlatforms.mockResolvedValue({
+        primaryPlatform: platform,
+        secondaryPlatforms: [],
+        confidence: 0.9,
+        evidence: [],
+      });
+      const result = await bootstrapValidationLoop({
+        projectPath: '/test/project',
+        currentIteration: 1,
+        deploymentCleanupRequested: true,
+        ...extra,
+      });
+      return result.content[0].text as string;
+    };
+
+    it.each(['kubernetes', 'openshift'])(
+      'emits no delete command for %s when no app selector was given',
+      async platform => {
+        const text = await cleanup(platform);
+
+        // A guessed selector is worse than none: it either deletes nothing and
+        // reports success, or deletes someone else's workload.
+        expect(text).not.toMatch(/kubectl\s+delete/);
+        expect(text).not.toMatch(/oc\s+delete/);
+      }
+    );
+
+    it.each(['kubernetes', 'openshift'])(
+      'never emits the hardcoded app=myapp selector for %s',
+      async platform => {
+        expect(await cleanup(platform)).not.toContain('myapp');
+      }
+    );
+
+    it.each(['kubernetes', 'openshift'])(
+      'emits a delete scoped to the selector it was given, for %s',
+      async platform => {
+        const text = await cleanup(platform, { appSelector: 'app=checkout-api' });
+
+        expect(text).toContain('app=checkout-api');
+        expect(text).not.toContain('myapp');
+        expect(text).toMatch(/(kubectl|oc)\s+delete/);
+      }
+    );
+
+    it.each(['docker', 'docker-compose'])(
+      'does not prune the whole machine for %s',
+      async platform => {
+        const text = await cleanup(platform);
+
+        // `docker-compose down -v` is scoped to the compose project.
+        // `docker system prune` is not scoped to anything.
+        expect(text).not.toContain('docker system prune');
+      }
+    );
+
+    it('tells the caller how to find the selector when it does not have one', async () => {
+      const text = await cleanup('kubernetes');
+
+      // Determinism: the server does not guess the scope, it says how to obtain it.
+      expect(text).toMatch(/--show-labels|appSelector/);
+    });
+  });
+
   describe('CI/CD Deployment Cleanup Workflow', () => {
     it('should provide OpenShift cleanup instructions when requested', async () => {
       mockDetectPlatforms.mockResolvedValue({
@@ -135,8 +220,8 @@ describe('Bootstrap Validation Loop Tool', () => {
       });
 
       expect(result.content[0].text).toContain('Deployment Cleanup & Restart');
-      expect(result.content[0].text).toContain('oc delete all --selector');
-      expect(result.content[0].text).toContain('oc get all --selector');
+      // No appSelector was passed, so no delete is offered -- discovery instead (#1536).
+      expect(result.content[0].text).toContain('oc get all --show-labels');
       expect(result.content[0].text).toContain('./bootstrap.sh');
       expect(result.isError).toBe(false);
     });
@@ -155,8 +240,8 @@ describe('Bootstrap Validation Loop Tool', () => {
         deploymentCleanupRequested: true,
       });
 
-      expect(result.content[0].text).toContain('kubectl delete deployment');
-      expect(result.content[0].text).toContain('kubectl get all');
+      // Was `kubectl delete ... -l app=myapp`; a delete now requires appSelector (#1536).
+      expect(result.content[0].text).toContain('kubectl get all --show-labels');
       expect(result.isError).toBe(false);
     });
 
@@ -175,7 +260,8 @@ describe('Bootstrap Validation Loop Tool', () => {
       });
 
       expect(result.content[0].text).toContain('docker-compose down -v');
-      expect(result.content[0].text).toContain('docker system prune');
+      // `docker system prune` reached every other project on the host (#1536).
+      expect(result.content[0].text).not.toContain('docker system prune');
       expect(result.content[0].text).toContain('docker ps -a');
       expect(result.isError).toBe(false);
     });
@@ -192,11 +278,32 @@ describe('Bootstrap Validation Loop Tool', () => {
         projectPath: '/test/project',
         currentIteration: 1,
         deploymentCleanupRequested: true,
+        appSelector: 'app=checkout-api',
       });
 
+      // The warning belongs on the path that actually offers a delete. Without a
+      // selector there is nothing to warn about, because nothing is offered (#1536).
       expect(result.content[0].text).toContain('DELETE all resources');
       expect(result.content[0].text).toContain('Confirm with human');
       expect(result.isError).toBe(false);
+    });
+
+    it('does not warn about deletion when no deletion is offered', async () => {
+      mockDetectPlatforms.mockResolvedValue({
+        primaryPlatform: 'openshift',
+        secondaryPlatforms: [],
+        confidence: 0.9,
+        evidence: [],
+      });
+
+      const result = await bootstrapValidationLoop({
+        projectPath: '/test/project',
+        currentIteration: 1,
+        deploymentCleanupRequested: true,
+      });
+
+      // A destruction warning with no destructive command trains readers to skim it.
+      expect(result.content[0].text).not.toContain('DELETE all resources');
     });
   });
 


### PR DESCRIPTION
Closes #1536. First issue in the Cleanup milestone.

## What the tool was telling agents to run

`bootstrap_validation_loop` registers as **"GUIDED EXECUTION MODE ... it tells YOU what commands to run"**. Two of those commands were unsafe.

```bash
# selector derived from nothing
oc delete all --selector app=myapp && oc delete configmap --selector app=myapp && ...
kubectl delete deployment,service,configmap,secret -l app=myapp

# scoped to the whole host, not the project
docker-compose down -v && docker system prune -f
```

**The selector.** For almost every user `app=myapp` matches nothing, so the teardown deletes nothing and reports success — a false green in a tool whose entire job is validation. For anyone who *does* label a workload `app=myapp`, an agent running with auto-approval destroys their deployments, services, configmaps and secrets.

**The prune.** `docker system prune -f` removes stopped containers, unused networks and dangling images belonging to every other project on the machine. `docker-compose down -v` alone is scoped to the compose project, which is what was wanted.

## Why it survived

The tests asserted the strings the tool emitted:

```ts
expect(result.content[0].text).toContain('docker system prune');
expect(result.content[0].text).toContain('oc delete all --selector');
```

So the machine-wide prune was **required** to pass, and a wrong selector was invisible. Those four tests are rewritten to assert the property rather than the string.

## The fix

Follows the deterministic contract the rest of this server uses: **the server does not invent the input, it says how to obtain it.**

- A destructive command is offered only when the caller supplies `appSelector` (new, in the MCP schema with a description saying why).
- Without one, the tool returns `kubectl get all --show-labels` and asks to be called again with the selector.
- `docker system prune -f` removed; `docker-compose down -v` kept.
- The "**This will DELETE all resources**" warning moves to the path that actually offers a delete — a destruction warning with no destructive command trains readers to skim it.

## Verified over the wire, not by grep

Against the **built** server, since the four defect classes found this week were all caught at that boundary:

```
appSelector in schema: true
no-selector   -> myapp: false | kubectl delete: false | oc delete: false | system prune: false
with-selector -> app=checkout-api: true | myapp: false
```

Six new assertions, each mutation-checked:

| mutation | tests failed |
|---|---|
| hardcoded `app=myapp` selector restored | 2 |
| machine-wide `docker system prune` restored | 2 |
| delete emitted without a selector | 4 |

Full suite: **3056 passed, 70 skipped, 0 failed.**

## Not in scope

The ~2,300 lines of dead engine in this same file — `executeLoop` has zero callers — are #1538, gated by `retirement.py` with its own admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev