### PR TITLE
fix(tests): give the non-hermetic tests a fixture instead of the repository

### DIFF
--- a/.repo-governor/acceptance/1519.json
+++ b/.repo-governor/acceptance/1519.json
@@ -1,0 +1,27 @@
+{
+  "authority_id": "1519",
+  "criteria": [
+    {
+      "check": "command_exit",
+      "target": "bash -c 'test $(grep -rl \"projectPath: process.cwd()\" tests/ | wc -l) -le 2'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -rn \"projectPath: process.cwd()\" tests/tools/search-codebase-tool.test.ts tests/tools/content-masking-tool.test.ts tests/research-question-tool.test.ts tests/index.test.ts'"
+    },
+    {
+      "check": "tests_pass",
+      "target": "tests/tools/search-codebase-tool.test.ts"
+    },
+    {
+      "check": "tests_pass",
+      "target": "tests/tools/content-masking-tool.test.ts"
+    }
+  ],
+  "covers": {
+    "declared": "Tests whose SUBJECT is the live working tree no longer have one: search-codebase and content-masking now run against built fixtures, research-question asserts a threaded path instead of the default, and index.test.ts stops seeding a mock with the real cwd.",
+    "uncovered": "Two occurrences remain, in tests/resources/code-quality-resource.test.ts and tests/resources/deployment-history-resource.test.ts.",
+    "split_to": "1541"
+  },
+  "$comment": "The issue's first acceptance box asks for `grep -rc \"projectPath: process.cwd()\" tests/` to return 0. It returns 2, and the criterion above says <= 2 deliberately rather than 0. Those two assertions are not the defect the issue describes. They do not scan anything -- they assert that a MOCKED callee received process.cwd(), and it does, because code-quality-resource.ts:196 and deployment-history-resource.ts:305 HARDCODE process.cwd() with no parameter to override it. Rewriting those tests would either delete real coverage of a real contract or require changing the source, and the source change is the actual bug: both resources ignore the configured PROJECT_PATH, so an MCP server started with PROJECT_PATH=/foo analyses its own cwd instead. That is a hardcoded value presented as a measurement, which is #1541's cohort, so it is split there rather than smuggled in under test hygiene. Grep count as a proxy for 'no test scans the live repo' is right about 31 of 33 occurrences and wrong about these two; the second criterion pins the four files that actually changed so the proxy cannot be satisfied by weakening them later."
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,7 +27,7 @@ vi.mock('../src/utils/directory-compat.js', () => ({
 // Mock config utilities
 vi.mock('../src/utils/config.js', () => ({
   loadConfig: vi.fn(() => ({
-    projectPath: process.cwd(), // Use actual working directory
+    projectPath: '/test/project', // #1519: a fake config should not name the real tree
     adrDirectory: 'docs/adrs',
     logLevel: 'INFO',
     cacheEnabled: true,
@@ -103,7 +103,11 @@ describe('Index.ts - Core Functionality', () => {
     it('should test config loading', async () => {
       const config = await import('../src/utils/config.js');
       const result = config.loadConfig();
-      expect(result.projectPath).toBe(process.cwd());
+      // `loadConfig` is mocked at the top of this file, so this asserts the
+      // mock, not the module. It previously read `toBe(process.cwd())` against
+      // a mock that returned `process.cwd()` — true no matter what the real
+      // loader does, and it tied the suite to the working tree (#1519).
+      expect(result.projectPath).toBe('/test/project');
     });
 
     it('should test logger creation', async () => {

--- a/tests/research-question-tool.test.ts
+++ b/tests/research-question-tool.test.ts
@@ -164,17 +164,21 @@ describe('Research Question Tool', () => {
       });
 
       test('should handle knowledge generation with enhanced mode enabled', async () => {
+        // #1519: this asserted `projectPath: process.cwd()`, which passes
+        // whether or not the argument is threaded through — cwd is also the
+        // default. Passing an explicit path makes the assertion mean something.
         await generateResearchQuestions({
           analysisType: 'correlation',
           problems: sampleProblems,
           knowledgeGraph: sampleKnowledgeGraph,
           enhancedMode: true,
           knowledgeEnhancement: true,
+          projectPath: '/fixture/research-project',
         });
 
         expect(mockGenerateArchitecturalKnowledge).toHaveBeenCalledWith(
           expect.objectContaining({
-            projectPath: process.cwd(),
+            projectPath: '/fixture/research-project',
             technologies: [],
             patterns: [],
             projectType: 'research-methodology',

--- a/tests/tools/content-masking-tool.test.ts
+++ b/tests/tools/content-masking-tool.test.ts
@@ -9,8 +9,40 @@
  * - Cognitive Systematization: Organized test structure covering all exported functions
  */
 
-import { describe, it as _it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it as _it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { McpAdrError } from '../../src/types/index.js';
+
+/**
+ * #1519: `configureCustomPatterns` used to be pointed at `process.cwd()` — the
+ * real working tree — so its assertions could only be structural ("the output
+ * mentions Total Files") and changed meaning whenever any unrelated file was
+ * added or deleted. Against a fixture of known size the count is exact.
+ */
+const FIXTURE_FILES: Record<string, string> = {
+  'package.json': '{"name":"masking-fixture","version":"1.0.0"}',
+  'src/server.ts': 'export const apiKey = process.env.API_KEY;\n',
+  'src/config.ts': 'export const config = { port: 3000 };\n',
+  '.env.example': 'API_KEY=replace-me\n',
+  'README.md': '# Masking fixture\n',
+};
+
+let FIXTURE: string;
+
+beforeAll(async () => {
+  FIXTURE = await mkdtemp(path.join(tmpdir(), 'content-masking-fixture-'));
+  for (const [relative, content] of Object.entries(FIXTURE_FILES)) {
+    const target = path.join(FIXTURE, relative);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, content, 'utf-8');
+  }
+});
+
+afterAll(async () => {
+  if (FIXTURE) await rm(FIXTURE, { recursive: true, force: true });
+});
 
 // Use vi.hoisted to ensure mocks are available before vi.mock is hoisted
 const { mockFsPromises } = vi.hoisted(() => ({
@@ -411,7 +443,7 @@ describe('Content Masking Tool', () => {
     describe('basic functionality', () => {
       test('configures patterns for project path', async () => {
         const result = await configureCustomPatterns({
-          projectPath: process.cwd(),
+          projectPath: FIXTURE,
         });
 
         expect(result).toBeDefined();
@@ -423,7 +455,7 @@ describe('Content Masking Tool', () => {
         const existingPatterns = ['api-key-\\w+', 'password=\\S+'];
 
         const result = await configureCustomPatterns({
-          projectPath: process.cwd(),
+          projectPath: FIXTURE,
           existingPatterns,
         });
 
@@ -435,13 +467,20 @@ describe('Content Masking Tool', () => {
     describe('project structure analysis', () => {
       test('analyzes project structure correctly', async () => {
         const result = await configureCustomPatterns({
-          projectPath: process.cwd(),
+          projectPath: FIXTURE,
         });
 
-        expect(result).toBeDefined();
         expect(result.content[0].text).toContain('Project Structure');
-        expect(result.content[0].text).toContain('Root Path');
-        expect(result.content[0].text).toContain('Total Files');
+        expect(result.content[0].text).toContain(FIXTURE);
+        // Exact, not merely present. Note the number: the fixture holds five
+        // files, but `scanProjectStructure` only counts ones matching a known
+        // category (here, package.json), and the report labels that count
+        // "Total Files". Pinning 1 documents the gap rather than hiding it
+        // behind `toContain('Total Files')`. Compare the 0 asserted for a
+        // nonexistent path below — that case is indistinguishable from this one
+        // under the old structural assertion.
+        expect(Object.keys(FIXTURE_FILES)).toHaveLength(5);
+        expect(result.content[0].text).toContain('Total Files**: 1');
       });
     });
 

--- a/tests/tools/search-codebase-tool.test.ts
+++ b/tests/tools/search-codebase-tool.test.ts
@@ -1,292 +1,273 @@
 /**
  * Tests for Search Codebase Tool
  *
- * Tests the atomic search_codebase function with dependency injection.
- * No complex ESM mocking required - uses simple dependency injection.
+ * #1519: these tests used to pass `projectPath: process.cwd()` — the real
+ * working tree — as their subject. That made them non-hermetic (adding or
+ * deleting any unrelated file changed what they read) and slow enough to lose a
+ * per-test timeout on a loaded runner: 170s for this file alone. Most of the
+ * assertions were vacuous (`toBeGreaterThanOrEqual(0)` and bodies wrapped in
+ * `if (result.matches.length > 0)`), so 114k lines were scanned to check that a
+ * result object had five keys.
+ *
+ * Every test now runs against FIXTURE, a ten-file project built here from
+ * literal content. Because the contents are known, the assertions are exact.
+ *
+ * Doing that made four defects visible that the old assertions could not fail
+ * on. They are pinned in the `known defects` block at the bottom rather than
+ * fixed here — scope is hermeticity, not relevance scoring — and are filed
+ * separately. Those tests assert what the tool DOES, and are written to break
+ * when it starts doing the right thing.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import {
   searchCodebase,
   searchCodebaseTool,
   type SearchCodebaseDependencies,
 } from '../../src/tools/search-codebase-tool.js';
 
-// Mock dependencies with proper typing
-const createMockDeps = (): SearchCodebaseDependencies => {
-  const mockReadFile = vi.fn();
-  return {
-    fs: {
-      readFile: mockReadFile,
-    } satisfies Partial<SearchCodebaseDependencies['fs']>,
-  } satisfies SearchCodebaseDependencies;
+/**
+ * The fixture project. Each file is present to exercise one discovery path:
+ * Docker, Kubernetes, package, config, environment, build, CI, test, source.
+ * Nothing here matches `xyzabc123nonexistentquery999` or `quantum blockchain`,
+ * which the no-match tests rely on.
+ */
+const FIXTURE_FILES: Record<string, string> = {
+  Dockerfile: 'FROM node:22-alpine\nWORKDIR /app\nCOPY package.json .\nRUN npm ci\n',
+  'docker-compose.yml': 'services:\n  app:\n    build: .\n    ports:\n      - "3000:3000"\n',
+  'package.json':
+    '{"name":"fixture-project","version":"1.0.0","dependencies":{"express":"^4.18.0"}}',
+  'tsconfig.json': '{"compilerOptions":{"target":"ES2022","strict":true}}',
+  Makefile: 'build:\n\tnpm run build\n',
+  '.env.example': 'DATABASE_URL=postgres://localhost:5432/app\nPORT=3000\n',
+  'k8s/deployment.yaml': 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: fixture-app\n',
+  '.github/workflows/ci.yml': 'name: ci\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n',
+  'src/database.config.ts':
+    'export const configuration = { port: 3000 };\n\nexport function connect(): void {}\n',
+  'tests/example.test.ts': "import { describe } from 'vitest';\n\ndescribe('example', () => {});\n",
 };
 
+let FIXTURE: string;
+
+/** Discovery yields a mix of absolute and project-relative paths; see `known defects`. */
+const relativePaths = (result: { matches: Array<{ path: string }> }): string[] => [
+  ...new Set(
+    result.matches.map(m => (path.isAbsolute(m.path) ? path.relative(FIXTURE, m.path) : m.path))
+  ),
+];
+
+beforeAll(async () => {
+  FIXTURE = await mkdtemp(path.join(tmpdir(), 'search-codebase-fixture-'));
+  for (const [relative, content] of Object.entries(FIXTURE_FILES)) {
+    const target = path.join(FIXTURE, relative);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, content, 'utf-8');
+  }
+});
+
+afterAll(async () => {
+  if (FIXTURE) await rm(FIXTURE, { recursive: true, force: true });
+});
+
 describe('searchCodebase', () => {
-  let mockDeps: SearchCodebaseDependencies;
-
-  beforeEach(() => {
-    mockDeps = createMockDeps();
-  });
-
   describe('input validation', () => {
     it('should throw error when query is empty', async () => {
-      await expect(searchCodebase({ query: '' }, mockDeps)).rejects.toThrow(
+      await expect(searchCodebase({ query: '', projectPath: FIXTURE })).rejects.toThrow(
         'Search query is required'
       );
     });
 
     it('should throw error when query is only whitespace', async () => {
-      await expect(searchCodebase({ query: '   ' }, mockDeps)).rejects.toThrow(
+      await expect(searchCodebase({ query: '   ', projectPath: FIXTURE })).rejects.toThrow(
         'Search query is required'
       );
     });
 
     it('should accept valid query', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'Docker configuration',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+      });
 
-      expect(result).toBeDefined();
-      expect(result.keywords).toBeDefined();
-      expect(Array.isArray(result.matches)).toBe(true);
+      expect(result.projectPath).toBe(FIXTURE);
+      expect(result.keywords).toEqual(['deployment', 'configuration']);
+      expect(relativePaths(result)).toEqual(['k8s/deployment.yaml']);
     });
   });
 
   describe('keyword extraction', () => {
     it('should extract keywords from query', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'How does the Docker configuration work?',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'How does the Docker configuration work?',
+        projectPath: FIXTURE,
+      });
 
-      expect(result.keywords).toContain('docker');
-      expect(result.keywords).toContain('configuration');
-      expect(result.keywords).toContain('work');
-      // Stop words should be excluded
-      expect(result.keywords).not.toContain('the');
-      expect(result.keywords).not.toContain('how');
-      expect(result.keywords).not.toContain('does');
+      expect(result.keywords).toEqual(['docker', 'configuration', 'work']);
     });
 
     it('should handle special characters in query', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'kubernetes deployment & CI/CD pipeline!',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'Kubernetes deployment (k8s) - CI/CD pipeline!',
+        projectPath: FIXTURE,
+      });
 
-      // Keywords can be either individual words or compound words (e.g., "kubernetes-deployment")
-      const hasKubernetes = result.keywords.some(k => k.includes('kubernetes'));
-      const hasDeployment = result.keywords.some(k => k.includes('deployment'));
-      const hasPipeline = result.keywords.some(k => k.includes('pipeline'));
-
-      expect(hasKubernetes).toBe(true);
-      expect(hasDeployment).toBe(true);
-      expect(hasPipeline).toBe(true);
+      expect(result.keywords).toContain('kubernetes');
+      expect(result.keywords).toContain('deployment');
+      expect(result.keywords).toContain('pipeline');
     });
 
     it('should remove duplicate keywords', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'Docker docker DOCKER configuration',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'Docker docker DOCKER container',
+        projectPath: FIXTURE,
+      });
 
-      const dockerCount = result.keywords.filter(k => k === 'docker').length;
-      expect(dockerCount).toBe(1);
+      expect(result.keywords.filter(k => k === 'docker')).toHaveLength(1);
     });
   });
 
   describe('file discovery', () => {
     it('should discover files based on query intent', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'Docker configuration',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const docker = await searchCodebase({ query: 'Docker configuration', projectPath: FIXTURE });
+      const kubernetes = await searchCodebase({
+        query: 'Kubernetes pods',
+        projectPath: FIXTURE,
+      });
 
-      expect(result.totalFiles).toBeGreaterThanOrEqual(0);
-      expect(result.matches).toBeDefined();
+      // Intent routing reaches different files for different queries — the
+      // point of the phase. Exact counts, not `>= 0`.
+      expect(docker.totalFiles).toBe(4);
+      expect(kubernetes.totalFiles).toBe(2);
     });
 
     it('should respect maxFiles limit', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'TypeScript files',
-          projectPath: process.cwd(),
-          maxFiles: 5,
-        },
-        mockDeps
-      );
+      const unlimited = await searchCodebase({ query: 'build pipeline', projectPath: FIXTURE });
+      const limited = await searchCodebase({
+        query: 'build pipeline',
+        projectPath: FIXTURE,
+        maxFiles: 1,
+      });
 
-      expect(result.matches.length).toBeLessThanOrEqual(5);
+      // The limit must actually bite, or this asserts nothing.
+      expect(unlimited.matches.length).toBeGreaterThan(1);
+      expect(limited.matches).toHaveLength(1);
     });
 
     it('should handle custom scope patterns', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'test files',
-          projectPath: process.cwd(),
-          scope: ['tests/**/*.ts', 'src/**/*.test.ts'],
-          maxFiles: 10,
-        },
-        mockDeps
-      );
+      const unscoped = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+      });
+      const scoped = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+        scope: ['src/**/*.ts'],
+      });
 
-      expect(result.totalFiles).toBeGreaterThanOrEqual(0);
+      expect(relativePaths(unscoped)).not.toContain('src/database.config.ts');
+      expect(relativePaths(scoped)).toContain('src/database.config.ts');
     });
   });
 
   describe('relevance scoring', () => {
     it('should return matches with relevance scores', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'Jest testing framework',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+      });
 
-      if (result.matches.length > 0) {
-        result.matches.forEach(match => {
-          expect(match.relevance).toBeGreaterThanOrEqual(0);
-          expect(match.relevance).toBeLessThanOrEqual(1);
-        });
-      }
+      expect(result.matches.length).toBeGreaterThan(0);
+      result.matches.forEach(match => {
+        expect(match.relevance).toBeGreaterThan(0);
+        expect(match.relevance).toBeLessThanOrEqual(1);
+      });
     });
 
     it('should sort matches by relevance descending', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'TypeScript configuration',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+        scope: ['src/**/*.ts'],
+      });
 
-      if (result.matches.length > 1) {
-        for (let i = 0; i < result.matches.length - 1; i++) {
-          expect(result.matches[i]!.relevance).toBeGreaterThanOrEqual(
-            result.matches[i + 1]!.relevance
-          );
-        }
-      }
+      expect(result.matches.length).toBeGreaterThan(1);
+      const relevances = result.matches.map(m => m.relevance);
+      expect(relevances).toEqual([...relevances].sort((a, b) => b - a));
     });
 
     it('should filter out low relevance matches', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'quantum computing blockchain AI',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
-
-      // All returned matches should have relevance > 0.2
-      result.matches.forEach(match => {
-        expect(match.relevance).toBeGreaterThan(0.2);
+      const result = await searchCodebase({
+        query: 'quantum computing blockchain',
+        projectPath: FIXTURE,
       });
+
+      // Nothing in the fixture is about any of those.
+      expect(result.matches).toEqual([]);
+      expect(result.totalFiles).toBe(0);
     });
   });
 
   describe('content inclusion', () => {
     it('should not include content by default', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'package.json',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+      });
 
-      if (result.matches.length > 0) {
-        expect(result.matches[0]!.content).toBeUndefined();
-      }
+      expect(result.matches.length).toBeGreaterThan(0);
+      result.matches.forEach(match => expect(match.content).toBeUndefined());
     });
 
     it('should include content when requested', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'package.json',
-          projectPath: process.cwd(),
-          includeContent: true,
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+        includeContent: true,
+      });
 
-      if (result.matches.length > 0) {
-        const packageJsonMatch = result.matches.find(m => m.path.includes('package.json'));
-        if (packageJsonMatch) {
-          expect(packageJsonMatch.content).toBeDefined();
-          expect(typeof packageJsonMatch.content).toBe('string');
-        }
-      }
+      const match = result.matches.find(m => m.path.endsWith('k8s/deployment.yaml'));
+      expect(match).toBeDefined();
+      expect(match!.content).toBe(FIXTURE_FILES['k8s/deployment.yaml']);
     });
   });
 
   describe('tree-sitter analysis', () => {
     it('should work without tree-sitter when disabled', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'TypeScript files',
-          projectPath: process.cwd(),
-          enableTreeSitter: false,
-        },
-        mockDeps
-      );
-
-      expect(result.matches).toBeDefined();
-      // Parse analysis should not be present
-      result.matches.forEach(match => {
-        expect(match.parseAnalysis).toBeUndefined();
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+        enableTreeSitter: false,
       });
+
+      expect(result.matches.length).toBeGreaterThan(0);
+      result.matches.forEach(match => expect(match.parseAnalysis).toBeUndefined());
     });
 
     it('should include parse analysis when tree-sitter is enabled', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'TypeScript configuration',
-          projectPath: process.cwd(),
-          enableTreeSitter: true,
-          maxFiles: 5,
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+        enableTreeSitter: true,
+        scope: ['src/**/*.ts'],
+      });
 
-      if (result.matches.length > 0) {
-        const tsFile = result.matches.find(m => m.path.endsWith('.ts'));
-        if (tsFile && tsFile.parseAnalysis) {
-          expect(tsFile.parseAnalysis.language).toBeDefined();
-          expect(typeof tsFile.parseAnalysis.functionCount).toBe('number');
-          expect(typeof tsFile.parseAnalysis.importCount).toBe('number');
-        }
-      }
+      const yaml = result.matches.find(m => m.path.endsWith('.yaml'));
+      const typescript = result.matches.find(m => m.path.endsWith('.ts'));
+
+      expect(yaml?.parseAnalysis?.language).toBe('yaml');
+      expect(typescript?.parseAnalysis?.language).toBe('typescript');
     });
   });
 
   describe('result structure', () => {
     it('should return complete CodebaseSearchResult structure', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'test query',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+      });
 
       expect(result).toHaveProperty('matches');
       expect(result).toHaveProperty('totalFiles');
@@ -294,123 +275,95 @@ describe('searchCodebase', () => {
       expect(result).toHaveProperty('projectPath');
       expect(result).toHaveProperty('duration');
 
-      expect(Array.isArray(result.matches)).toBe(true);
-      expect(typeof result.totalFiles).toBe('number');
-      expect(Array.isArray(result.keywords)).toBe(true);
-      expect(typeof result.projectPath).toBe('string');
-      expect(typeof result.duration).toBe('number');
+      expect(result.projectPath).toBe(FIXTURE);
+      expect(result.keywords).toEqual(['deployment', 'configuration']);
+      expect(result.totalFiles).toBe(4);
       expect(result.duration).toBeGreaterThan(0);
     });
 
     it('should return FileMatch objects with correct structure', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'package.json',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
+      });
 
-      if (result.matches.length > 0) {
-        const match = result.matches[0]!;
-        expect(match).toHaveProperty('path');
-        expect(match).toHaveProperty('relevance');
-        expect(typeof match.path).toBe('string');
-        expect(typeof match.relevance).toBe('number');
-      }
+      const match = result.matches[0];
+      expect(match).toBeDefined();
+      expect(match!.path).toContain('k8s/deployment.yaml');
+      expect(typeof match!.relevance).toBe('number');
     });
   });
 
   describe('intent-based discovery', () => {
     it('should detect Docker-related queries', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'Docker container configuration',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'Docker container configuration',
+        projectPath: FIXTURE,
+      });
 
-      // Should search for docker-related files
       expect(result.keywords).toContain('docker');
-      expect(result.totalFiles).toBeGreaterThanOrEqual(0);
+      // Discovery reaches the Docker files even though scoring drops them —
+      // see `known defects > filename is never scored`.
+      expect(result.totalFiles).toBe(4);
     });
 
     it('should detect Kubernetes-related queries', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'Kubernetes deployment and pods',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'Kubernetes deployment and pods',
+        projectPath: FIXTURE,
+      });
 
       expect(result.keywords).toContain('kubernetes');
       expect(result.keywords).toContain('deployment');
+      expect(relativePaths(result)).toEqual(['k8s/deployment.yaml']);
     });
 
     it('should detect test-related queries', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'testing framework and test files',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'testing framework and test files',
+        projectPath: FIXTURE,
+      });
 
-      expect(result.keywords).toContain('testing');
-      expect(result.keywords).toContain('test');
-      expect(result.keywords).toContain('files');
+      expect(result.keywords).toEqual(['testing', 'framework', 'test', 'files']);
+      expect(result.totalFiles).toBeGreaterThan(0);
     });
 
     it('should detect build/CI queries', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'CI/CD pipeline and build configuration',
-          projectPath: process.cwd(),
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'CI/CD pipeline and build configuration',
+        projectPath: FIXTURE,
+      });
 
       expect(result.keywords).toContain('pipeline');
       expect(result.keywords).toContain('build');
-      expect(result.keywords).toContain('configuration');
+      expect(relativePaths(result).sort()).toEqual(['.github/workflows/ci.yml', 'Makefile']);
     });
   });
 
   describe('error handling', () => {
     it('should handle non-existent project path gracefully', async () => {
-      const result = await searchCodebase(
-        {
-          query: 'test query',
-          projectPath: '/non/existent/path',
-        },
-        mockDeps
-      );
+      const result = await searchCodebase({
+        query: 'deployment configuration',
+        projectPath: path.join(FIXTURE, 'no', 'such', 'directory'),
+      });
 
-      // Should return empty results for non-existent path
       expect(result.matches).toEqual([]);
       expect(result.totalFiles).toBe(0);
     });
 
     it('should continue on file read errors', async () => {
-      const failingDeps: SearchCodebaseDependencies = {
-        fs: {
-          readFile: vi.fn().mockRejectedValue(new Error('File read error')),
-        } as any,
-      };
+      const readFile = vi.fn().mockRejectedValue(new Error('File read error'));
+      const failingDeps = { fs: { readFile } } as unknown as SearchCodebaseDependencies;
 
       const result = await searchCodebase(
-        {
-          query: 'test query',
-          projectPath: process.cwd(),
-        },
+        { query: 'deployment configuration', projectPath: FIXTURE },
         failingDeps
       );
 
-      // Should still return a valid result even if file reads fail
-      expect(result).toBeDefined();
-      expect(result.matches).toBeDefined();
+      // Discovery still succeeds and is reported; only scoring is lost.
+      expect(readFile).toHaveBeenCalled();
+      expect(result.totalFiles).toBe(4);
+      expect(result.matches).toEqual([]);
     });
   });
 });
@@ -419,21 +372,19 @@ describe('searchCodebaseTool', () => {
   describe('MCP tool wrapper', () => {
     it('should return CallToolResult structure', async () => {
       const result = await searchCodebaseTool({
-        query: 'package.json',
-        projectPath: process.cwd(),
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
       });
 
-      expect(result).toHaveProperty('content');
       expect(Array.isArray(result.content)).toBe(true);
-      expect(result.content[0]).toHaveProperty('type');
-      expect(result.content[0]).toHaveProperty('text');
       expect(result.content[0]!.type).toBe('text');
+      expect(typeof result.content[0]!.text).toBe('string');
     });
 
     it('should format output with search results', async () => {
       const result = await searchCodebaseTool({
-        query: 'TypeScript configuration',
-        projectPath: process.cwd(),
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
         maxFiles: 3,
       });
 
@@ -443,13 +394,11 @@ describe('searchCodebaseTool', () => {
       expect(output).toContain('Matches');
       expect(output).toContain('Duration');
       expect(output).toContain('Keywords');
+      expect(output).toContain('k8s/deployment.yaml');
     });
 
     it('should handle errors gracefully', async () => {
-      const result = await searchCodebaseTool({
-        query: '',
-        projectPath: process.cwd(),
-      });
+      const result = await searchCodebaseTool({ query: '', projectPath: FIXTURE });
 
       expect(result.isError).toBe(true);
       expect(result.content[0]!.text).toContain('Search failed');
@@ -458,29 +407,73 @@ describe('searchCodebaseTool', () => {
     it('should show "No files found" when no matches', async () => {
       const result = await searchCodebaseTool({
         query: 'xyzabc123nonexistentquery999',
-        projectPath: process.cwd(),
+        projectPath: FIXTURE,
       });
 
-      if (!result.isError) {
-        const output = result.content[0]!.text;
-        expect(output).toContain('No files found matching the query');
-      }
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]!.text).toContain('No files found matching the query');
     });
 
     it('should include content preview when requested', async () => {
       const result = await searchCodebaseTool({
-        query: 'package.json',
-        projectPath: process.cwd(),
+        query: 'deployment configuration',
+        projectPath: FIXTURE,
         includeContent: true,
         maxFiles: 1,
       });
 
-      if (!result.isError) {
-        const output = result.content[0]!.text;
-        if (output.includes('package.json')) {
-          expect(output).toContain('Content Preview');
-        }
-      }
+      expect(result.isError).toBeFalsy();
+      const output = result.content[0]!.text;
+      expect(output).toContain('Content Preview');
+      expect(output).toContain('kind: Deployment');
     });
+  });
+});
+
+/**
+ * Defects the old `process.cwd()` assertions could not fail on.
+ *
+ * These pin CURRENT behaviour, not desired behaviour. Each is written so that
+ * fixing the underlying defect breaks the test — which is the point: the fix
+ * should have to come back here and say so.
+ */
+describe('searchCodebase — known defects (pinned, not endorsed)', () => {
+  it('returns the same file twice, once absolute and once relative', async () => {
+    const result = await searchCodebase({
+      query: 'deployment configuration',
+      projectPath: FIXTURE,
+    });
+
+    // `scanProjectStructure` yields absolute paths, `findFiles` yields relative
+    // ones, and both feed the same `discoveredFiles` Set — so a file found by
+    // both routes is scored, returned and counted twice.
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches.filter(m => path.isAbsolute(m.path))).toHaveLength(1);
+    expect(result.matches.filter(m => !path.isAbsolute(m.path))).toHaveLength(1);
+    expect(relativePaths(result)).toHaveLength(1);
+  });
+
+  it('never scores a filename, so searching "docker" cannot return Dockerfile', async () => {
+    const result = await searchCodebase({ query: 'Docker configuration', projectPath: FIXTURE });
+
+    // Both Docker files are discovered...
+    expect(result.totalFiles).toBe(4);
+    // ...and none is returned, because relevance is computed from file CONTENT
+    // only and neither file contains the string "docker".
+    expect(result.matches).toEqual([]);
+  });
+
+  it('reports hasInfrastructure for a file with no infrastructure', async () => {
+    const result = await searchCodebase({
+      query: 'deployment configuration',
+      projectPath: FIXTURE,
+      scope: ['src/**/*.ts'],
+    });
+
+    const typescript = result.matches.find(m => m.path.endsWith('database.config.ts'));
+    expect(typescript?.parseAnalysis).toBeDefined();
+    // `hasInfrastructure: !!analysis.infraStructure` — an empty array is truthy,
+    // so this is true for every parsed file regardless of content.
+    expect(typescript!.parseAnalysis!.hasInfrastructure).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1519. Batch 2 of the Cleanup milestone, alongside #1551.

## The defect

33 assertions across 6 files passed `projectPath: process.cwd()` — the **live working tree** — as their subject. Two consequences, the second worse than the first:

- **timing-dependent**: `search-codebase-tool.test.ts` scanned ~114k source lines under a per-test timeout and lost that race on a loaded machine
- **non-hermetic**: the subject was whatever the tree happened to contain. Deleting three unrelated files in #1487 turned a test in a different subsystem red. It was timing, not causation — but *the suite cannot distinguish those two cases*, which is the actual problem.

## The fix

`search-codebase` and `content-masking` build a fixture project from literal content in `beforeAll` and tear it down after. Because the contents are known, assertions became **exact**:

```ts
// before — scans 114k lines to check a result object has five keys
expect(result.totalFiles).toBeGreaterThanOrEqual(0);
if (result.matches.length > 0) { /* ... */ }

// after
expect(relativePaths(result)).toEqual(['k8s/deployment.yaml']);
expect(match!.content).toBe(FIXTURE_FILES['k8s/deployment.yaml']);
```

Note the `if (result.matches.length > 0)` wrappers: those bodies **skipped silently** whenever the search returned nothing, which — see below — was most of the time.

`research-question-tool` passed the default and asserted the default, which holds whether or not the argument is threaded through; it now passes an explicit path. `index.test.ts` seeded a mocked config with the real cwd and asserted it back.

## Measured

```
tests/tools/search-codebase-tool.test.ts    170.3s  ->  0.12s
all six files together                      170.65s ->  0.30s
```

178 → 181 tests. **Ten consecutive runs of the six files: 10/10 green.**

## Four defects the old assertions could not fail on

Exactness surfaced these immediately. They are **pinned, not fixed** — in a `known defects (pinned, not endorsed)` block written to break when the underlying bug is fixed, so the fix has to come back and say what it changed. Filed as #1552 and #1553.

- **The same file is returned twice** — `scanProjectStructure` yields absolute paths, `findFiles` yields relative ones, both feed one `Set`. One `k8s/deployment.yaml` came back as two matches at identical relevance, double-counted in `totalFiles` and spending `maxFiles` twice.
- **Filenames are never scored** — relevance is computed from content only, so `Docker configuration` discovers 4 files and returns **0** (`Dockerfile` contains no string "docker"), and `package dependency` returns 0 for `package.json`. Still empty at `relevanceThreshold: 0`.
- **`hasInfrastructure: !!analysis.infraStructure`** — an empty array is truthy, so it is `true` for every parsed file.
- **"Total Files": 1 for a five-file fixture** — only recognised categories are counted, and the count is indistinguishable from the `0` returned for a nonexistent path.

## Two occurrences deliberately left

`grep -rc "projectPath: process.cwd()" tests/` returns **2**, not the 0 the issue asks for, and the acceptance bar says `<= 2` on purpose.

Those two assert that a *mocked* callee received `process.cwd()` — and it does, because `code-quality-resource.ts:196` and `deployment-history-resource.ts:305` **hardcode** it with no parameter to override. Neither resource calls `loadConfig()`. So both ignore the configured `PROJECT_PATH`: a server started with `PROJECT_PATH=/target` analyses its own cwd and reports it as the target's.

That is a source defect in #1541's cohort, not test hygiene. Rewriting the tests would have deleted true coverage of a real contract or smuggled a behaviour change in under a hygiene issue. Filed as **#1553**, and split to #1541 in the acceptance bar's `covers` block; when it lands, both assertions become the configured path and the criterion drops to 0.

## Verification

- `tsc --noEmit` clean
- `scripts/check-adr-drift.sh` — `drift: 1  baseline: 1  OK`
- 10/10 consecutive green on the six converted files
- `npm run test:coverage` completing without `--retry` is the issue's fourth acceptance box; it is running and its result will be posted here. CI is the binding check.

Acceptance bar at `.repo-governor/acceptance/1519.json`, with an explicit `covers.uncovered` naming the two remaining occurrences and splitting them to #1541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev