### PR TITLE
ci(lint): add a ratcheting dead-code check, and hold it at 17

### DIFF
--- a/.dead-code-baseline
+++ b/.dead-code-baseline
@@ -1,0 +1,12 @@
+17
+
+Modules under src/ that no other src/ module imports, measured by
+scripts/check-dead-code.sh. A ratchet: this number may fall, never rise.
+
+17 files / 9,062 lines as of 2026-08-29, unchanged from the census that opened
+milestone 6 (#1540) even though src/ itself shrank from 183 files to 172 -- the
+deletions so far removed reachable code and dead methods, not whole orphans.
+
+14 of the 17 have a test suite and no caller. Their tests pass. Lower this
+number only by deleting a module through retirement.py with its own admission,
+or by wiring one up; never by editing this file alone.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Check ADR drift (ratchet)
         run: bash scripts/check-adr-drift.sh
 
+      # Modules under src/ that nothing in src/ imports. RATCHET, not a
+      # zero-dead-code gate: 17 remain, 14 of them carrying test suites that
+      # pass against code with no caller. Deleting one needs retirement.py plus
+      # its own admission, so demanding zero would gate CI behind a queue of
+      # human dispositions and the check would never land. The count may fall,
+      # never rise. See #1540.
+      - name: Check dead code (ratchet)
+        run: bash scripts/check-dead-code.sh
+
       - name: Check formatting
         run: |
           echo "=== Checking Code Formatting ==="

--- a/.repo-governor/acceptance/1540.json
+++ b/.repo-governor/acceptance/1540.json
@@ -1,0 +1,26 @@
+{
+  "authority_id": "1540",
+  "criteria": [
+    {
+      "check": "file_exists",
+      "target": "scripts/check-dead-code.sh"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash scripts/check-dead-code.sh"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'grep -q \"check-dead-code.sh\" .github/workflows/lint.yml'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'test $(python3 scripts/dead-code.py | awk -F\"\\t\" \"\\$1==\\\"TOTAL\\\"{print \\$2}\") -le $(sed -n \"s/^[[:space:]]*\\([0-9][0-9]*\\).*/\\1/p\" .dead-code-baseline | head -1)'"
+    }
+  ],
+  "covers": {
+    "declared": "The instrument only: a ratcheting dead-code check that makes the census reproducible, wired into the lint workflow beside the ADR-drift ratchet, with the 17 known orphans confirmed as its starting reading.",
+    "uncovered": "No module is deleted here. Each of the 17 carries a recorded RETIREMENT_REVIEW verdict and needs its own admission. Three of them -- sandbox-executor.ts and the two memory-migration modules, 2,560 lines between them -- may be scaffolding for the CE-MCP work in milestone 5 rather than abandoned code, and that is an owner judgement the census cannot make."
+  },
+  "$comment": "The check is mutation-verified in three directions: adding an orphan to src/ raises the count and exits 1; wiring an orphan into src/index.ts lowers it and prints the ratchet instruction; hiding src/index.ts aborts with exit 2 rather than reporting a clean repository, because a check that silently scans nothing is the failure this milestone keeps finding in the code it is cleaning up. That second mutation earned its place immediately -- it did NOT move the count on the first run, which exposed a missing edge shape in my own graph builder: bare side-effect imports (`import './x.js';`, no bindings) were not matched, so any module reached only that way would have been reported dead. A graph that misses an edge shape reports live code as dead, and deletion is the one error here that a revert does not always undo. Fixed before the script landed; the census reading is unchanged at 17/9,062 because no such import existed. Note the census held at 17 files / 9,062 lines while src/ itself fell from 183 files to 172 across this milestone: the work so far removed reachable code and dead methods inside live files, not whole orphans. 14 of the 17 have a test suite and no caller -- their tests pass against code nothing runs, which reads as coverage and is not."
+}

--- a/scripts/check-dead-code.sh
+++ b/scripts/check-dead-code.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Report modules under src/ that nothing in src/ imports (#1540).
+#
+# Why: the dead-code census that opened this milestone was a one-off audit run
+# by hand. A number in an issue body decays the moment someone lands a commit,
+# and every claim in this repository that nothing executes has eventually turned
+# out to be wrong. This makes the 9,062-line figure reproducible on demand.
+#
+# This is a RATCHET, not a zero-dead-code gate: the count may fall, never rise.
+# Demanding zero would gate CI behind a retirement queue that needs a human
+# disposition per asset -- ADR-025's precedent -- and the realistic outcome is
+# the check never lands.
+#
+# It REPORTS. It never deletes. Deletion needs retirement.py plus an admission,
+# and a zero-reference asset returning RETIREMENT_REVIEW is the correct terminal
+# result, not a false positive to argue with.
+#
+# THREE TRAPS THIS DELIBERATELY AVOIDS
+#
+#   1. Grep for the module name. Substring matching is how CI came to assert a
+#      tool that has never existed (`analyze_project` matched
+#      `analyze_project_ecosystem`). This builds a real import graph instead:
+#      relative specifiers only, .js -> .ts resolution, directory -> index.ts.
+#
+#   2. Missing `await import()` edges. Several modules here are reached only
+#      through dynamic import. A static-import-only graph reports them dead and
+#      would have had us delete live code.
+#
+#   3. A check that silently scans nothing. If the walk finds no files, or
+#      src/index.ts is missing, that is a BROKEN CHECK reported as a clean
+#      repository -- the exact failure this milestone keeps finding in the code
+#      it is cleaning up. Both conditions abort loudly.
+
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+BASELINE_FILE=".dead-code-baseline"
+
+report="$(python3 scripts/dead-code.py)"
+
+if [ -z "$report" ] || printf '%s' "$report" | grep -q '^ABORT'; then
+  reason="$(printf '%s' "$report" | sed -n 's/^ABORT\t//p')"
+  printf "  \033[31mABORT\033[0m %s\n" "${reason:-the check produced no output}"
+  echo "The dead-code check could not run. That is a failure, not a clean result."
+  exit 2
+fi
+
+scanned="$(printf '%s' "$report" | awk -F'\t' '$1=="SCANNED"{print $2" files, "$3" lines"}')"
+count="$(printf '%s'  "$report" | awk -F'\t' '$1=="TOTAL"{print $2}')"
+deadlines="$(printf '%s' "$report" | awk -F'\t' '$1=="TOTAL"{print $3}')"
+
+echo "Dead code under src/ -- modules no other src/ module imports"
+echo "  scanned: $scanned"
+echo
+
+printf '%s' "$report" | awk -F'\t' '$1=="DEAD"{printf "  \033[33m%6d\033[0m  %s  (%s)\n", $2, $3, $4}'
+
+echo
+echo "  $count files, $deadlines lines"
+
+# First integer on the first line. The rest of the file is prose, so the number
+# always arrives with the reason it is what it is.
+baseline="$count"
+if [ -f "$BASELINE_FILE" ]; then
+  parsed="$(sed -n 's/^[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$BASELINE_FILE" | head -1)"
+  [ -n "$parsed" ] && baseline="$parsed"
+fi
+
+if [ "$count" -gt "$baseline" ]; then
+  printf "  \033[31mFAIL\033[0m dead modules rose from %s to %s. Wire it up or do not add it.\n" "$baseline" "$count"
+  exit 1
+fi
+
+if [ "$count" -lt "$baseline" ]; then
+  printf "  \033[32mOK\033[0m   dead modules fell from %s to %s -- ratchet %s into %s\n" \
+    "$baseline" "$count" "$count" "$BASELINE_FILE"
+else
+  printf "  \033[32mOK\033[0m   dead modules holding at %s\n" "$count"
+fi

--- a/scripts/dead-code.py
+++ b/scripts/dead-code.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Import-graph walk behind scripts/check-dead-code.sh (#1540).
+
+Emits tab-separated records: SCANNED, TOTAL, DEAD, or ABORT.
+Kept as its own file rather than a heredoc inside a command substitution,
+which bash 3.2 -- the version macOS ships -- mis-lexes.
+"""
+
+import os, re, sys, collections
+
+SRC = os.path.abspath('src')
+ENTRY = os.path.join(SRC, 'index.ts')
+
+if not os.path.isfile(ENTRY):
+    print("ABORT\tsrc/index.ts not found -- cannot root the reachability walk")
+    sys.exit(0)
+
+files = sorted(
+    os.path.join(root, n)
+    for root, _, names in os.walk(SRC)
+    for n in names if n.endswith('.ts')
+)
+TESTS = os.path.abspath('tests')
+test_files = sorted(
+    os.path.join(root, n)
+    for root, _, names in os.walk(TESTS)
+    for n in names if n.endswith('.ts')
+) if os.path.isdir(TESTS) else []
+if not files:
+    print("ABORT\tno .ts files found under src/ -- the walk matched nothing")
+    sys.exit(0)
+
+def resolve(spec, frm):
+    """Relative specifiers only. Package imports cannot make a local file live."""
+    if not spec.startswith('.'):
+        return None
+    base = os.path.normpath(os.path.join(os.path.dirname(frm), spec))
+    candidates = [base, base + '.ts', os.path.join(base, 'index.ts')]
+    if base.endswith('.js'):
+        candidates.insert(1, base[:-3] + '.ts')
+    for c in candidates:
+        if c.endswith('.ts') and os.path.isfile(c):
+            return c
+    return None
+
+# Four edge shapes, all of which make a module live:
+#
+#   from '...'          static import/export, including `export * from`
+#   import('...')       dynamic import -- several modules here are reached
+#                       only this way, and omitting it reports live code dead
+#   require('...')      a CommonJS interop shim
+#   import '...'        SIDE-EFFECT import, no bindings
+#
+# The last one was missing from the first version of this script, and the
+# mutation check caught it: wiring an orphan into src/index.ts with a bare
+# `import './x.js';` did not move the count. A graph that misses an edge shape
+# reports live code as dead, which is the one error here that a revert does not
+# always undo.
+IMP = re.compile(r"""(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"]([^'"]+)['"]""")
+
+edges = collections.defaultdict(set)
+importers = collections.defaultdict(set)
+for f in files:
+    for spec in IMP.findall(open(f, encoding='utf-8').read()):
+        t = resolve(spec, f)
+        if t:
+            edges[f].add(t)
+            importers[t].add(f)
+
+# Importers from tests/ are tracked separately and never make a module live.
+# A module with a test suite and no caller is code the suite keeps green while
+# nothing runs it -- which reads as coverage, and is not.
+test_importers = collections.defaultdict(set)
+for f in test_files:
+    for spec in IMP.findall(open(f, encoding='utf-8').read()):
+        t = resolve(spec, f)
+        if t and t.startswith(SRC + os.sep):
+            test_importers[t].add(f)
+
+seen, stack = set(), [ENTRY]
+while stack:
+    cur = stack.pop()
+    if cur in seen:
+        continue
+    seen.add(cur)
+    stack.extend(edges[cur])
+
+def lines(f):
+    return sum(1 for _ in open(f, encoding='utf-8'))
+
+root = os.path.dirname(SRC)
+dead = sorted((f for f in files if f not in seen), key=lambda f: -lines(f))
+
+print(f"SCANNED\t{len(files)}\t{sum(lines(f) for f in files)}")
+print(f"TOTAL\t{len(dead)}\t{sum(lines(f) for f in dead)}")
+for f in dead:
+    n = len(test_importers[f])
+    note = f"{n} test file{'s' if n != 1 else ''}, no caller" if n else "no test, no caller"
+    print(f"DEAD\t{lines(f)}\t{os.path.relpath(f, root)}\t{note}")


### PR DESCRIPTION
Refs #1540. The instrument, not the deletions — nothing is removed here.

#1540's census (17 orphaned modules, 9,062 lines) was a one-off audit run by hand. A number in an issue body decays on the next commit, and every claim in this repository that nothing executes has eventually turned out to be wrong. This makes it reproducible.

## What it does

Builds a real import graph over `src/` — relative specifiers only, `.js` → `.ts`, directory → `index.ts`, with static, dynamic (`await import()`), `require()` and bare side-effect edges — and walks it from `src/index.ts`. It **reports**; it never deletes.

A ratchet like the `check-adr-drift` and `check-test-typecheck` gates beside it in `lint.yml`: the count may fall, never rise. A zero-dead-code gate would sit behind a queue of per-asset human dispositions and never land.

```
Dead code under src/ -- modules no other src/ module imports
  scanned: 172 files, 106726 lines

    1016  src/utils/memory-migration-manager.ts  (3 test files, no caller)
     864  src/tools/tree-sitter-code-tools.ts  (no test, no caller)
     800  src/utils/sandbox-executor.ts  (3 test files, no caller)
     ...
  17 files, 9062 lines
  OK   dead modules holding at 17
```

## Mutation-verified in three directions

| mutation | expected | result |
|---|---|---|
| add an orphan to `src/` | count rises, exit 1 | `dead modules rose from 17 to 18` |
| wire an orphan into `src/index.ts` | count falls, ratchet message | `fell from 17 to 16` |
| hide `src/index.ts` | abort, exit 2 | `ABORT ... cannot root the reachability walk` |

**The second mutation earned its place immediately — it did not move the count on the first run.** That exposed a missing edge shape in my own graph builder: bare side-effect imports (`import './x.js';`, no bindings) were not matched, so a module reached only that way would have been reported dead. A graph that misses an edge shape reports live code as dead, and deletion is the one error here that a revert does not always undo. Fixed before landing; the census reading is unchanged at 17/9,062 because no such import existed.

The third mutation exists because a check that silently scans nothing is the exact failure this milestone keeps finding in the code it is cleaning up.

## Two things the reading shows that the issue does not

- The count **held at 17 files / 9,062 lines while `src/` fell from 183 files to 172** across this milestone. The work so far removed reachable code and dead methods inside live files, not whole orphans.
- **14 of the 17 carry a test suite and no caller.** Their tests pass against code nothing runs. That reads as coverage and is not.

## Notes

- The python walk lives in `scripts/dead-code.py` rather than a heredoc inside a command substitution, which bash 3.2 — the version macOS ships — mis-lexes.
- `.dead-code-baseline` carries the number on line 1 and the reason after it, so the figure always arrives with its justification.
- Acceptance bar at `.repo-governor/acceptance/1540.json`. The engine correctly reports `BAR_COVERS_PART`: this bar covers the instrument, and the deletions remain uncovered pending a per-asset admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev