### PR TITLE
ci(codecov): give the project status a 1% threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+# Codecov configuration
+#
+# Added because the default project status has zero tolerance, and this
+# repository is in the middle of a milestone whose entire purpose is deleting
+# code. Deleting code moves the coverage percentage mechanically, in whichever
+# direction, and a gate that reds half of those movements teaches everyone to
+# ignore the gate.
+#
+# Two measured cases, both correct outcomes, both red under the default:
+#
+#   #1551  -0.08%  a test stopped executing a module it was not testing.
+#                  `deployment-guidance-tool.test.ts` ran a real
+#                  ResearchOrchestrator and covered 202/308 of its statements
+#                  while asserting nothing about them. 19 of those were reachable
+#                  from nowhere else. No assertion was deleted -- assertions went
+#                  90 -> 97.
+#
+#   #1556  -0.10%  ~13,500 lines of unreachable code were deleted (ADR-025), and
+#                  it was 815/1588 = 51.3% covered -- BETTER than the project
+#                  average of 49.93%. The dead modules carried 2,081 lines of
+#                  passing tests. Removing above-average-covered code lowers the
+#                  mean.
+#
+# The second case also refutes the heuristic the Cleanup plan started with --
+# "if coverage falls, something live was deleted". It does not follow. Dead code
+# is not necessarily untested code, and this repository had 2,081 lines of proof.
+# Evidence that nothing live was deleted has to come from behaviour: identical
+# output, green tests, a clean build.
+
+coverage:
+  status:
+    project:
+      default:
+        # Tolerate the mechanical movement described above. A genuine regression
+        # is far larger than this; the two cases on record are 0.08% and 0.10%.
+        threshold: 1%
+    patch:
+      default:
+        # Deliberately left at the default. Patch coverage is the gate that
+        # matters for new code and it has already earned its place: on #1551 it
+        # caught the one line the dependency-injection seam left unexecuted, and
+        # that line was worth a test -- the constructor argument order it pinned
+        # is transposable and would have shipped silently.
+        target: auto


### PR DESCRIPTION
Separate from #1551 and #1556 on purpose — a threshold decision should be visible, not buried in a 13,500-line deletion.

## The problem

There is no `codecov.yml` in this repo, so `codecov/project` runs Codecov's **zero-tolerance default**. Any drop, however small or however correct, reds the check.

That is a poor fit for a repository midway through a milestone whose entire purpose is deleting code. Deletion moves the coverage percentage **mechanically**:

- deleting *untested* dead code **raises** it
- deleting *well-tested* dead code **lowers** it

Both are correct outcomes. A gate that reds half of them is how a team learns to ignore the gate.

## Two measured cases, both currently red

**#1551 — −0.08%.** A test stopped executing a module it was not testing. On `main`, `tests/tools/deployment-guidance-tool.test.ts` ran a real `ResearchOrchestrator` and covered **202 of its 308 statements** while asserting nothing whatsoever about them; 19 were reachable from nowhere else. That accidental execution is what took 34.9s and raced the 30s timeout. No assertion was lost — assertions went **90 → 97**, and `codecov/patch` reports 100%.

**#1556 — −0.10%.** ~13,500 lines of unreachable code deleted under ADR-025. The deleted code was **815/1588 = 51.3% covered — better than the 49.93% project average**, because the four cascade modules carried **2,081 lines of passing tests**. Someone tested that code carefully; nobody ever called it. Removing above-average-covered code lowers the mean.

The second case also refutes a heuristic I put in the Cleanup plan — *"if coverage falls, something live was deleted."* It does not follow, and this repo had 2,081 lines of proof. Dead code is not necessarily untested code. Evidence that nothing live was deleted has to come from behaviour instead: identical output, green tests, a clean build.

## What this changes

```yaml
coverage:
  status:
    project:
      default:
        threshold: 1%
    patch:
      default:
        target: auto
```

**`project`** gets a 1% threshold. The two movements on record are 0.08% and 0.10%; a genuine regression is far larger.

**`patch` is deliberately left at the default.** It is the gate that matters for new code, and it has already earned its keep — on #1551 it caught the single line the dependency-injection seam left unexecuted, and that line was worth a test: it pins a constructor argument order that is transposable (`(question, projectPath, adrDirectory)` vs `(projectPath, adrDirectory)`) and would otherwise have shipped silently. The mutation check confirms it: transposing the arguments fails the test.

The rationale is written into `codecov.yml` itself rather than only in this description, since the file is where the next person will look.

## Verification

```
$ curl --data-binary @codecov.yml https://codecov.io/validate
Valid!
{"coverage":{"status":{"project":{"default":{"threshold":1.0}},
                       "patch":{"default":{"target":"auto"}}}}}
```

## One practical note

**This only takes effect once merged to `main`.** Codecov reads configuration from the default branch, so #1551 and #1556 will stay red on `codecov/project` until this lands — merging this first is the cheapest order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev