### PR TITLE
ci(test): skip the Codecov upload for Dependabot, unblocking 13 PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,23 @@ jobs:
       #   Some files were not found --- {"not_found_files": ["coverage/lcov.info"]}
       # That was latent for as long as lcov.info was never generated at all;
       # generating it and setting fail_ci_if_error: true is what surfaced it.
+      # Skipped for Dependabot. A Dependabot-triggered `pull_request` run does not
+      # receive the repository's Actions secrets, so `secrets.CODECOV_TOKEN`
+      # resolves to the empty string even though the secret exists in BOTH the
+      # Actions and the Dependabot store. The uploader says so plainly:
+      #   -> Token length: 0
+      #   error -- Upload queued for processing failed:
+      #            {"message":"Token required because branch is protected"}
+      # With fail_ci_if_error: true that fails `test (20)`, and it had blocked
+      # all 13 open Dependabot PRs -- every dependency and security update in
+      # the repository -- while 13 high-severity advisories sat on main.
+      #
+      # Skipping is the right call rather than relaxing fail_ci_if_error: the
+      # coverage delta of a dependency bump is not a signal worth gating a
+      # security update on, and the hard failure stays in force for every
+      # human-authored PR, where the token is present and the upload works.
       - name: Upload coverage reports
-        if: matrix.node-version == '20'
+        if: matrix.node-version == '20' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info


### PR DESCRIPTION
Not part of #1540 — found while working it. Every open Dependabot PR is red, and none of them for anything to do with its own content.

```
13 failing PRs   →  13 dependabot, 0 non-dependabot
all failing      →  test (20), same step
```

Meanwhile GitHub reports **40 vulnerabilities on `main`, 13 of them high**. A broken coverage upload is currently gating every dependency and security update in the repository.

## Root cause, from the uploader's own log

```
 -> Token length: 0
==> Running upload-coverage
error -- Upload queued for processing failed:
         {"message":"Token required because branch is protected"}
==> Failed to run upload-coverage
```

A Dependabot-triggered `pull_request` run does not receive the repository's Actions secrets, so `${{ secrets.CODECOV_TOKEN }}` resolves to the empty string.

**The secret exists in both stores** — I checked, and adding it is not the fix:

```
$ gh secret list                    CODECOV_TOKEN  2026-08-28T01:21:05Z
$ gh secret list --app dependabot   CODECOV_TOKEN  2026-08-28T01:42:01Z
```

Both predate the failing runs (2026-08-29T01:48). The token is still empty in the Dependabot context.

## Why skip rather than relax `fail_ci_if_error`

That flag was set deliberately, and the comment above the step records why: a silently missing `lcov.info` looked like a healthy upload for as long as the file was never generated at all. Turning it off would restore exactly the blindness it was added to remove.

Skipping for Dependabot is narrower. The coverage delta of a dependency bump is not a signal worth gating a security update on, and the hard failure stays in force for every human-authored PR — verified on **#1570 and #1573**, both of which pass this step with the token present.

```yaml
if: matrix.node-version == '20' && github.actor != 'dependabot[bot]'
```

One line, plus a comment carrying the log excerpt so the next person does not re-diagnose it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsdrp8aYppGfxuZiJt9xev