### PR TITLE
fix(tests): un-skip rule-generation-tool pattern test (#744)

### DIFF
--- a/.repo-governor/acceptance/744.json
+++ b/.repo-governor/acceptance/744.json
@@ -1,0 +1,13 @@
+{
+  "authority_id": "744",
+  "criteria": [
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -P \"it\\.skip\\(\" tests/tools/rule-generation-tool.test.ts'"
+    },
+    {
+      "check": "tests_pass",
+      "target": "npx vitest run tests/tools/rule-generation-tool.test.ts"
+    }
+  ]
+}

--- a/tests/tools/rule-generation-tool.test.ts
+++ b/tests/tools/rule-generation-tool.test.ts
@@ -137,9 +137,7 @@ describe('rule-generation-tool', () => {
       });
     });
 
-    // Skip: Pattern-based rule generation triggers slow file system operations
-    // Run manually with `npm run test:integration`
-    it.skip('should generate rules from patterns', async () => {
+    it('should generate rules from patterns', async () => {
       const result = await generateRules({
         source: 'patterns',
         codebasePath: '/test/codebase',


### PR DESCRIPTION
## Summary
- Un-skip `should generate rules from patterns` test in `tests/tools/rule-generation-tool.test.ts`
- The `generateRulesFromPatterns` mock was already in place; the filesystem concern that motivated the skip no longer applies
- Add acceptance criteria file for governor tracking

## Test plan
- [x] `npx vitest run tests/tools/rule-generation-tool.test.ts` — 17/17 pass (was 16 + 1 skipped)
- [x] No `it.skip` remains in the file

Closes #744

Made with [Cursor](https://cursor.com)