### PR TITLE
fix(cache): bound the resource cache Map on write, drop the dead timer API

### DIFF
--- a/src/resources/resource-cache.ts
+++ b/src/resources/resource-cache.ts
@@ -32,6 +32,16 @@ export interface CacheStats {
 /**
  * Resource cache with TTL support and statistics tracking
  */
+/**
+ * Hard ceiling on cached entries.
+ *
+ * The Map used to be unbounded (#1542). Lazy expiry in `get` only removes an
+ * entry that is READ AGAIN after expiring, so anything queried once -- a one-off
+ * resource URI, a per-project key -- stayed for the life of the process, which
+ * under stdio transport is the whole session.
+ */
+export const MAX_CACHE_ENTRIES = 500;
+
 export class ResourceCache {
   private cache = new Map<string, CacheEntry>();
   private hits = 0;
@@ -232,6 +242,19 @@ export class ResourceCache {
       entry.metadata = resourceMetadata;
     }
 
+    // Bound on write rather than on a timer. `startAutomaticCleanup` scheduled the
+    // only bulk sweep and had zero callers, so the sweep never ran; and a cache
+    // whose correctness depends on a background interval having been started is
+    // unbounded whenever it was not. A setInterval would also hold the stdio event
+    // loop open. Expired entries go first, so a live entry is never evicted to make
+    // room while dead ones remain. (#1542)
+    if (this.cache.size >= MAX_CACHE_ENTRIES) {
+      this.cleanup();
+      if (this.cache.size >= MAX_CACHE_ENTRIES) {
+        this.evictLRU(MAX_CACHE_ENTRIES - 1);
+      }
+    }
+
     this.cache.set(key, entry);
   }
 
@@ -396,33 +419,6 @@ export class ResourceCache {
  * Singleton resource cache instance
  */
 export const resourceCache = new ResourceCache();
-
-/**
- * Start automatic cleanup interval
- * Cleans up expired entries every 5 minutes
- */
-let cleanupInterval: NodeJS.Timeout | null = null;
-
-export function startAutomaticCleanup(intervalMs: number = 5 * 60 * 1000): void {
-  if (cleanupInterval) {
-    clearInterval(cleanupInterval);
-  }
-
-  cleanupInterval = setInterval(() => {
-    const removed = resourceCache.cleanup();
-    if (removed > 0) {
-      // NOTE: All console output goes to stderr to preserve stdout for MCP JSON-RPC
-      console.error(`[ResourceCache] Cleaned up ${removed} expired entries`);
-    }
-  }, intervalMs);
-}
-
-export function stopAutomaticCleanup(): void {
-  if (cleanupInterval) {
-    clearInterval(cleanupInterval);
-    cleanupInterval = null;
-  }
-}
 
 /**
  * Generate ETag for resource data

--- a/tests/resources/resource-cache.test.ts
+++ b/tests/resources/resource-cache.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The cache Map was unbounded (#1542).
+ *
+ * Three eviction mechanisms existed. One worked:
+ *
+ *   - lazy expiry on read (`get`) deleted an expired entry when it was read again
+ *   - `cleanup()`, the bulk sweep, was scheduled only by `startAutomaticCleanup`,
+ *     which had zero callers
+ *   - `evictLRU()` had zero callers, so nothing capped the size
+ *
+ * So the entries that accumulated were exactly the ones NEVER READ AGAIN — one-off
+ * resource URIs, per-project keys, anything queried once. Under stdio transport the
+ * process is long-lived, so that is the whole session.
+ *
+ * The fix bounds on write rather than on a timer. A `setInterval` under stdio keeps
+ * the event loop alive, and a cache whose correctness depends on a background timer
+ * having been started is a cache that is unbounded whenever it was not.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ResourceCache, MAX_CACHE_ENTRIES } from '../../src/resources/resource-cache.js';
+
+describe('ResourceCache bounds (#1542)', () => {
+  let cache: ResourceCache;
+
+  beforeEach(() => {
+    cache = new ResourceCache();
+  });
+
+  it('does not grow without bound when entries expire unread', async () => {
+    // The exact leak: written, expired, never read back, so lazy expiry never fires.
+    for (let i = 0; i < MAX_CACHE_ENTRIES * 2; i++) {
+      cache.set(`expired-${i}`, { i }, -1); // already expired
+    }
+
+    expect(cache.getStats().totalEntries).toBeLessThanOrEqual(MAX_CACHE_ENTRIES);
+  });
+
+  it('caps live entries and evicts least-recently-used first', async () => {
+    for (let i = 0; i < MAX_CACHE_ENTRIES; i++) {
+      cache.set(`live-${i}`, { i }, 3600);
+    }
+    // Touch the oldest so it is no longer the LRU candidate.
+    expect(await cache.get('live-0')).not.toBeNull();
+
+    for (let i = 0; i < 10; i++) {
+      cache.set(`overflow-${i}`, { i }, 3600);
+    }
+
+    expect(cache.getStats().totalEntries).toBeLessThanOrEqual(MAX_CACHE_ENTRIES);
+    expect(
+      await cache.get('live-0'),
+      'a recently-read entry should survive eviction'
+    ).not.toBeNull();
+    expect(await cache.get('overflow-9'), 'the newest entry should survive').not.toBeNull();
+  });
+
+  it('prefers dropping expired entries over evicting live ones', async () => {
+    for (let i = 0; i < MAX_CACHE_ENTRIES; i++) {
+      cache.set(`stale-${i}`, { i }, -1);
+    }
+    cache.set('fresh', { v: 1 }, 3600);
+
+    expect(
+      await cache.get('fresh'),
+      'a live entry must not be evicted to make room'
+    ).not.toBeNull();
+
+    // The discriminating assertion: sweeping expired entries first clears all of
+    // them, so the cache collapses to roughly the live set. Evicting by LRU alone
+    // would only shed enough to get under the cap, leaving the rest of the dead
+    // entries resident.
+    expect(cache.getStats().totalEntries).toBeLessThan(MAX_CACHE_ENTRIES / 2);
+  });
+
+  it('still serves what it stores', async () => {
+    cache.set('k', { v: 42 }, 3600);
+    expect(await cache.get('k')).toEqual({ v: 42 });
+  });
+
+  it('exposes no timer-based cleanup API', async () => {
+    // Correctness must not depend on a background interval having been started,
+    // and no interval should be able to hold the stdio event loop open.
+    const mod: Record<string, unknown> = await import('../../src/resources/resource-cache.js');
+    expect(mod['startAutomaticCleanup']).toBeUndefined();
+    expect(mod['stopAutomaticCleanup']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1542.

## Three eviction mechanisms, one of them working

| mechanism | state |
|---|---|
| lazy expiry in `get` | **works** — deletes an entry read again after expiring |
| `cleanup()` bulk sweep | scheduled only by `startAutomaticCleanup`, which had **zero callers** |
| `evictLRU()` | **zero callers** — nothing capped the size |

## The consequence, stated precisely

Not "the cache never sweeps". Lazy expiry does work. What accumulated were exactly the entries **never read again** — a one-off resource URI, a per-project key, anything queried once. Under stdio transport the process is long-lived, so that is the whole session.

Worth being narrow about it: my first framing of this was broader than the evidence, and checking `get` is what corrected it.

## Bounded on write, not by restoring the timer

Two reasons for not simply calling `startAutomaticCleanup` somewhere:

1. A cache whose correctness depends on a background interval having been started is unbounded whenever it was not. Bounding in `set()` cannot be forgotten.
2. A `setInterval` holds the stdio event loop open.

Expired entries are swept before LRU eviction, so a live entry is never dropped while dead ones remain. `startAutomaticCleanup` / `stopAutomaticCleanup` are removed rather than wired — nothing referenced them, and keeping an unused timer API invites exactly the hazard above.

## Mutation-checked, including one that caught me out

| mutation | tests failed |
|---|---|
| bound removed entirely (the original unbounded Map) | 2 |
| expired entries no longer swept before LRU eviction | 1 |

The first draft of that second assertion **passed** its mutation — LRU order alone happened to spare the live entry, so the test proved nothing. Rewritten to assert the cache collapses to roughly the live set, which discriminates. Same failure mode as the sort assertion in #1529; worth assuming until disproved.

Full suite: **3051 passed, 70 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev