### PR TITLE
fix(adr): validate_all_adrs derives its verdict instead of asserting one

### DIFF
--- a/src/tools/adr-validation-tool.ts
+++ b/src/tools/adr-validation-tool.ts
@@ -10,7 +10,6 @@
 import { McpAdrError } from '../types/index.js';
 import { ResearchOrchestrator } from '../utils/research-orchestrator.js';
 import { getAIExecutor } from '../utils/ai-executor.js';
-import { KnowledgeGraphManager } from '../utils/knowledge-graph-manager.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -95,6 +94,33 @@ export async function validateAdr(args: {
   includeEnvironmentCheck?: boolean;
   confidenceThreshold?: number;
 }): Promise<any> {
+  const { result, research, aiAvailable } = await computeAdrValidation(args);
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: formatValidationResponse(result, research, aiAvailable),
+      },
+    ],
+  };
+}
+
+/**
+ * Compute a validation result for one ADR.
+ *
+ * Split out of `validateAdr` because `validateAllAdrs` needs the STRUCTURE, and
+ * previously had no way to get it: `validateAdr` returned formatted markdown, so
+ * the bulk path awaited it, discarded the return, and pushed `isValid: true`
+ * unconditionally. Every summary reported 100% valid and 0 critical issues. (#1539)
+ */
+async function computeAdrValidation(args: {
+  adrPath: string;
+  projectPath?: string;
+  adrDirectory?: string;
+  includeEnvironmentCheck?: boolean;
+  confidenceThreshold?: number;
+}): Promise<{ result: ADRValidationResult; research: any; aiAvailable: boolean }> {
   const {
     adrPath,
     projectPath = process.cwd(),
@@ -204,24 +230,13 @@ Return JSON with:
       validationResult = performRuleBasedValidation(fullAdrPath, adrTitle, adrDecision, research);
     }
 
-    // Step 5: Check knowledge graph for related ADRs
-    const kgManager = new KnowledgeGraphManager();
-    const relatedAdrs = kgManager.getRelationships('adr', 'relates-to') || [];
-
-    // Step 6: Format response
-    return {
-      content: [
-        {
-          type: 'text',
-          text: formatValidationResponse(
-            validationResult,
-            research,
-            relatedAdrs,
-            aiExecutor.isAvailable()
-          ),
-        },
-      ],
-    };
+    // The "related ADRs" step is gone. It called
+    // KnowledgeGraphManager.getRelationships, which is @deprecated and returns []
+    // unconditionally, and rendered the empty result as a section of the report.
+    // A heading that is always empty because its source is a stub is worse than
+    // no heading. `queryKnowledgeGraph` is the documented replacement if this is
+    // ever wanted back. (#1539)
+    return { result: validationResult, research, aiAvailable: aiExecutor.isAvailable() };
   } catch (error) {
     throw new McpAdrError(
       `ADR validation failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -257,8 +272,11 @@ export async function validateAllAdrs(args: {
 
     for (const adrFile of adrFiles) {
       try {
-        // Validate individual ADR - result extraction will be added later
-        await validateAdr({
+        // The verdict comes from the validation, not from a literal. This loop
+        // used to `await validateAdr(...)` for its side effects, throw the return
+        // away, and push `isValid: true` -- so every summary read 100% valid and
+        // 0 critical issues regardless of what was in docs/adrs/. (#1539)
+        const { result } = await computeAdrValidation({
           adrPath: path.join(adrDirectory, adrFile),
           projectPath,
           adrDirectory,
@@ -266,17 +284,7 @@ export async function validateAllAdrs(args: {
           confidenceThreshold: minConfidence,
         });
 
-        // Extract validation result from response
-        // This is a simplified extraction - in production would parse the response
-        results.push({
-          adrPath: path.join(fullAdrDir, adrFile),
-          adrTitle: adrFile,
-          isValid: true,
-          confidence: 0.8,
-          findings: [],
-          recommendations: [],
-          researchData: { sources: [], confidence: 0.8, needsWebSearch: false },
-        });
+        results.push(result);
       } catch (error) {
         console.warn(`Failed to validate ${adrFile}:`, error);
       }
@@ -354,10 +362,26 @@ function extractAdrContext(content: string): string {
 function performRuleBasedValidation(
   adrPath: string,
   adrTitle: string,
-  _adrDecision: string,
+  adrDecision: string,
   research: any
 ): ADRValidationResult {
   const findings: ADRValidationResult['findings'] = [];
+
+  // An ADR whose Decision section is absent or empty records no decision. Before
+  // #1539 this path could only emit medium/low findings, so `isValid` -- computed
+  // as "no critical or high findings" -- was true for every ADR ever passed to it.
+  // The rule needed at least one condition it could actually fail.
+  //
+  // Not hypothetical: ADR-023 shipped Accepted with an empty Decision and needed
+  // #1490 to record one.
+  if (!adrDecision || adrDecision === 'No decision section found') {
+    findings.push({
+      type: 'missing_evidence',
+      severity: 'critical',
+      description: 'ADR records no decision - the Decision section is missing or empty',
+      evidence: `No "## Decision" content found in ${adrPath}`,
+    });
+  }
 
   // Check if research confidence is low
   if (research.confidence < 0.5) {
@@ -400,7 +424,6 @@ function performRuleBasedValidation(
 function formatValidationResponse(
   result: ADRValidationResult,
   research: any,
-  relatedAdrs: any[],
   aiEnabled: boolean
 ): string {
   return `# ADR Validation Report
@@ -443,9 +466,6 @@ ${
 
 ${result.recommendations.map(rec => `- ${rec}`).join('\n')}
 
-## Related ADRs
-
-${relatedAdrs.length > 0 ? relatedAdrs.map(adr => `- ${adr}`).join('\n') : 'No related ADRs found in knowledge graph.'}
 
 ## Next Steps
 

--- a/src/utils/knowledge-graph-manager.ts
+++ b/src/utils/knowledge-graph-manager.ts
@@ -895,16 +895,6 @@ export class KnowledgeGraphManager {
   }
 
   /**
-   * Get relationships from knowledge graph
-   * @deprecated Use queryKnowledgeGraph for actual queries
-   */
-  getRelationships(_nodeType: string, _relationType?: string): Array<any> {
-    // This is a synchronous method that requires async data
-    // Return empty array for now - use queryKnowledgeGraph for actual queries
-    return [];
-  }
-
-  /**
    * Calculate memory-based health score from knowledge graph
    */
   private async calculateMemoryScore(kg: KnowledgeGraphSnapshot): Promise<MemoryHealthScore> {

--- a/tests/tools/adr-validation-summary.test.ts
+++ b/tests/tools/adr-validation-summary.test.ts
@@ -1,0 +1,100 @@
+/**
+ * validate_all_adrs reported every ADR valid, always (#1539).
+ *
+ * The loop awaited `validateAdr` and bound its return to nothing, then pushed a
+ * literal:
+ *
+ *     await validateAdr({ ... });          // result discarded
+ *     results.push({ isValid: true, confidence: 0.8, findings: [] });
+ *
+ * so `validAdrs = results.filter(r => r.isValid).length` equalled `totalAdrs` on
+ * every run, and `criticalIssues` was always 0. The tool that validates ADRs --
+ * this product's core function -- could not report an invalid one. The only way
+ * to observe a problem was for `validateAdr` to throw, which was caught and
+ * warned.
+ *
+ * This runs against a real temp project rather than mocking the module graph:
+ * the assertion is about what a user sees in the summary, and `validateAdr`
+ * without an API key takes the rule-based path, which needs no network.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { validateAllAdrs } from '../../src/tools/adr-validation-tool.js';
+
+describe('validate_all_adrs summary (#1539)', () => {
+  let projectPath: string;
+
+  const writeAdr = async (name: string, body: string) => {
+    await fs.writeFile(path.join(projectPath, 'docs', 'adrs', name), body);
+  };
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-all-adrs-'));
+    await fs.mkdir(path.join(projectPath, 'docs', 'adrs'), { recursive: true });
+
+    await writeAdr(
+      'adr-001-caching.md',
+      '# ADR-001: Caching\n\n## Status\n\nAccepted\n\n## Context\n\nRepeated reads are slow.\n\n## Decision\n\nWe cache research results in memory.\n'
+    );
+
+    // Accepted, but decides nothing. This is not hypothetical: ADR-023 shipped in
+    // exactly this state and needed #1490 to record its Decision.
+    await writeAdr(
+      'adr-002-undecided.md',
+      '# ADR-002: Undecided\n\n## Status\n\nAccepted\n\n## Context\n\nWe considered several options.\n'
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const summary = async () => {
+    const result = await validateAllAdrs({ projectPath, adrDirectory: 'docs/adrs' });
+    return result.content[0].text as string;
+  };
+
+  it('reports an ADR invalid when it is', async () => {
+    const text = await summary();
+
+    expect(text).toContain('**Total ADRs Validated**: 2');
+    expect(text, 'an Accepted ADR that decides nothing is not valid').not.toContain(
+      '**Valid ADRs**: 2 (100.0%)'
+    );
+    expect(text).toContain('**Invalid/Drifted ADRs**: 1');
+  }, 60_000);
+
+  it('names which ADR failed, not just a count', async () => {
+    const text = await summary();
+
+    // Entries are keyed by the ADR's own title heading; the filename appears last,
+    // on the Path line, so slicing from it lands in the following entry.
+    const entry = text.slice(text.indexOf('### ADR-002'));
+    expect(entry.slice(0, entry.indexOf('- **Path**'))).toContain('Needs Review');
+  }, 60_000);
+
+  it('counts critical issues from findings rather than reporting zero', async () => {
+    const text = await summary();
+
+    expect(text).not.toContain('**Critical Issues**: 0');
+  }, 60_000);
+
+  it('still reports a sound ADR as valid', async () => {
+    const text = await summary();
+
+    const entry = text.slice(text.indexOf('### ADR-001'));
+    expect(entry.slice(0, entry.indexOf('- **Path**'))).toContain('✅ Valid');
+  }, 60_000);
+
+  it('derives confidence per ADR rather than emitting a constant', async () => {
+    const text = await summary();
+
+    // Every entry read `**Confidence**: 80.0%` because 0.8 was hardcoded.
+    const confidences = [...text.matchAll(/\*\*Confidence\*\*: ([\d.]+)%/g)].map(m => m[1]);
+    expect(confidences.length).toBe(2);
+    expect(new Set(confidences).has('80.0') && confidences.length === 2).toBe(false);
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #1539.

## The tool that validates ADRs could not report an invalid one

```ts
await validateAdr({ ... });                              // result discarded
results.push({ isValid: true, confidence: 0.8, findings: [] });   // literal
```

So `validAdrs = results.filter(r => r.isValid).length` equalled `totalAdrs` on every run and `criticalIssues` was always 0. Point it at a corpus of contradictory ADRs and it reports 100% valid. The only way to observe a problem was for `validateAdr` to *throw*, which was caught and `console.warn`ed.

It had no way to do better: `validateAdr` returned formatted markdown, so "extraction" meant parsing prose.

## Three layers, all of which had to move

**1. Split compute from format.** The structured `ADRValidationResult` was already being built — and thrown away at the formatting step. `computeAdrValidation` now returns it; `validateAdr` formats it; the bulk path consumes it.

**2. The rule-based path could not fail either.** `performRuleBasedValidation` computes `isValid` as "no critical or high findings" but could only emit `medium`/`low` ones. Without an API key every ADR was valid there too, so fixing layer 1 alone would have changed nothing for most users.

It now records a **critical** finding for an ADR whose Decision section is missing or empty — an ADR that decides nothing. Not hypothetical: ADR-023 shipped `Accepted` with an empty Decision and needed #1490 to record one.

**3. A section sourced from a stub.** The report rendered:

```
## Related ADRs

No related ADRs found in knowledge graph.
```

on *every* run, because `KnowledgeGraphManager.getRelationships` is `@deprecated` and returns `[]` unconditionally. A heading that is always empty because its source is a stub is worse than no heading. Section and stub both removed.

`queryKnowledgeGraph` — the real method, keyword-scored retrieval that populates nodes and relationships — is untouched.

## Measured

Temp project, one sound ADR and one `Accepted` but undecided:

```
Total ADRs Validated: 2
Valid ADRs: 1 (50.0%)
Invalid/Drifted ADRs: 1
Critical Issues: 1

### ADR-001: Caching     ✅ Valid          76.7%   0 findings
### ADR-002: Undecided   ⚠️ Needs Review   55.0%   2 findings
```

Confidence now differs per ADR. It was the constant `0.8`.

## Mutation-checked

| mutation | tests failed |
|---|---|
| the original discard-and-hardcode restored | **5 of 5** |
| the empty-Decision rule removed | 3 |

Full suite: **3051 passed, 70 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev