### PR TITLE
chore: bump version to v2.7.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-adr-analysis-server",
-  "version": "2.7.35",
+  "version": "2.7.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-adr-analysis-server",
-      "version": "2.7.35",
+      "version": "2.7.36",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-adr-analysis-server",
   "mcpName": "io.github.tosin2013/mcp-adr-analysis-server",
-  "version": "2.7.35",
+  "version": "2.7.36",
   "description": "MCP server for analyzing Architectural Decision Records and project architecture",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
## Version Bump

Automated version bump to **v2.7.36** following release.

- **Triggered by**: fix(ci): enumerate packaged entry points instead of a MODULES list (#1589)
- **Author**: @tosin2013
- **Bump type**: patch

> This PR updates `package.json` and `package-lock.json` only.
> The `no-release` label prevents this merge from triggering another release.
>
> The auto-release workflow that opened this PR is **waiting**
> for it to merge so it can tag the resulting commit (where
> package.json correctly says v2.7.36). Do not
> close this PR without merging unless you also intend to abort
> the release.
>
> **If CI did not run on this PR**, the parent workflow opened it
> with the default `GITHUB_TOKEN` (because the `RELEASE_TOKEN`
> repo secret is not set). To kick CI, either:
> 1. Close and immediately reopen this PR, OR
> 2. Push an empty commit to its branch.
>
> To enable full hands-off automation in the future, create a
> PAT (or GitHub App) with `Contents: Read & Write` and `Pull
> requests: Read & Write`, and add it as the `RELEASE_TOKEN`
> repo secret.