### PR TITLE
fix(resources): derive the research topic from the document, not its filename

### DIFF
--- a/.repo-governor/acceptance/1530.json
+++ b/.repo-governor/acceptance/1530.json
@@ -1,0 +1,31 @@
+{
+  "authority_id": "1530",
+  "criteria": [
+    {
+      "check": "tests_pass",
+      "target": "tests/resources/research-index-resource.test.ts"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -q \"perform_research_research_001\\|totalWords:\" src/resources/research-index-resource.ts'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'test $(ls docs/research | grep -c test || true) -eq 0'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'grep -q \"perform-research-{ISO timestamp}.md\" docs/research/README.md'"
+    },
+    {
+      "check": "tests_pass",
+      "target": "tests/tools/perform-research-output.test.ts"
+    }
+  ],
+  "covers": {
+    "declared": "The research index's topic derivation, the doc-comment example that documented a test artifact, and the naming convention statement in docs/research/README.md.",
+    "uncovered": "research-documentation.ts is still unretired -- it carries a recorded RETIREMENT_REVIEW verdict but deleting it belongs to the dead-code batch, not here.",
+    "split_to": "1540"
+  },
+  "$comment": "Two corrections to the issue's own account, both verified rather than reasoned. First: the retired underscore convention was no better than the live one. `perform_research_test_research_001` splits to five parts, indexOf finds `research` at 1, and the function returns parts.slice(0,2) -- the constant 'perform_research'. summary.byTopic was a single bucket under BOTH conventions, so the facet was decorative, not miscalibrated, and #1530's own proposed fix ('split on [-_]') would have rebuilt it. Second, and this one only the end-to-end case caught: the document on disk is NOT what perform-research-tool.ts:159 builds. That '# Research Results: {question}' string is the reply to the caller. The file is a tool-context document written by context-document-manager.ts:348, whose H1 is '# Tool Context: perform_research' in every research document ever produced -- so deriving the topic from the heading rebuilds the single-bucket defect by a third route. The hand-written fixtures agreed with that wrong guess and stayed green; only running the tool and reading the resource in one test disagreed. That is exactly what this issue's acceptance asked for, and it is why it asked. The topic now comes from the '- Question:' line in Key Findings. Every branch of extractTopic is mutation-checked: dropping the Question parse fails three tests, dropping the title fallback fails one, and a second redundant parse of the quick-reference line was written, found to change no outcome, and deleted rather than left as untested redundancy. Four of the eight tests are red against the original implementation; the header names which four and does not claim the other four caught anything. The three leaked perform_research_test_*.md fixtures were already gone before this work started."
+}

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -27,8 +27,16 @@ This directory contains research documentation for the project, written by the
 ### Creating New Research
 
 1. Use the `generate_research_questions` MCP tool to create research questions
-2. Research files are automatically generated in `docs/context/research/` with timestamp-based naming
+2. `perform_research` writes the findings to this directory as
+   `perform-research-{ISO timestamp}.md` — the one convention, stated once, above
 3. Research findings are integrated into project knowledge base
+
+The `research-index` resource groups these documents by **topic**, which it reads from
+the `- Question:` line in each document's Key Findings — not from the filename, and not
+from the heading. A timestamped filename carries no subject, and the heading is
+`# Tool Context: perform_research` in every research document ever written, so both
+collapse every document into one bucket. Parsing them for a topic is what #1530
+corrected.
 
 ### Research Process
 

--- a/src/resources/research-index-resource.ts
+++ b/src/resources/research-index-resource.ts
@@ -34,24 +34,42 @@ function extractTitle(content: string): string {
 }
 
 /**
- * Extract topic from filename
+ * Extract topic from the document's own content.
+ *
+ * This used to parse the filename, splitting the basename on `_`. That never
+ * worked for either naming convention (#1530). `perform_research` writes
+ * `perform-research-{ISO}.md`, which has no underscore at all, so the whole
+ * filename -- timestamp included -- was returned as the "topic". The retired
+ * underscore convention fared no better: every such name returned the constant
+ * `"perform_research"`, collapsing `summary.byTopic` into a single bucket.
+ *
+ * A timestamped filename carries no subject, and neither does the heading: the
+ * document on disk is a tool-context document whose H1 is `# Tool Context:
+ * perform_research` for every research run ever written. The question is
+ * recorded in the body, as a `- Question:` key finding and again in the quick
+ * reference. Read it from there.
  */
-function extractTopic(filename: string): string {
-  // Remove extension and parse filename
-  // Example: perform_research_test_research_001.md -> research
-  const baseName = filename.replace(/\.md$/, '');
-  const parts = baseName.split('_');
-
-  // Try to find meaningful topic
-  if (parts.includes('research')) {
-    const researchIndex = parts.indexOf('research');
-    if (researchIndex > 0) {
-      return parts.slice(0, researchIndex + 1).join('_');
-    }
-    return 'research';
+function extractTopic(filename: string, content: string): string {
+  // `- Question: How is caching handled` -- the Key Findings entry. The quick
+  // reference above it repeats the question in prose, but parsing the
+  // structured line is the more durable of the two and a second parse that
+  // never changes an outcome is the kind of untested redundancy this milestone
+  // exists to remove.
+  const keyFinding = content.match(/^\s*-\s*Question:\s*(.+)$/m);
+  if (keyFinding?.[1]?.trim()) {
+    return keyFinding[1].trim();
   }
 
-  return parts[0] || 'general';
+  // A hand-written research note, which is a plain document with a real title.
+  const title = extractTitle(content);
+  if (title !== 'Untitled' && !/^Tool Context:/i.test(title)) {
+    const subject = title.replace(/^Research Results:\s*/i, '').trim();
+    if (subject) {
+      return subject;
+    }
+  }
+
+  return filename.replace(/\.md$/, '') || 'general';
 }
 
 /**
@@ -122,20 +140,19 @@ function groupByTopic(docs: ResearchDocument[]): Record<string, number> {
  *     summary: {
  *       total: 55,
  *       byTopic: {
- *         "performance": 12,
- *         "security": 8,
- *         "architecture": 15
+ *         "Kubernetes ingress configuration": 2,
+ *         "Database connection pooling": 1
  *       },
- *       totalWords: 45000,
- *       averageWordCount: 818
+ *       totalWordCount: 45000,
+ *       totalSize: 372736
  *     },
  *     documents: [
  *       {
- *         id: "perform_research_research_001",
- *         title: "TypeScript Performance Optimization",
- *         topic: "performance",
- *         path: "docs/research/perform_research_research_001.md",
- *         lastModified: "2025-10-10T12:00:00.000Z",
+ *         id: "perform-research-2026-08-28T04-37-26-533Z",
+ *         title: "Research Results: Kubernetes ingress configuration",
+ *         topic: "Kubernetes ingress configuration",
+ *         path: "docs/research/perform-research-2026-08-28T04-37-26-533Z.md",
+ *         lastModified: "2026-08-28T04:37:26.533Z",
  *         wordCount: 1250,
  *         size: 8192
  *       }
@@ -180,7 +197,7 @@ export async function generateResearchIndexResource(): Promise<ResourceGeneratio
             researchDocs.push({
               id: file.replace(/\.md$/, ''),
               title: extractTitle(content),
-              topic: extractTopic(file),
+              topic: extractTopic(file, content),
               path: path.join(dir, file),
               lastModified: stats.mtime.toISOString(),
               wordCount: content.split(/\s+/).filter(w => w.length > 0).length,

--- a/tests/resources/research-index-resource.test.ts
+++ b/tests/resources/research-index-resource.test.ts
@@ -1,0 +1,207 @@
+/**
+ * #1530: the research index is calibrated to a filename convention nothing
+ * produces.
+ *
+ * `perform_research` writes `perform-research-{ISO}.md`. `extractTopic` split
+ * the basename on `_` only, so a real filename yielded exactly one part, the
+ * `parts.includes('research')` branch was never taken, and the returned "topic"
+ * was the entire filename including its timestamp.
+ *
+ * Worth recording that the *dead* convention was no better, which #1530 does not
+ * say. `perform_research_test_research_001` splits to five parts, `indexOf`
+ * finds `research` at 1, and the function returns `parts.slice(0, 2)` --
+ * the constant `"perform_research"`, for every document ever written. So
+ * `summary.byTopic` was a single bucket under both conventions. The facet was
+ * decorative, not merely miscalibrated.
+ *
+ * The fix derives the topic from the `- Question:` line the document records in
+ * its Key Findings. Not from the heading: the file on disk is a tool-context
+ * document whose H1 is `# Tool Context: perform_research`, identical in every
+ * research document ever written, so reading the heading rebuilds the same
+ * single-bucket defect by a different route. That was not obvious from the
+ * source -- `perform-research-tool.ts:159` builds a `# Research Results:
+ * {question}` heading, but that string is the reply to the caller and never
+ * reaches the file. Only the end-to-end case at the bottom of this file caught
+ * it; the hand-written fixtures agreed with the wrong guess.
+ *
+ * Which of these were red, stated plainly: four of the eight, verified in both
+ * directions against the original `extractTopic`. Red were `derives a topic
+ * from the document`, `groups by that topic in the summary`, `reads the title
+ * of a hand-written note`, and the end-to-end `classifies a document the tool
+ * itself produced`. The other four pass either way and are kept as guards
+ * rather than claimed as catches -- `never reports the tool name as a topic`
+ * in particular guards the wrong fix, not the old defect, since the old code
+ * returned a filename and could not have surfaced the heading.
+ *
+ * Every branch of the new `extractTopic` is discriminated by a test: removing
+ * the `- Question:` parse fails three, removing the title fallback fails one,
+ * and the filename fallback has its own case.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { generateResearchIndexResource } from '../../src/resources/research-index-resource.js';
+import { resourceCache } from '../../src/resources/resource-cache.js';
+
+/**
+ * What perform_research actually writes. Copied from a real run, not invented:
+ * the H1 is the tool name, identical in every research document ever produced,
+ * and the question appears only in the body.
+ */
+const liveDoc = (question: string, confidence: number) => `# Tool Context: perform_research
+
+> **Generated**: 2026-08-28T04:37:26.533Z
+> **Tool Version**: 2.0.0
+> **Project**: example
+
+## Quick Reference
+
+Research: "${question}" - ${confidence}% confidence. Sources: 📁 Project Files
+
+## Execution Summary
+
+- **Status**: Research completed with ${confidence}% confidence
+- **Confidence**: ${confidence}%
+- **Key Findings**:
+  - Question: ${question}
+  - Confidence: ${confidence}.0%
+`;
+
+const LIVE_NAME = 'perform-research-2026-08-28T04-37-26-533Z.md';
+const LIVE_DOC = liveDoc('Kubernetes ingress configuration', 82);
+
+const SECOND_NAME = 'perform-research-2026-08-28T09-12-00-000Z.md';
+const SECOND_DOC = liveDoc('Database connection pooling', 71);
+
+let dir: string;
+
+// The resource resolves its directories against process.cwd(), and vitest
+// workers cannot chdir. Stubbing cwd is the only way to point it at a fixture.
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'research-index-'));
+  mkdirSync(path.join(dir, 'docs', 'research'), { recursive: true });
+  writeFileSync(path.join(dir, 'docs', 'research', LIVE_NAME), LIVE_DOC);
+  writeFileSync(path.join(dir, 'docs', 'research', SECOND_NAME), SECOND_DOC);
+  vi.spyOn(process, 'cwd').mockReturnValue(dir);
+  resourceCache.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(dir, { recursive: true, force: true });
+  resourceCache.clear();
+});
+
+const docs = async () => {
+  const r = await generateResearchIndexResource();
+  return (r.data as any).documents as Array<{ id: string; title: string; topic: string }>;
+};
+
+describe('research index — files perform_research actually writes', () => {
+  it('finds them at all', async () => {
+    const d = await docs();
+    expect(d.map(x => x.id).sort()).toEqual([
+      'perform-research-2026-08-28T04-37-26-533Z',
+      'perform-research-2026-08-28T09-12-00-000Z',
+    ]);
+  });
+
+  it('derives a topic from the document, not from its timestamp', async () => {
+    const d = await docs();
+    const live = d.find(x => x.id.includes('04-37-26'))!;
+    expect(live.topic).toBe('Kubernetes ingress configuration');
+    expect(live.title).toBe('Tool Context: perform_research');
+    // The specific regression: the timestamp leaking into the topic.
+    expect(live.topic).not.toContain('2026');
+    expect(live.topic).not.toContain('perform-research');
+  });
+
+  it('gives documents on different questions different topics', async () => {
+    const d = await docs();
+    const topics = new Set(d.map(x => x.topic));
+    // Both the live and the retired convention collapsed every document into a
+    // single bucket. Two documents on unrelated questions must not share one.
+    expect(topics.size).toBe(2);
+  });
+
+  it('groups by that topic in the summary', async () => {
+    const r = await generateResearchIndexResource();
+    const byTopic = (r.data as any).summary.byTopic as Record<string, number>;
+    expect(Object.keys(byTopic).sort()).toEqual([
+      'Database connection pooling',
+      'Kubernetes ingress configuration',
+    ]);
+  });
+
+  it('reads the title of a hand-written note that has no Question line', async () => {
+    writeFileSync(
+      path.join(dir, 'docs', 'research', 'notes.md'),
+      '# Sidecar proxy overhead\n\nMeasured at 3ms.\n'
+    );
+    resourceCache.clear();
+    const d = await docs();
+    expect(d.find(x => x.id === 'notes')!.topic).toBe('Sidecar proxy overhead');
+  });
+
+  it('falls back to the filename when there is nothing to read', async () => {
+    writeFileSync(path.join(dir, 'docs', 'research', 'scratch.md'), 'no heading here\n');
+    resourceCache.clear();
+    const d = await docs();
+    expect(d.find(x => x.id === 'scratch')!.topic).toBe('scratch');
+  });
+
+  it('never reports the tool name as a topic', async () => {
+    // The H1 is `# Tool Context: perform_research` in every research document.
+    // Deriving the topic from it would rebuild the single-bucket defect.
+    const d = await docs();
+    for (const doc of d) {
+      expect(doc.topic).not.toContain('Tool Context');
+      expect(doc.topic).not.toBe('perform_research');
+    }
+  });
+});
+
+/**
+ * #1530's acceptance asks that this be "verified by running the tool and reading
+ * the resource, not by unit test alone". The fixtures above are hand-written, so
+ * they prove the resource handles a filename shape I asserted the tool produces.
+ * This one removes that assumption: perform_research writes the file, and the
+ * resource reads whatever it actually wrote.
+ */
+describe('research index — end to end with a real perform_research run', () => {
+  it('classifies a document the tool itself produced', async () => {
+    const { performResearch } = await import('../../src/tools/perform-research-tool.js');
+    const project = mkdtempSync(path.join(tmpdir(), 'research-e2e-'));
+    mkdirSync(path.join(project, 'docs', 'adrs'), { recursive: true });
+    writeFileSync(
+      path.join(project, 'docs', 'adrs', 'adr-001-storage-layer.md'),
+      '# ADR-001: Storage Layer\n\n## Status\n\nAccepted\n\nResults are cached in memory.\n'
+    );
+
+    try {
+      await performResearch({
+        question: 'How is caching handled',
+        projectPath: project,
+        adrDirectory: 'docs/adrs',
+      });
+
+      vi.spyOn(process, 'cwd').mockReturnValue(project);
+      resourceCache.clear();
+      const result = await generateResearchIndexResource();
+      const written = (result.data as any).documents as Array<{ id: string; topic: string }>;
+
+      // The tool writes latest.md alongside the timestamped file; both are real
+      // output and both must classify.
+      expect(written.length).toBeGreaterThan(0);
+      for (const doc of written) {
+        expect(doc.topic).toBe('How is caching handled');
+      }
+    } finally {
+      vi.restoreAllMocks();
+      rmSync(project, { recursive: true, force: true });
+      resourceCache.clear();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Closes part of #1530. Tranche A of the #1540 + #1530 batch — the code fixes, no deletions.

## The defect

`extractTopic` split the basename on `_`. `perform_research` writes `perform-research-{ISO}.md`, which has no underscore, so the whole filename — timestamp included — was returned as the "topic".

**The retired underscore convention was no better**, which #1530 does not say. `perform_research_test_research_001` splits to five parts, `indexOf` finds `research` at 1, and the function returns `parts.slice(0, 2)` — the constant `"perform_research"`. `summary.byTopic` was a single bucket under *both* conventions. The facet was decorative, not miscalibrated — and the issue's own proposed fix (split on `[-_]`) would have rebuilt it.

## What the fix reads instead

The `- Question:` line in the document's Key Findings.

**Not the heading.** The file on disk is a tool-context document written by `context-document-manager.ts:348`, whose H1 is `# Tool Context: perform_research` in every research document ever produced. That was not visible from the source: `perform-research-tool.ts:159` builds a `# Research Results: {question}` heading, but that string is the reply to the caller and never reaches the file.

My hand-written fixtures agreed with that wrong guess and stayed green. Only running the tool and reading the resource in one test disagreed — which is exactly what #1530's acceptance asked for, and why it asked.

## Also corrected

- The doc-comment example documented a leaked test fixture (`perform_research_research_001`) as the expected shape, and named two summary fields the code does not emit (`totalWords`, `averageWordCount` vs the actual `totalWordCount`, `totalSize`).
- `docs/research/README.md`'s "Creating New Research" step still pointed at `docs/context/research/`, contradicting the corrected block directly above it.

## Verification

Four of the eight tests are red against the original implementation, verified in both directions: `derives a topic from the document`, `groups by that topic in the summary`, `reads the title of a hand-written note`, and the end-to-end `classifies a document the tool itself produced`. The header names which four and does not claim the other four caught anything.

Every branch of the new `extractTopic` is mutation-checked — removing the `- Question:` parse fails three tests, removing the title fallback fails one, and the filename fallback has its own case. A second redundant parse of the quick-reference line was written, found to change no outcome, and deleted rather than left as untested redundancy.

Acceptance bar recorded at `.repo-governor/acceptance/1530.json`; it declares `research-documentation.ts` as uncovered and splits it to #1540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev