### PR TITLE
docs(naming): rename "Knowledge Graph" to "Session & Tool-Usage Tracker" (#1548)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 This is a **Model Context Protocol (MCP) server** that provides AI-powered architectural analysis and ADR (Architectural Decision Record) management. The server integrates with AI assistants (Claude, Cline, Cursor) via the MCP protocol and uses OpenRouter.ai for generating actual analysis results instead of prompts.
 
-**Core Architecture**: MCP server (`src/index.ts`) exposes 73 tools through `@modelcontextprotocol/sdk` that call into utilities for AI execution, caching, knowledge graphs, and memory management.
+**Core Architecture**: MCP server (`src/index.ts`) exposes 73 tools through `@modelcontextprotocol/sdk` that call into utilities for AI execution, caching, session/tool-usage tracking, and memory management.
 
 ## Critical Technical Conventions
 
@@ -81,17 +81,17 @@ return {
 
 ## Memory & State Management
 
-### Knowledge Graph System (`src/utils/knowledge-graph-manager.ts`)
+### Session & Tool-Usage Tracker (`src/utils/knowledge-graph-manager.ts`)
 
-- **Persistent storage** in OS temp directory: `$TMPDIR/{projectName}/cache/`
+- **Persistent storage** in project-local JSON snapshots: `$TMPDIR/{projectName}/cache/knowledge-graph-snapshots.json`
 - Tracks intents, tool executions, ADR decisions, and relationships
-- Provides `queryKnowledgeGraph()` for semantic context retrieval
+- Provides `queryKnowledgeGraph()` for keyword-scored retrieval over stored snapshots
 - Memory operations are recorded for analytics (limited to last 1000 entries)
 
 ### State Reinforcement (`src/utils/state-reinforcement-manager.ts`)
 
 - **Context decay mitigation**: Re-injects core context every 5 turns or when responses exceed 3000 tokens
-- Integrates recent knowledge graph intents into context reminders
+- Integrates recent session tracker intents into context reminders
 - Configuration: `turnInterval`, `tokenThreshold`, `includeKnowledgeGraphContext`
 
 ### Conversation Memory (`src/utils/conversation-memory-manager.ts`)
@@ -138,7 +138,7 @@ Authoritative templates for infrastructure deployment that LLMs query for platfo
 
 ### Research & Integration
 
-- `research-question-tool.ts`: Query knowledge graph and external sources
+- `research-question-tool.ts`: Query session state and external sources
 - `llm-web-search-tool.ts`: Firecrawl integration for web research
 - `research-integration-tool.ts`: Synthesize research into actionable insights
 
@@ -179,7 +179,7 @@ Authoritative templates for infrastructure deployment that LLMs query for platfo
 src/
 ├── index.ts              # MCP server entry point (8466 lines - tool/resource/prompt handlers)
 ├── tools/                # 73 specialized MCP tools
-├── utils/                # Core utilities (AI, caching, knowledge graph, logging)
+├── utils/                # Core utilities (AI, caching, session tracking, logging)
 ├── types/                # TypeScript type definitions and schemas
 ├── config/               # Configuration management
 ├── prompts/              # Prompt templates for AI execution

--- a/.repo-governor/acceptance/1548.json
+++ b/.repo-governor/acceptance/1548.json
@@ -1,0 +1,21 @@
+{
+  "authority_id": "1548",
+  "criteria": [
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -q \"A graph database maintained\" README.md'"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c 'grep -q \"tool-usage\" README.md'"
+    },
+    {
+      "check": "tests_pass",
+      "target": "npx vitest run tests/smoke.test.ts"
+    },
+    {
+      "check": "command_exit",
+      "target": "npm run typecheck"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The **Model Context Protocol (MCP)** is an open standard that enables seamless i
 <details>
 <summary><b>Key Terms</b></summary>
 
-| Term                   | Definition                                                                                                                                                                                                        |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ADR**                | **Architectural Decision Record** — A document that captures an important architectural decision along with its context, alternatives considered, and consequences.                                               |
-| **MCP**                | **Model Context Protocol** — An open standard enabling AI assistants to connect to external tools and data sources.                                                                                               |
-| **Tree-sitter**        | An incremental parsing library that provides AST (Abstract Syntax Tree) analysis for 50+ languages. Used for semantic code understanding, extracting function signatures, and identifying architectural patterns. |
-| **Knowledge Graph**    | A graph database maintained by the server that tracks relationships between ADRs, code implementations, and architectural decisions. Enables intelligent code linking and impact analysis.                        |
-| **Smart Code Linking** | AI-powered discovery of code files related to ADRs and architectural decisions, using keyword extraction and semantic search.                                                                                     |
-| **ADR Aggregator**     | Optional SaaS integration for syncing and sharing ADR context across teams (`ADR_AGGREGATOR_API_KEY`).                                                                                                            |
+| Term                             | Definition                                                                                                                                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ADR**                          | **Architectural Decision Record** — A document that captures an important architectural decision along with its context, alternatives considered, and consequences.                                                |
+| **MCP**                          | **Model Context Protocol** — An open standard enabling AI assistants to connect to external tools and data sources.                                                                                                |
+| **Tree-sitter**                  | An incremental parsing library that provides AST (Abstract Syntax Tree) analysis for 50+ languages. Used for semantic code understanding, extracting function signatures, and identifying architectural patterns.  |
+| **Session & Tool-Usage Tracker** | Project-local tracking of session intents, tool executions, and ADR registrations, with keyword-scored retrieval over JSON snapshots. Supports workflow continuity and tool-usage evidence — not a graph database. |
+| **Smart Code Linking**           | AI-powered discovery of code files related to ADRs and architectural decisions, using keyword extraction and semantic search.                                                                                      |
+| **ADR Aggregator**               | Optional SaaS integration for syncing and sharing ADR context across teams (`ADR_AGGREGATOR_API_KEY`).                                                                                                             |
 
 </details>
 
@@ -156,14 +156,14 @@ Get your API key at [adraggregator.com](https://adraggregator.com)
 
 ### Execution Modes
 
-|                          | **Full Mode**                                                                      | **Prompt-Only Mode**                                              |
-| ------------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| **Requires API key?**    | Yes (`OPENROUTER_API_KEY`)                                                         | No                                                                |
-| **Returns**              | Actual analysis results with confidence scores                                     | Prompts you can paste into any AI chat                            |
-| **Set via**              | `EXECUTION_MODE=full`                                                              | `EXECUTION_MODE=prompt-only` (default)                            |
-| **Best for**             | Production use, automation                                                         | Trying it out, no-cost exploration                                |
-| **Available Features**   | All 73 tools, AI analysis, confidence scoring, Smart Code Linking, Knowledge Graph | Analysis prompts, templates, local file operations, ADR discovery |
-| **Unavailable Features** | —                                                                                  | AI execution, confidence scores, Smart Code Linking, web research |
+|                          | **Full Mode**                                                                                   | **Prompt-Only Mode**                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Requires API key?**    | Yes (`OPENROUTER_API_KEY`)                                                                      | No                                                                |
+| **Returns**              | Actual analysis results with confidence scores                                                  | Prompts you can paste into any AI chat                            |
+| **Set via**              | `EXECUTION_MODE=full`                                                                           | `EXECUTION_MODE=prompt-only` (default)                            |
+| **Best for**             | Production use, automation                                                                      | Trying it out, no-cost exploration                                |
+| **Available Features**   | All 73 tools, AI analysis, confidence scoring, Smart Code Linking, Session & Tool-Usage Tracker | Analysis prompts, templates, local file operations, ADR discovery |
+| **Unavailable Features** | —                                                                                               | AI execution, confidence scores, Smart Code Linking, web research |
 
 **Tip:** Start with prompt-only mode to explore the tool catalog — you can analyze projects, discover ADRs, and generate templates without an API key. Add an API key when you're ready for AI-powered analysis with confidence scoring.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ graph TD
 ### **Advanced Capabilities**
 
 - **AI-Powered Analysis** - Intelligent architectural pattern recognition
-- **Knowledge Graph** - Dynamic learning and relationship mapping
+- **Session & Tool-Usage Tracker** - Project-local state tracking with keyword-scored retrieval
 - **Content Security** - Automatic sensitive data masking
 - **Multi-Format Support** - TypeScript, Python, Java, Go, and more
 - **CI/CD Integration** - Automated validation and deployment workflows
@@ -145,13 +145,13 @@ graph TD
 
 ## 📊 Performance Metrics
 
-| Capability               | Performance   | Coverage |
-| ------------------------ | ------------- | -------- |
-| **Project Analysis**     | 2-5 seconds   | 100%     |
-| **ADR Generation**       | 8-15 seconds  | 95%      |
-| **Security Scanning**    | 1-3 seconds   | 100%     |
-| **Content Masking**      | 0.5-1 seconds | 95%      |
-| **Knowledge Graph**      | Real-time     | 90%      |
+| Capability                 | Performance   | Coverage |
+| -------------------------- | ------------- | -------- |
+| **Project Analysis**       | 2-5 seconds   | 100%     |
+| **ADR Generation**         | 8-15 seconds  | 95%      |
+| **Security Scanning**      | 1-3 seconds   | 100%     |
+| **Content Masking**        | 0.5-1 seconds | 95%      |
+| **Session State Tracking** | Real-time     | 90%      |
 
 ---
 

--- a/docs/explanation/ai-architecture-concepts.md
+++ b/docs/explanation/ai-architecture-concepts.md
@@ -11,7 +11,7 @@ The MCP ADR Analysis Server integrates AI capabilities at multiple levels to pro
 ### Key Concepts
 
 - **Dual Execution Modes**: Full AI mode vs. prompt-only mode for flexibility
-- **Knowledge Graph**: Persistent memory of architectural relationships
+- **Session & Tool-Usage Tracker**: Project-local tracking of session intents, tool executions, and ADR registrations
 - **Tree-sitter Integration**: Semantic code understanding for accurate analysis
 - **Confidence Scoring**: Quantified reliability of analysis results
 - **Cascading Data Sources**: Multi-tier information retrieval strategy
@@ -118,9 +118,9 @@ interface AIExecutorRequest {
 
 ---
 
-## Knowledge Graph Architecture
+## Session & Tool-Usage Tracker Architecture
 
-The Knowledge Graph is a persistent memory system that tracks relationships between architectural artifacts.
+The Session & Tool-Usage Tracker is a project-local state system that tracks relationships between architectural artifacts using JSON snapshots with keyword-scored retrieval.
 
 ### Graph Structure
 
@@ -326,7 +326,7 @@ flowchart TD
     L1 -->|Not found| L2
     L1 -->|Found| R[Result]
 
-    subgraph L2[Level 2: Knowledge Graph]
+    subgraph L2[Level 2: Session State]
         D[ADR History]
         E[Decision Context]
         F[Relationships]
@@ -356,7 +356,7 @@ flowchart TD
 ### Priority Order
 
 1. **Project Files**: Most authoritative, highest confidence
-2. **Knowledge Graph**: Architectural context and history
+2. **Session State**: Architectural context and history
 3. **Environment**: Runtime configuration and deployment
 4. **Web Search**: not performed by this server. It reports that web research would help and leaves it to the host, which has native web search (ADR-023, #1526).
 
@@ -376,11 +376,11 @@ flowchart TD
 - Better user flexibility and adoption
 - No vendor lock-in for AI provider
 
-### Decision 2: Local Knowledge Graph
+### Decision 2: Local Session & Tool-Usage Tracker
 
 **Problem**: AI models lack persistent memory between sessions.
 
-**Solution**: Maintain a local knowledge graph that persists architectural relationships.
+**Solution**: Maintain project-local JSON snapshots that persist session intents, tool executions, and architectural relationships with keyword-scored retrieval.
 
 **Trade-offs**:
 

--- a/docs/explanation/ai-workflow-concepts.md
+++ b/docs/explanation/ai-workflow-concepts.md
@@ -181,9 +181,9 @@ The Human Override system forces AI-powered planning when LLMs get confused or s
 - Input: "The build is broken and tests are failing, need to fix everything"
 - Extracted Goals: ["Fix build issues", "Resolve test failures", "Validate system stability"]
 
-### Integration with Knowledge Graph
+### Integration with Session & Tool-Usage Tracker
 
-The Human Override system integrates with the Knowledge Graph to:
+The Human Override system integrates with the Session & Tool-Usage Tracker to:
 
 - Track human intervention patterns
 - Record forced execution contexts
@@ -414,7 +414,7 @@ Combine AI-powered tools for comprehensive workflows:
 Maintain context across tool executions:
 
 - Include conversation history in orchestration requests
-- Use knowledge graph to track intent progressions
+- Use session state to track intent progressions
 - Leverage smart scoring for continuous assessment
 
 ### Fallback Strategies

--- a/docs/explanation/architecture-overview.md
+++ b/docs/explanation/architecture-overview.md
@@ -44,7 +44,7 @@ flowchart TB
 
         subgraph Utils[Utility Layer]
             U1[AI Executor]
-            U2[Knowledge Graph]
+            U2[Session Tracker]
             U3[Cache Manager]
             U4[Tree-sitter]
         end
@@ -119,7 +119,7 @@ graph LR
 
     subgraph Utilities
         AI[AI Executor]
-        KG[Knowledge Graph]
+        KG[Session Tracker]
         CM[Cache Manager]
         TS[Tree-sitter]
         LOG[Logger]
@@ -163,7 +163,7 @@ sequenceDiagram
     Server-->>Client: JSON-RPC Response
 ```
 
-### Knowledge Graph Flow
+### Session & Tool-Usage Tracking Flow
 
 ```mermaid
 flowchart LR
@@ -180,7 +180,7 @@ flowchart LR
     end
 
     subgraph Storage
-        G[(Knowledge Graph)]
+        G[(Session State)]
     end
 
     subgraph Output
@@ -321,9 +321,7 @@ The architecture supports extension through:
 export const myNewTool = {
   name: 'my_new_tool',
   description: 'Does something useful',
-  inputSchema: {
-    /* JSON Schema */
-  },
+  inputSchema: {/* JSON Schema */},
   handler: async params => {
     /* Implementation */
   },

--- a/docs/explanation/context-file-tool-coverage.md
+++ b/docs/explanation/context-file-tool-coverage.md
@@ -84,7 +84,7 @@ The patterns section shows **successful multi-tool workflows**:
 
 ### 4. **Context Awareness** (All Tools)
 
-Every tool execution is tracked in the knowledge graph:
+Every tool execution is tracked in the session state:
 
 ```markdown
 ### Active Intents
@@ -243,7 +243,7 @@ await generator.writeContextFile(kgManager, memoryManager, conversationManager);
 
 ### 2. **Rich Analytics**
 
-Let the knowledge graph track tool usage:
+Let the session tracker track tool usage:
 
 ```typescript
 await kgManager.addToolExecution(intentId, toolName, parameters, result, success);
@@ -266,7 +266,7 @@ await kgManager.createIntent('Implement authentication microservice', [
 Document successful tool chains:
 
 ```typescript
-// Knowledge graph automatically tracks tool execution order
+// Session tracker automatically tracks tool execution order
 // Context file surfaces successful patterns
 ```
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -25,7 +25,7 @@ This section contains explanation documentation following the Diataxis framework
 - [Server Architecture](./server-architecture.md)
 - [MCP Architecture Flow](./mcp-architecture-flow.md)
 - [Tool Design](./tool-design.md)
-- [Knowledge Graph](./knowledge-graph.md)
+- [Session & Tool-Usage Tracker](./knowledge-graph.md)
 - [Security Philosophy](./security-philosophy.md)
 - [Performance Design](./performance-design.md)
 - [ADR Philosophy](./adr-philosophy.md)

--- a/docs/explanation/knowledge-graph.md
+++ b/docs/explanation/knowledge-graph.md
@@ -1,26 +1,26 @@
-# 🧠 Knowledge Graph Architecture
+# Session & Tool-Usage Tracker
 
-**Understanding how the MCP ADR Analysis Server builds and maintains intelligent knowledge graphs for enhanced architectural analysis.**
+**Understanding how the MCP ADR Analysis Server tracks project-local session intents, tool usage, and ADR registrations with keyword-scored retrieval.**
 
 ---
 
 ## 🎯 Overview
 
-The Knowledge Graph system is the intelligent memory and learning component of the MCP ADR Analysis Server. It builds and maintains a dynamic graph of relationships between architectural decisions, code patterns, and project evolution over time, enabling the server to provide increasingly sophisticated and contextual analysis.
+This component stores project-local workflow state (intents, tool executions, ADR registrations, todo sync, score trends) and supports keyword retrieval. It tracks relationships between architectural decisions, code patterns, and project evolution over time within project-local JSON snapshots.
 
 ### Key Concepts
 
-- **Graph-Based Learning** - Relationships between architectural elements
+- **Session Intent Tracking** - Records human requests and AI tool executions per session
 - **Temporal Evolution** - How decisions and patterns change over time
-- **Contextual Memory** - Project-specific knowledge retention
-- **Intelligent Inference** - Drawing connections between disparate elements
-- **Adaptive Learning** - Improving analysis quality through experience
+- **Project-Local State** - Stores intents, tool results, ADR registrations, and score trends in JSON snapshots
+- **Keyword-Scored Retrieval** - Finds relevant entries by keyword matching over stored snapshots
+- **TODO Synchronization** - Keeps task state in sync with project TODO files
 
 ---
 
 ## 🏗️ Architecture and Design
 
-### Knowledge Graph Structure
+### Tracker Structure
 
 ```mermaid
 graph TB
@@ -38,7 +38,7 @@ graph TB
         HistoryParser --> Entities
 
         Entities --> Relations[Relationship Mapping]
-        Relations --> Graph[Knowledge Graph]
+        Relations --> Graph[Session State Store]
     end
 
     subgraph "Graph Storage"
@@ -359,14 +359,14 @@ class PatternRecognizer {
 
 ## 💡 Design Decisions
 
-### Decision 1: Graph-Based Knowledge Representation
+### Decision 1: JSON-Snapshot-Based State Tracking
 
-**Problem**: Traditional relational databases don't capture the complex, interconnected nature of architectural knowledge  
-**Solution**: Use a graph database to represent entities and their relationships naturally  
+**Problem**: Need a lightweight way to persist session state and architectural relationships without external dependencies  
+**Solution**: Use project-local JSON snapshots with keyword-scored retrieval  
 **Trade-offs**:
 
-- ✅ **Pros**: Natural representation of complex relationships, powerful query capabilities
-- ❌ **Cons**: More complex queries, potentially slower for simple lookups
+- ✅ **Pros**: No external database required, simple file-based persistence, easy to inspect and debug
+- ❌ **Cons**: Limited query expressiveness compared to a full database, linear scan for keyword matching
 
 ### Decision 2: Multi-Layer Graph Storage
 
@@ -397,7 +397,7 @@ class PatternRecognizer {
 
 ---
 
-## 📊 Knowledge Graph Metrics
+## 📊 Session & Tool-Usage Tracker Metrics
 
 ### Current Performance
 
@@ -420,18 +420,18 @@ class PatternRecognizer {
 
 ## 🔗 Related Concepts
 
-- **[Server Architecture](./server-architecture.md)** - How the knowledge graph integrates with the overall system
-- **[Performance Design](./performance-design.md)** - Graph query optimization strategies
-- **[Tool Design](./tool-design.md)** - How tools leverage the knowledge graph
+- **[Server Architecture](./server-architecture.md)** - How the session tracker integrates with the overall system
+- **[Performance Design](./performance-design.md)** - Query optimization strategies
+- **[Tool Design](./tool-design.md)** - How tools leverage the session tracker
 
 ---
 
 ## 📚 Further Reading
 
 - **[Knowledge Generation Framework](./knowledge-generation-framework-design.md)** - Detailed framework documentation
-- **[Research Integration Guide](../how-to-guides/research-integration.md)** - Using knowledge graph for research
-- **[API Reference](../reference/api-reference.md)** - Knowledge graph query endpoints
+- **[Research Integration Guide](../how-to-guides/research-integration.md)** - Using session state for research
+- **[API Reference](../reference/api-reference.md)** - Session state query endpoints
 
 ---
 
-**Questions about the knowledge graph?** → **[Open an Issue](https://github.com/tosin2013/mcp-adr-analysis-server/issues)**
+**Questions about the session tracker?** → **[Open an Issue](https://github.com/tosin2013/mcp-adr-analysis-server/issues)**

--- a/docs/explanation/mcp-concepts.md
+++ b/docs/explanation/mcp-concepts.md
@@ -138,7 +138,7 @@ Resources in MCP are like "live documents" that the AI can read. Unlike static f
 
 ### Our Key Resources
 
-#### **Architectural Knowledge Graph**
+#### **Architectural Session State**
 
 ```
 adr://architectural_knowledge_graph?projectPath=/your/project
@@ -326,7 +326,7 @@ You → AI + MCP → Specialized tools → Your actual project → Tailored anal
 1. **Real-Time Analysis** - Always works with current project state
 2. **Specialized Knowledge** - Applies architectural best practices and methodologies
 3. **Actionable Outputs** - Generates actual files, documentation, and plans
-4. **Continuous Learning** - Builds knowledge graph that improves over time
+4. **Continuous Tracking** - Builds project-local session state that accumulates over time
 5. **Integration-Ready** - Works with your existing tools and workflows
 
 ---
@@ -355,9 +355,9 @@ This context helps the AI:
 - Provide consistent recommendations across sessions
 - Build on previous analysis rather than starting fresh
 
-### Knowledge Graph Integration
+### Session State Tracking
 
-The server builds a persistent knowledge graph that captures:
+The server builds persistent project-local session state that captures:
 
 ```mermaid
 graph LR
@@ -378,10 +378,10 @@ graph LR
 
 This enables:
 
-- **Learning from Experience** - Each analysis improves future recommendations
+- **Accumulating State** - Each session adds intents, tool results, and ADR registrations to local snapshots
 - **Relationship Discovery** - Understanding how decisions impact each other
 - **Progress Tracking** - Monitoring implementation across time
-- **Pattern Recognition** - Identifying recurring issues and solutions
+- **Keyword Retrieval** - Finding relevant prior entries by keyword matching over stored snapshots
 
 ### Advanced AI Techniques
 
@@ -443,8 +443,8 @@ The server employs sophisticated prompting techniques:
    - Deployment readiness for production systems
    - Performance analysis for high-scale applications
 
-5. **Maintain the Knowledge Graph**
-   - Regular analysis updates keep the knowledge current
+5. **Maintain Session State**
+   - Regular analysis updates keep the tracked state current
    - Progressive refinement improves accuracy over time
 
 ---

--- a/docs/explanation/prompt-engineering.md
+++ b/docs/explanation/prompt-engineering.md
@@ -27,7 +27,7 @@ graph TB
     subgraph "Input Processing"
         Task[Analysis Task] --> Context[Context Gathering]
         Context --> History[Historical Context]
-        History --> Knowledge[Knowledge Graph]
+        History --> Knowledge[Session State]
     end
 
     subgraph "Prompt Construction"
@@ -377,7 +377,7 @@ class ChainOfThoughtFramework {
 ### Decision 2: Context-Aware Prompt Generation
 
 **Problem**: Generic prompts don't leverage project-specific context effectively  
-**Solution**: Dynamically generate prompts based on project context and knowledge graph  
+**Solution**: Dynamically generate prompts based on project context and session state  
 **Trade-offs**:
 
 - ✅ **Pros**: More relevant and accurate analysis, better user experience
@@ -427,7 +427,7 @@ class ChainOfThoughtFramework {
 ## 🔗 Related Concepts
 
 - **[Server Architecture](./server-architecture.md)** - How prompt engineering integrates with the overall system
-- **[Knowledge Graph](./knowledge-graph.md)** - How knowledge graph enhances prompt context
+- **[Session & Tool-Usage Tracker](./knowledge-graph.md)** - How session state enhances prompt context
 - **[Tool Design](./tool-design.md)** - How tools leverage advanced prompting techniques
 
 ---

--- a/docs/explanation/self-learning-architecture.md
+++ b/docs/explanation/self-learning-architecture.md
@@ -46,7 +46,7 @@ graph TB
     subgraph "Knowledge Sources"
         ADR[ADR Files]
         ENV[Environment Detection]
-        GRAPH[Knowledge Graph]
+        GRAPH[Session State]
         WEB[Web Search]
         LEARNED[Learned Patterns]
     end
@@ -133,7 +133,7 @@ async generateDeploymentPlan(): Promise<DynamicDeploymentPlan> {
 graph LR
     Q[Question] --> PF[Project Files]
     PF --> |Found| CONF1[Confidence: 0.9]
-    PF --> |Not Found| KG[Knowledge Graph]
+    PF --> |Not Found| KG[Session State]
     KG --> |Found| CONF2[Confidence: 0.8]
     KG --> |Not Found| ENV[Environment]
     ENV --> |Found| CONF3[Confidence: 0.7]
@@ -189,9 +189,7 @@ await memory.upsertEntity({
     applicabilityScope: ['openshift', 'kubernetes'],
     lastValidated: '2025-01-09T...',
     keyInsights: ['Recommended platform: openshift', 'Confidence: 0.95', 'Required files: 8'],
-    actionableItems: [
-      /* deployment steps */
-    ],
+    actionableItems: [/* deployment steps */],
   },
 });
 ```
@@ -275,7 +273,7 @@ sequenceDiagram
         DDI-->>BVL: Use learned pattern (FAST)
     else No pattern or low confidence
         DDI->>RES: Research live documentation
-        RES->>RES: Query ADRs, Knowledge Graph, Environment
+        RES->>RES: Query ADRs, Session State, Environment
         alt Need web search
             RES->>RES: Fallback to web search
         end
@@ -667,7 +665,7 @@ Every intelligence source returns a confidence score:
 | --------------- | ---------------- | -------------- |
 | Learned Pattern | 0.8 - 1.0        | Reuse if > 0.8 |
 | Project Files   | 0.8 - 0.9        | High trust     |
-| Knowledge Graph | 0.7 - 0.8        | Medium trust   |
+| Session State   | 0.7 - 0.8        | Medium trust   |
 | Environment     | 0.6 - 0.7        | Context-aware  |
 | Web Search      | 0.5 - 0.6        | Lowest trust   |
 
@@ -816,7 +814,7 @@ LOG_LEVEL=debug npm start
 ### Research Areas
 
 1. **Reinforcement Learning**: Improve pattern selection based on success metrics
-2. **Graph Neural Networks**: Better relationship modeling in knowledge graph
+2. **Graph Neural Networks**: Better relationship modeling in session state tracking
 3. **Federated Learning**: Share patterns while preserving privacy
 4. **Active Learning**: Ask humans for feedback on uncertain decisions
 
@@ -824,7 +822,7 @@ LOG_LEVEL=debug npm start
 
 - [Bootstrap Validation Loop Guide](../how-to-guides/interactive-adr-planning.md)
 - [Deployment Readiness Tool](../reference/validation-tools.md#-deployment_readiness)
-- [Knowledge Graph System](./knowledge-graph-architecture.md)
+- [Session & Tool-Usage Tracker](./knowledge-graph-architecture.md)
 - [Memory Loading Tool](../reference/api-reference.md#memory_loading)
 
 ---

--- a/docs/explanation/server-architecture.md
+++ b/docs/explanation/server-architecture.md
@@ -10,15 +10,15 @@ The MCP ADR Analysis Server is an intelligent architectural analysis platform th
 graph TB
     subgraph "Client Environment"
         Claude[Claude AI]
-        Gemini[Google Gemini] 
+        Gemini[Google Gemini]
         OpenAI[OpenAI GPT]
         Other[Other LLM Clients]
     end
-    
+
     subgraph "MCP Protocol Layer"
         Protocol[MCP Protocol<br/>stdin/stdout]
     end
-    
+
     subgraph "MCP ADR Server"
         subgraph "Core Server"
             Index[index.ts<br/>Server Entry Point]
@@ -26,33 +26,33 @@ graph TB
             Resources[Resource Registry<br/>3 MCP Resources]
             Prompts[Prompt Registry<br/>AI Templates]
         end
-        
+
         subgraph "New File System Layer"
             ReadFile[read_file tool]
-            WriteFile[write_file tool] 
+            WriteFile[write_file tool]
             ListDir[list_directory tool]
             Security[Path Security<br/>Validation]
         end
-        
+
         subgraph "Utility Layer"
             ADRDisc[adr-discovery.js<br/>Actual ADR Reading]
             FileOps[actual-file-operations.js<br/>Project Scanning]
             ContentMask[content-masking.js<br/>Security Analysis]
             ResearchInt[research-integration.js<br/>Research Processing]
         end
-        
+
         subgraph "AI Processing Layer"
             PromptExec[prompt-execution.js<br/>Internal AI Engine]
             KnowledgeGen[knowledge-generation.js<br/>GKP Enhancement]
             AIFallback[AI Fallback Strategy]
         end
-        
+
         subgraph "Cache & Config"
             Cache[.mcp-adr-cache/<br/>Result Caching]
             Config[Environment Config<br/>PROJECT_PATH, etc.]
         end
     end
-    
+
     subgraph "Target Project"
         ProjectFiles[Project Files]
         ADRs[././adrs/<br/>ADR Files]
@@ -60,44 +60,44 @@ graph TB
         Config2[Configuration Files]
         Scripts[Build Scripts]
     end
-    
+
     %% Communication Flow
     Claude -->|MCP Calls| Protocol
     Gemini -->|MCP Calls| Protocol
     OpenAI -->|MCP Calls| Protocol
     Other -->|MCP Calls| Protocol
-    
+
     Protocol <-->|JSON-RPC| Index
-    
+
     Index --> Tools
     Index --> Resources
     Index --> Prompts
-    
+
     Tools --> ReadFile
     Tools --> WriteFile
     Tools --> ListDir
-    
+
     ReadFile --> Security
     WriteFile --> Security
     ListDir --> Security
-    
+
     Security --> ADRDisc
     Security --> FileOps
     Security --> ContentMask
     Security --> ResearchInt
-    
+
     ADRDisc -->|Read Files| ProjectFiles
     FileOps -->|Scan Structure| ProjectFiles
     ContentMask -->|Analyze Content| ProjectFiles
     ResearchInt -->|Process Research| Research
-    
+
     Tools --> PromptExec
     PromptExec --> KnowledgeGen
     PromptExec --> AIFallback
-    
+
     PromptExec --> Cache
     Tools --> Config
-    
+
     %% Data Flow
     ProjectFiles -.->|File Content| ADRs
     ProjectFiles -.->|File Content| Research
@@ -115,25 +115,25 @@ sequenceDiagram
     participant Utils as Utility Layer
     participant AI as Internal AI
     participant Project as Target Project
-    
+
     Note over Client,Project: Example: discover_existing_adrs tool call
-    
+
     Client->>MCP: discover_existing_adrs(adrDirectory)
     MCP->>FileSystem: list_directory(adrDirectory)
     FileSystem->>Utils: Security validation
     Utils->>Project: Read directory contents
     Project-->>Utils: File list
-    
+
     loop For each ADR file
         Utils->>FileSystem: read_file(adrPath)
         FileSystem->>Project: Read ADR content
         Project-->>FileSystem: ADR content
         FileSystem-->>Utils: Validated content
     end
-    
+
     Utils->>Utils: Parse ADR metadata & content
     Utils->>AI: Generate analysis prompt + actual data
-    
+
     alt Internal AI Available
         AI->>AI: Process prompt with file content
         AI-->>Utils: Intelligent analysis results
@@ -141,9 +141,9 @@ sequenceDiagram
     else AI Unavailable (Fallback)
         Utils-->>MCP: Raw prompt + file content
     end
-    
+
     MCP-->>Client: Analysis results or prompt for external processing
-    
+
     Note over Client,Project: Client gets either AI insights or raw data to process
 ```
 
@@ -157,11 +157,11 @@ graph LR
         B3 --> B4[Return Template]
         B4 --> B1
         B1 --> B5[Client must process<br/>externally]
-        
+
         style B3 fill:#ffcccc
         style B5 fill:#ffcccc
     end
-    
+
     subgraph "AFTER: Hybrid Mode"
         A1[LLM Client] -->|Call Tool| A2[MCP Server]
         A2 --> A3[Read Actual Files]
@@ -171,7 +171,7 @@ graph LR
         A5 -->|No| A7[Return Prompt + Data]
         A6 --> A1
         A7 --> A1
-        
+
         style A3 fill:#ccffcc
         style A4 fill:#ccffcc
         style A6 fill:#ccffcc
@@ -181,16 +181,19 @@ graph LR
 ## Core Components
 
 ### 1. MCP Server Core (`src/index.ts`)
+
 - **Entry Point**: Main server initialization and protocol handling
 - **Tool Registry**: 31 MCP tools for comprehensive ADR analysis and project management
 - **Resource Registry**: 3 MCP resources for structured data access
 - **Prompt Registry**: AI-ready templates for analysis tasks
-- **Knowledge Graph**: Advanced intent tracking and TODO synchronization
+- **Session & Tool-Usage Tracker**: Project-local intent tracking and TODO synchronization
 
 ### 2. File System Layer (New)
+
 Three new fundamental tools that enable universal LLM compatibility:
 
 #### `read_file` Tool
+
 ```typescript
 {
   name: 'read_file',
@@ -206,6 +209,7 @@ Three new fundamental tools that enable universal LLM compatibility:
 ```
 
 #### `write_file` Tool
+
 ```typescript
 {
   name: 'write_file',
@@ -222,6 +226,7 @@ Three new fundamental tools that enable universal LLM compatibility:
 ```
 
 #### `list_directory` Tool
+
 ```typescript
 {
   name: 'list_directory',
@@ -237,25 +242,30 @@ Three new fundamental tools that enable universal LLM compatibility:
 ```
 
 ### 3. Utility Layer
+
 Provides actual file operations and intelligent processing:
 
 #### ADR Discovery (`src/utils/adr-discovery.js`)
+
 - **Function**: `discoverAdrsInDirectory()`
 - **Purpose**: Actually read and parse ADR files + initialize `.mcp-adr-cache` infrastructure
 - **Output**: Structured ADR data with content
 - **Note**: Always initializes cache infrastructure, regardless of ADR presence
 
 #### File Operations (`src/utils/actual-file-operations.js`)
+
 - **Function**: `scanProjectStructure()`
 - **Purpose**: Comprehensive project analysis
 - **Features**: Shell script detection, content masking, pattern matching
 
 #### Content Masking (`src/utils/content-masking.js`)
+
 - **Function**: `analyzeSensitiveContent()`
 - **Purpose**: Security analysis and data protection
 - **Features**: Pattern detection, confidence scoring, masking strategies
 
 #### Research Integration (`src/utils/research-integration.js`)
+
 - **Function**: `monitorResearchDirectory()`
 - **Purpose**: Research file processing and ADR impact analysis
 - **Features**: Topic extraction, impact evaluation, update suggestions
@@ -263,6 +273,7 @@ Provides actual file operations and intelligent processing:
 ### 4. AI Processing Layer
 
 #### Internal AI Engine (`src/utils/prompt-execution.js`)
+
 ```typescript
 // Enhanced analysis with actual file content
 const result = await discoverAdrsInDirectory(adrDirectory, true, projectPath);
@@ -271,17 +282,20 @@ const aiResult = await executePromptWithFallback(analysisPrompt);
 ```
 
 #### AI-Powered Tool Orchestration
+
 - **OpenRouter.ai Integration**: Advanced AI planning through external LLM services
 - **Dynamic Tool Sequencing**: AI generates optimal tool execution sequences
 - **Hallucination Detection**: Reality checks prevent AI confusion and loops
 - **Human Override Patterns**: Predefined workflows bypass AI confusion
 
 #### Generated Knowledge Prompting (GKP)
+
 - **Enhanced Analysis**: Leverages architectural knowledge for better insights
 - **Context-Aware**: Understands project-specific patterns and technologies
 - **Confidence Scoring**: Provides reliability metrics for recommendations
 
 #### Intelligent Workflow Management
+
 ```typescript
 // AI-powered tool orchestration
 const plan = await generateToolPlan(userIntent, availableTools);
@@ -290,6 +304,7 @@ const execution = await executeWithFallback(sequence);
 ```
 
 #### Fallback Strategy
+
 ```typescript
 if (executionResult.isAIGenerated) {
   // Return smart analysis
@@ -303,30 +318,37 @@ if (executionResult.isAIGenerated) {
 ## Key Architectural Improvements
 
 ### 1. Universal LLM Compatibility
+
 - **Before**: Worked only with Claude (had file access)
 - **After**: Works with all LLM providers through internal file operations
 
 ### 2. Intelligent Fallback Strategy
+
 The server provides both AI-enhanced analysis and raw data depending on capabilities:
+
 - **AI Available**: Smart insights with confidence scores
 - **AI Unavailable**: Structured prompts with actual file content
 
 ### 3. Security-First File Access
+
 - **Path Validation**: Absolute paths required, security sandboxing
 - **Content Masking**: Automatic sensitive data detection and protection
 - **Access Control**: Configurable project boundaries
 
 ### 4. Performance Optimization
+
 - **Caching System**: Results cached in `.mcp-adr-cache/` with TTL
 - **Lazy Loading**: Utilities loaded on-demand
 - **Intelligent Filtering**: Content-aware file processing
 
 ### 5. Enhanced AI Capabilities
+
 - **Generated Knowledge Prompting**: Domain expertise enhancement
 - **Context Awareness**: Project-specific analysis
 - **Risk Assessment**: Confidence scoring and impact evaluation
 
 ### 6. Advanced Project Management Tools
+
 - **Smart Scoring System**: Dynamic project health assessment across all dimensions
 - **TODO Lifecycle Management**: Complete task tracking with status transitions
 - **AI-Powered Troubleshooting**: Systematic failure analysis with test plan generation
@@ -334,21 +356,25 @@ The server provides both AI-enhanced analysis and raw data depending on capabili
 - **Human Override System**: Force planning when LLMs get confused or stuck
 - **Smart Git Operations**: Release readiness analysis with sensitive content filtering
 
-### 7. Knowledge Graph Integration
+### 7. Session & Tool-Usage Tracking
+
 - **Intent Tracking**: Comprehensive tracking of human requests and AI responses
 - **Tool Execution History**: Complete audit trail of all tool executions
-- **TODO Synchronization**: Bidirectional sync between TODO.md and knowledge graph
+- **TODO Synchronization**: Bidirectional sync between TODO.md and project-local session state
 - **Analytics Generation**: Real-time project insights and completion metrics
 
 ## Communication Protocols
 
 ### MCP Protocol Integration
+
 The server communicates with LLM clients via the Model Context Protocol:
+
 - **Transport**: stdin/stdout JSON-RPC
 - **Format**: Structured tool calls and responses
 - **Validation**: Zod schema validation for all inputs/outputs
 
 ### Tool Execution Flow
+
 1. **Client Request**: LLM client calls MCP tool
 2. **Security Validation**: Path and content validation
 3. **File Operations**: Read actual project files
@@ -358,6 +384,7 @@ The server communicates with LLM clients via the Model Context Protocol:
 ## File System Security
 
 ### Path Security
+
 ```typescript
 // Absolute path requirement
 if (!path.isAbsolute(filePath)) {
@@ -372,6 +399,7 @@ if (!filePath.startsWith(projectPath)) {
 ```
 
 ### Content Masking
+
 - **Automatic Detection**: API keys, tokens, passwords, secrets
 - **Configurable Patterns**: Project-specific sensitive data patterns
 - **Masking Strategies**: Full, partial, placeholder, environment-based
@@ -379,6 +407,7 @@ if (!filePath.startsWith(projectPath)) {
 ## Deployment Architecture
 
 ### Environment Configuration
+
 ```bash
 PROJECT_PATH=/path/to/target/project
 ADR_DIRECTORY=./adrs
@@ -387,6 +416,7 @@ CACHE_ENABLED=true
 ```
 
 ### Cache Management
+
 - **Location**: `.mcp-adr-cache/`
 - **TTL**: Configurable time-to-live
 - **Invalidation**: Automatic on file changes
@@ -395,19 +425,21 @@ CACHE_ENABLED=true
 ## Integration Examples
 
 ### Claude Code Integration
+
 ```typescript
 // Claude automatically uses internal file tools
 const adrAnalysis = await mcpClient.call('discover_existing_adrs', {
-  adrDirectory: './adrs'
+  adrDirectory: './adrs',
 });
 // Returns intelligent analysis with actual ADR content
 ```
 
 ### Gemini/OpenAI Integration
+
 ```typescript
 // Gemini/OpenAI get actual file content through MCP file tools
 const adrAnalysis = await mcpClient.call('discover_existing_adrs', {
-  adrDirectory: './adrs'
+  adrDirectory: './adrs',
 });
 // Returns structured data they can process independently
 ```
@@ -415,26 +447,31 @@ const adrAnalysis = await mcpClient.call('discover_existing_adrs', {
 ## Tool Categories and Advanced Features
 
 ### Core Analysis Tools (Original)
+
 - `discover_existing_adrs` - ADR discovery and cataloging
 - `analyze_project_ecosystem` - Technology stack analysis
 - `suggest_adrs` - Implicit decision identification
 - `generate_adrs_from_prd` - Requirements-driven ADR generation
 
 ### Enhanced TDD and TODO Management
+
 - `generate_adr_todo` - Two-phase TDD task generation with ADR linking
 - `manage_todo` - Advanced TODO.md lifecycle management
 - `compare_adr_progress` - Implementation validation with mock detection
 
 ### AI-Powered Orchestration and Planning
+
 - `tool_chain_orchestrator` - Dynamic tool sequencing based on user intent
 - `troubleshoot_guided_workflow` - Systematic failure analysis with test plans
 
 ### Project Health and Operations
+
 - `smart_score` - Cross-tool project health scoring coordination
 - `smart_git_push` - Release readiness analysis with content security
 - `generate_deployment_guidance` - AI-driven deployment guidance generation
 
-### Knowledge Graph and Analytics
+### Session & Tool-Usage Tracking and Analytics
+
 - Comprehensive intent tracking and execution history
 - Real-time TODO.md synchronization and change detection
 - Cross-ADR dependency validation and analytics
@@ -443,6 +480,7 @@ const adrAnalysis = await mcpClient.call('discover_existing_adrs', {
 ## Future Enhancements
 
 ### Planned Improvements
+
 1. **Real-time File Watching**: Automatic updates on file changes
 2. **Distributed Caching**: Multi-project cache sharing
 3. **Enhanced Security**: Role-based access control
@@ -452,11 +490,12 @@ const adrAnalysis = await mcpClient.call('discover_existing_adrs', {
 7. **Multi-Repository Support**: Cross-repository architectural analysis
 
 ### Integration Opportunities
+
 - **CI/CD Pipelines**: Automated ADR compliance checking
 - **IDE Extensions**: Real-time architectural guidance
 - **Documentation Systems**: Automated documentation generation
 - **Compliance Tools**: Regulatory requirement tracking
-- **Team Collaboration**: Shared knowledge graphs and scoring metrics
+- **Team Collaboration**: Shared session state and scoring metrics
 
 ## Conclusion
 

--- a/docs/knowledge-graph-resource-tool.md
+++ b/docs/knowledge-graph-resource-tool.md
@@ -1,21 +1,23 @@
-# Knowledge Graph Resource and Tool (ADR-018)
+# Session State Resource and Tool (ADR-018)
 
 ## Overview
 
-The Knowledge Graph has been refactored to follow the ADR-018 Atomic Tools pattern, providing:
-- **Zero token cost** for reading graph data via MCP Resource
-- **Simple CRUD operations** for modifying graph via Tool
+Project session/tool-usage state has been refactored to follow the ADR-018 Atomic Tools pattern, providing:
+
+- **Zero token cost** for reading session state data via MCP Resource
+- **Simple CRUD operations** for modifying session state via Tool
 - **Consistent behavior** - data is queryable, not actively managed
 
 ## Architecture
 
 ### Resource: `knowledge://graph`
 
-Read-only access to the knowledge graph structure with nodes, edges, and metadata.
+Read-only access to the session state structure with nodes, edges, and metadata.
 
 **URI**: `knowledge://graph`
 
 **Returns**:
+
 ```json
 {
   "nodes": [
@@ -47,21 +49,24 @@ Read-only access to the knowledge graph structure with nodes, edges, and metadat
 ```
 
 **Benefits**:
+
 - **Zero token cost** - Resources are free to query in MCP
 - **Caching** - 60-second cache for performance
 - **Consistent data** - Always returns current graph state
 
 ### Tool: `update_knowledge`
 
-Simple CRUD operations for modifying the knowledge graph.
+Simple CRUD operations for modifying the session state.
 
 **Operations**:
+
 1. `add_entity` - Add a new node (intent, ADR, tool, code file, decision)
 2. `remove_entity` - Remove an existing node
 3. `add_relationship` - Add an edge between two nodes
 4. `remove_relationship` - Remove an edge between two nodes
 
 **Example - Add an Entity**:
+
 ```json
 {
   "operation": "add_entity",
@@ -75,6 +80,7 @@ Simple CRUD operations for modifying the knowledge graph.
 ```
 
 **Example - Add a Relationship**:
+
 ```json
 {
   "operation": "add_relationship",
@@ -85,6 +91,7 @@ Simple CRUD operations for modifying the knowledge graph.
 ```
 
 **Example - Remove an Entity**:
+
 ```json
 {
   "operation": "remove_entity",
@@ -93,6 +100,7 @@ Simple CRUD operations for modifying the knowledge graph.
 ```
 
 **Response**:
+
 ```json
 {
   "success": true,
@@ -112,13 +120,15 @@ Simple CRUD operations for modifying the knowledge graph.
 ### For Tool Developers
 
 **Old Pattern** (using KnowledgeGraphManager):
+
 ```typescript
 const kgManager = new KnowledgeGraphManager();
 const snapshot = await kgManager.loadKnowledgeGraph();
-const results = await kgManager.queryKnowledgeGraph("what ADRs exist?");
+const results = await kgManager.queryKnowledgeGraph('what ADRs exist?');
 ```
 
 **New Pattern** (using Resource):
+
 ```typescript
 // Read graph - zero token cost via MCP Resource
 const graph = await readResource('knowledge://graph');
@@ -129,18 +139,20 @@ await callTool('update_knowledge', {
   operation: 'add_entity',
   entity: 'adr-019',
   entityType: 'adr',
-  metadata: { title: 'New Decision' }
+  metadata: { title: 'New Decision' },
 });
 ```
 
 ### For LLM Prompts
 
 **Reading Graph**:
+
 - Query `knowledge://graph` resource for current state
 - Filter nodes by type: `intent`, `adr`, `tool`, `code`, `decision`
 - Traverse edges by relationship: `implements`, `uses`, `created`, `depends-on`, `supersedes`
 
 **Modifying Graph**:
+
 - Use `update_knowledge` tool with appropriate operation
 - Always check `success` field in response
 - Use `graphState` to see updated counts
@@ -148,15 +160,19 @@ await callTool('update_knowledge', {
 ## Benefits
 
 ### Zero Token Cost for Reads
+
 Resources in MCP have zero token cost for clients. Reading graph state via `knowledge://graph` is free, unlike querying via tools.
 
 ### Simple Testing
+
 Resources return pure data - no complex mocking needed. Tool operations are atomic and testable.
 
 ### LLM Control
+
 LLM decides when to query graph, not an active manager. Better aligns with AI decision-making patterns.
 
 ### Consistent Behavior
+
 Data is data. No stateful manager with inconsistent behavior between calls.
 
 ## Deprecation Notice
@@ -166,11 +182,13 @@ Data is data. No stateful manager with inconsistent behavior between calls.
 ### Internal vs External
 
 **Internal** (can still use KnowledgeGraphManager):
+
 - Core MCP server code
 - Existing tools being migrated gradually
 - Internal managers and utilities
 
 **External** (should use resource/tool):
+
 - New tools and resources
 - User prompts and queries
 - AI assistant integrations
@@ -178,12 +196,14 @@ Data is data. No stateful manager with inconsistent behavior between calls.
 ## Implementation Details
 
 ### Files
+
 - **Resource**: `src/resources/knowledge-graph-resource.ts`
 - **Tool**: `src/tools/update-knowledge-tool.ts`
 - **Tests**: `tests/resources/knowledge-graph-resource.test.ts`, `tests/tools/update-knowledge-tool.test.ts`
 - **Deprecated**: `src/utils/knowledge-graph-manager.ts` (marked with `@deprecated`)
 
 ### Registration
+
 - Resource registered in `index.ts` ListResourcesRequestSchema
 - Tool registered in `index.ts` ListToolsRequestSchema
 - Special handler for `knowledge://graph` in readResource() to inject KnowledgeGraphManager
@@ -198,12 +218,14 @@ Data is data. No stateful manager with inconsistent behavior between calls.
 ## Future Work
 
 ### Next Steps
+
 1. Migrate dependent tools to use resource/tool pattern
 2. Add more relationship types as needed
 3. Consider adding bulk operations for efficiency
 4. Remove KnowledgeGraphManager in v3.0.0
 
 ### Potential Enhancements
+
 - **Graph queries**: Add query DSL for complex graph traversals
 - **Bulk operations**: Add batch add/remove for performance
 - **Versioning**: Track graph changes over time

--- a/docs/notes/knowledge-graph.md
+++ b/docs/notes/knowledge-graph.md
@@ -1,26 +1,26 @@
-# 🧠 Knowledge Graph Architecture
+# Session & Tool-Usage Tracker
 
-**Understanding how the MCP ADR Analysis Server builds and maintains intelligent knowledge graphs for enhanced architectural analysis.**
+**Understanding how the MCP ADR Analysis Server tracks project-local session intents, tool usage, and ADR registrations with keyword-scored retrieval.**
 
 ---
 
 ## 🎯 Overview
 
-The Knowledge Graph system is the intelligent memory and learning component of the MCP ADR Analysis Server. It builds and maintains a dynamic graph of relationships between architectural decisions, code patterns, and project evolution over time, enabling the server to provide increasingly sophisticated and contextual analysis.
+This component stores project-local workflow state (intents, tool executions, ADR registrations, todo sync, score trends) and supports keyword retrieval. It tracks relationships between architectural decisions, code patterns, and project evolution over time within project-local JSON snapshots.
 
 ### Key Concepts
 
-- **Graph-Based Learning** - Relationships between architectural elements
+- **Session Intent Tracking** - Records human requests and AI tool executions per session
 - **Temporal Evolution** - How decisions and patterns change over time
-- **Contextual Memory** - Project-specific knowledge retention
-- **Intelligent Inference** - Drawing connections between disparate elements
-- **Adaptive Learning** - Improving analysis quality through experience
+- **Project-Local State** - Stores intents, tool results, ADR registrations, and score trends in JSON snapshots
+- **Keyword-Scored Retrieval** - Finds relevant entries by keyword matching over stored snapshots
+- **TODO Synchronization** - Keeps task state in sync with project TODO files
 
 ---
 
 ## 🏗️ Architecture and Design
 
-### Knowledge Graph Structure
+### Tracker Structure
 
 ```mermaid
 graph TB
@@ -30,23 +30,23 @@ graph TB
         Config[Configuration] --> ConfigParser[Config Parser]
         History[Git History] --> HistoryParser[History Parser]
     end
-    
+
     subgraph "Graph Construction"
         Parser --> Entities[Entity Extraction]
         ADRParser --> Entities
         ConfigParser --> Entities
         HistoryParser --> Entities
-        
+
         Entities --> Relations[Relationship Mapping]
-        Relations --> Graph[Knowledge Graph]
+        Relations --> Graph[Session State Store]
     end
-    
+
     subgraph "Graph Storage"
         Graph --> Memory[In-Memory Graph]
         Graph --> Persistent[Persistent Storage]
         Graph --> Cache[Graph Cache]
     end
-    
+
     subgraph "Graph Query"
         Memory --> Query[Graph Queries]
         Persistent --> Query
@@ -58,6 +58,7 @@ graph TB
 ### Entity Types
 
 **Core Entities**:
+
 ```typescript
 interface Entity {
   id: string;
@@ -74,26 +75,27 @@ enum EntityType {
   FUNCTION = 'function',
   MODULE = 'module',
   INTERFACE = 'interface',
-  
+
   // Architectural Entities
   COMPONENT = 'component',
   SERVICE = 'service',
   DATABASE = 'database',
   API = 'api',
-  
+
   // Decision Entities
   ADR = 'adr',
   PATTERN = 'pattern',
   CONSTRAINT = 'constraint',
-  
+
   // Project Entities
   FEATURE = 'feature',
   REQUIREMENT = 'requirement',
-  DEPENDENCY = 'dependency'
+  DEPENDENCY = 'dependency',
 }
 ```
 
 **Relationship Types**:
+
 ```typescript
 interface Relationship {
   id: string;
@@ -110,23 +112,23 @@ enum RelationshipType {
   EXTENDS = 'extends',
   DEPENDS_ON = 'depends_on',
   CALLS = 'calls',
-  
+
   // Architectural Relationships
   CONTAINS = 'contains',
   CONNECTS_TO = 'connects_to',
   USES = 'uses',
   PROVIDES = 'provides',
-  
+
   // Decision Relationships
   DECIDES = 'decides',
   CONSTRAINS = 'constrains',
   INFLUENCES = 'influences',
   REPLACES = 'replaces',
-  
+
   // Temporal Relationships
   EVOLVES_FROM = 'evolves_from',
   SUPERSEDES = 'supersedes',
-  PREVIOUS_VERSION = 'previous_version'
+  PREVIOUS_VERSION = 'previous_version',
 }
 ```
 
@@ -137,78 +139,80 @@ enum RelationshipType {
 ### Graph Construction Pipeline
 
 **Phase 1: Entity Extraction**
+
 ```typescript
 class EntityExtractor {
   async extractEntities(projectPath: string): Promise<Entity[]> {
     const entities: Entity[] = [];
-    
+
     // 1. Extract code entities
     const codeEntities = await this.extractCodeEntities(projectPath);
     entities.push(...codeEntities);
-    
+
     // 2. Extract architectural entities
     const archEntities = await this.extractArchitecturalEntities(projectPath);
     entities.push(...archEntities);
-    
+
     // 3. Extract decision entities
     const decisionEntities = await this.extractDecisionEntities(projectPath);
     entities.push(...decisionEntities);
-    
+
     // 4. Extract temporal entities
     const temporalEntities = await this.extractTemporalEntities(projectPath);
     entities.push(...temporalEntities);
-    
+
     return entities;
   }
-  
+
   private async extractCodeEntities(projectPath: string): Promise<Entity[]> {
     const files = await this.scanCodeFiles(projectPath);
     const entities: Entity[] = [];
-    
+
     for (const file of files) {
       const ast = await this.parseFile(file);
       const fileEntities = this.extractFromAST(ast, file);
       entities.push(...fileEntities);
     }
-    
+
     return entities;
   }
 }
 ```
 
 **Phase 2: Relationship Mapping**
+
 ```typescript
 class RelationshipMapper {
   async mapRelationships(entities: Entity[]): Promise<Relationship[]> {
     const relationships: Relationship[] = [];
-    
+
     // 1. Code relationships
     const codeRelations = await this.mapCodeRelationships(entities);
     relationships.push(...codeRelations);
-    
+
     // 2. Architectural relationships
     const archRelations = await this.mapArchitecturalRelationships(entities);
     relationships.push(...archRelations);
-    
+
     // 3. Decision relationships
     const decisionRelations = await this.mapDecisionRelationships(entities);
     relationships.push(...decisionRelations);
-    
+
     // 4. Temporal relationships
     const temporalRelations = await this.mapTemporalRelationships(entities);
     relationships.push(...temporalRelations);
-    
+
     return relationships;
   }
-  
+
   private async mapCodeRelationships(entities: Entity[]): Promise<Relationship[]> {
     const relationships: Relationship[] = [];
     const codeEntities = entities.filter(e => this.isCodeEntity(e));
-    
+
     for (const entity of codeEntities) {
       // Find imports and dependencies
       const dependencies = await this.findDependencies(entity, codeEntities);
-      
+
       for (const dep of dependencies) {
         relationships.push({
           id: `${entity.id}-depends_on-${dep.id}`,
@@ -216,10 +220,10 @@ class RelationshipMapper {
           target: dep.id,
           type: RelationshipType.DEPENDS_ON,
           weight: this.calculateDependencyWeight(entity, dep),
-          context: 'code_dependency'
+          context: 'code_dependency',
         });
       }
-      
+
       // Find usage patterns
       const usages = await this.findUsages(entity, codeEntities);
       for (const usage of usages) {
@@ -229,17 +233,18 @@ class RelationshipMapper {
           target: entity.id,
           type: RelationshipType.USES,
           weight: this.calculateUsageWeight(entity, usage),
-          context: 'code_usage'
+          context: 'code_usage',
         });
       }
     }
-    
+
     return relationships;
   }
 }
 ```
 
 **Phase 3: Graph Query and Inference**
+
 ```typescript
 class GraphQueryEngine {
   async queryGraph(query: GraphQuery): Promise<QueryResult> {
@@ -256,38 +261,38 @@ class GraphQueryEngine {
         throw new Error(`Unknown query type: ${query.type}`);
     }
   }
-  
+
   private async findRelatedEntities(query: FindRelatedQuery): Promise<QueryResult> {
     const entity = await this.getEntity(query.entityId);
     const relationships = await this.getRelationships(entity.id);
-    
+
     // Find entities within specified degrees of separation
     const related = await this.traverseGraph(entity, query.maxDepth);
-    
+
     // Rank by relevance
     const ranked = this.rankByRelevance(related, query.context);
-    
+
     return {
       entities: ranked,
       relationships: relationships,
-      confidence: this.calculateConfidence(ranked)
+      confidence: this.calculateConfidence(ranked),
     };
   }
-  
+
   private async traceInfluence(query: TraceInfluenceQuery): Promise<QueryResult> {
     const source = await this.getEntity(query.sourceId);
     const target = await this.getEntity(query.targetId);
-    
+
     // Find paths between source and target
     const paths = await this.findPaths(source, target, query.maxPathLength);
-    
+
     // Calculate influence strength
     const influence = this.calculateInfluence(paths);
-    
+
     return {
       paths: paths,
       influence: influence,
-      confidence: this.calculatePathConfidence(paths)
+      confidence: this.calculatePathConfidence(paths),
     };
   }
 }
@@ -296,36 +301,40 @@ class GraphQueryEngine {
 ### Learning and Adaptation
 
 **Pattern Recognition**:
+
 ```typescript
 class PatternRecognizer {
   async identifyPatterns(entities: Entity[], relationships: Relationship[]): Promise<Pattern[]> {
     const patterns: Pattern[] = [];
-    
+
     // 1. Structural patterns
     const structuralPatterns = await this.identifyStructuralPatterns(entities, relationships);
     patterns.push(...structuralPatterns);
-    
+
     // 2. Behavioral patterns
     const behavioralPatterns = await this.identifyBehavioralPatterns(entities, relationships);
     patterns.push(...behavioralPatterns);
-    
+
     // 3. Architectural patterns
     const archPatterns = await this.identifyArchitecturalPatterns(entities, relationships);
     patterns.push(...archPatterns);
-    
+
     // 4. Evolution patterns
     const evolutionPatterns = await this.identifyEvolutionPatterns(entities, relationships);
     patterns.push(...evolutionPatterns);
-    
+
     return patterns;
   }
-  
-  private async identifyStructuralPatterns(entities: Entity[], relationships: Relationship[]): Promise<Pattern[]> {
+
+  private async identifyStructuralPatterns(
+    entities: Entity[],
+    relationships: Relationship[]
+  ): Promise<Pattern[]> {
     const patterns: Pattern[] = [];
-    
+
     // Find common structural motifs
     const motifs = await this.findStructuralMotifs(entities, relationships);
-    
+
     for (const motif of motifs) {
       if (motif.frequency > 3 && motif.confidence > 0.7) {
         patterns.push({
@@ -336,11 +345,11 @@ class PatternRecognizer {
           entities: motif.entities,
           relationships: motif.relationships,
           confidence: motif.confidence,
-          frequency: motif.frequency
+          frequency: motif.frequency,
         });
       }
     }
-    
+
     return patterns;
   }
 }
@@ -350,19 +359,21 @@ class PatternRecognizer {
 
 ## 💡 Design Decisions
 
-### Decision 1: Graph-Based Knowledge Representation
+### Decision 1: JSON-Snapshot-Based State Tracking
 
-**Problem**: Traditional relational databases don't capture the complex, interconnected nature of architectural knowledge  
-**Solution**: Use a graph database to represent entities and their relationships naturally  
+**Problem**: Need a lightweight way to persist session state and architectural relationships without external dependencies  
+**Solution**: Use project-local JSON snapshots with keyword-scored retrieval  
 **Trade-offs**:
-- ✅ **Pros**: Natural representation of complex relationships, powerful query capabilities
-- ❌ **Cons**: More complex queries, potentially slower for simple lookups
+
+- ✅ **Pros**: No external database required, simple file-based persistence, easy to inspect and debug
+- ❌ **Cons**: Limited query expressiveness compared to a full database, linear scan for keyword matching
 
 ### Decision 2: Multi-Layer Graph Storage
 
 **Problem**: Graph queries need to be fast but also persistent across sessions  
 **Solution**: Implement in-memory graph for speed with persistent storage for durability  
 **Trade-offs**:
+
 - ✅ **Pros**: Fast queries, data persistence, memory efficiency
 - ❌ **Cons**: Complexity in synchronization, potential consistency issues
 
@@ -371,6 +382,7 @@ class PatternRecognizer {
 **Problem**: Not all relationships are equally strong or reliable  
 **Solution**: Assign confidence weights to relationships based on evidence strength  
 **Trade-offs**:
+
 - ✅ **Pros**: More nuanced analysis, better handling of uncertainty
 - ❌ **Cons**: Increased complexity, need for confidence calculation algorithms
 
@@ -379,22 +391,23 @@ class PatternRecognizer {
 **Problem**: Architectural knowledge changes over time and needs to be tracked  
 **Solution**: Maintain temporal relationships and track evolution patterns  
 **Trade-offs**:
+
 - ✅ **Pros**: Historical analysis, trend identification, evolution understanding
 - ❌ **Cons**: Increased storage requirements, complexity in temporal queries
 
 ---
 
-## 📊 Knowledge Graph Metrics
+## 📊 Session & Tool-Usage Tracker Metrics
 
 ### Current Performance
 
-| Metric | Current Value | Target |
-|--------|---------------|--------|
-| **Entity Count** | 50,000+ | 100,000+ |
-| **Relationship Count** | 200,000+ | 500,000+ |
-| **Query Response Time** | 150ms | <100ms |
-| **Pattern Recognition Accuracy** | 85% | 90%+ |
-| **Graph Update Frequency** | Real-time | Real-time |
+| Metric                           | Current Value | Target    |
+| -------------------------------- | ------------- | --------- |
+| **Entity Count**                 | 50,000+       | 100,000+  |
+| **Relationship Count**           | 200,000+      | 500,000+  |
+| **Query Response Time**          | 150ms         | <100ms    |
+| **Pattern Recognition Accuracy** | 85%           | 90%+      |
+| **Graph Update Frequency**       | Real-time     | Real-time |
 
 ### Learning Effectiveness
 
@@ -407,18 +420,18 @@ class PatternRecognizer {
 
 ## 🔗 Related Concepts
 
-- **[Server Architecture](./server-architecture.md)** - How the knowledge graph integrates with the overall system
+- **[Server Architecture](./server-architecture.md)** - How the session tracker integrates with the overall system
 - **[Performance Design](./performance-design.md)** - Graph query optimization strategies
-- **[Tool Design](./tool-design.md)** - How tools leverage the knowledge graph
+- **[Tool Design](./tool-design.md)** - How tools leverage the session tracker
 
 ---
 
 ## 📚 Further Reading
 
 - **[Knowledge Generation Framework](./knowledge-generation-framework-design.md)** - Detailed framework documentation
-- **[Research Integration Guide](../how-to-guides/research-integration.md)** - Using knowledge graph for research
-- **[API Reference](../reference/api-reference.md)** - Knowledge graph query endpoints
+- **[Research Integration Guide](../how-to-guides/research-integration.md)** - Using session state for research
+- **[API Reference](../reference/api-reference.md)** - Session state query endpoints
 
 ---
 
-**Questions about the knowledge graph?** → **[Join the Discussion](https://github.com/tosin2013/mcp-adr-analysis-server/discussions)**
+**Questions about the session tracker?** → **[Join the Discussion](https://github.com/tosin2013/mcp-adr-analysis-server/discussions)**

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -14,9 +14,9 @@ A short document that captures an important architectural decision, including th
 
 A tree representation of the syntactic structure of source code. The server uses AST analysis (via tree-sitter) to understand code patterns, detect architectural decisions embedded in code, and perform intelligent code linking.
 
-## Knowledge Graph
+## Session & Tool-Usage Tracker (Knowledge Graph)
 
-An in-memory data structure maintained by the server that models relationships between ADRs, code implementations, technology decisions, and their impacts. It powers intelligent features like pattern recognition and cross-ADR dependency analysis.
+A project-local JSON-snapshot-based data structure maintained by the server that tracks session intents, tool executions, ADR registrations, and their relationships. It supports keyword-scored retrieval for contextual lookups and cross-ADR dependency analysis.
 
 ## MCP (Model Context Protocol)
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -16,9 +16,9 @@ The MCP ADR Analysis Server is a [Model Context Protocol](https://modelcontextpr
 
 Each MCP tool follows a consistent response pattern and is registered in both `ListToolsRequestSchema` and `CallToolRequestSchema` handlers in `src/index.ts`. Tools are organized by domain in `src/tools/`.
 
-### Knowledge Graph
+### Session & Tool-Usage Tracker
 
-Maintains relationships between ADRs, code implementations, and technology decisions. Managed by `src/utils/knowledge-graph-manager.ts`.
+Tracks session intents, tool executions, and ADR registrations in project-local JSON snapshots with keyword-scored retrieval. Managed by `src/utils/knowledge-graph-manager.ts`.
 
 ### Content Security
 

--- a/src/mcp-adr-analysis-server.ts
+++ b/src/mcp-adr-analysis-server.ts
@@ -360,9 +360,8 @@ export class McpAdrAnalysisServer {
           // Existing resources (refactored to return data)
           {
             uri: 'adr://architectural_knowledge_graph',
-            name: 'Architectural Knowledge Graph',
-            description:
-              'Complete architectural knowledge graph with technologies, patterns, and relationships',
+            name: 'Project Session State',
+            description: 'Project session state with technologies, patterns, and relationships',
             mimeType: 'application/json',
           },
           {
@@ -533,9 +532,9 @@ export class McpAdrAnalysisServer {
           // NEW Knowledge Graph Resource (ADR-018)
           {
             uri: 'knowledge://graph',
-            name: 'Knowledge Graph',
+            name: 'Session & Tool-Usage State',
             description:
-              'Read-only knowledge graph structure with nodes (intents, ADRs, tools, code files) and edges (relationships). Zero token cost for querying graph state. Use update_knowledge tool to modify.',
+              'Read-only session state structure with nodes (intents, ADRs, tools, code files) and edges (relationships). Zero token cost for querying state. Use update_knowledge tool to modify.',
             mimeType: 'application/json',
           },
         ],

--- a/src/prompts/research-question-prompts.ts
+++ b/src/prompts/research-question-prompts.ts
@@ -22,9 +22,9 @@ export function generateProblemKnowledgeCorrelationPrompt(
   }
 ): string {
   return `
-# Problem-Knowledge Graph Correlation Analysis Guide
+# Problem-Session State Correlation Analysis Guide
 
-**Note: Use this as guidance for analyzing problems and correlating them with the architectural knowledge graph to identify research opportunities and knowledge gaps. Focus on the most relevant correlations for this specific context.**
+**Note: Use this as guidance for analyzing problems and correlating them with the project session state / ADR index to identify research opportunities and knowledge gaps. Focus on the most relevant correlations for this specific context.**
 
 ## Identified Problems
 ${problems
@@ -39,7 +39,7 @@ ${problems
   )
   .join('')}
 
-## Architectural Knowledge Graph
+## Project Session State / ADR Index
 ### Technologies
 ${knowledgeGraph.technologies.map(tech => `- **${tech.name}**: ${tech.description || 'No description'}`).join('\n')}
 
@@ -59,12 +59,12 @@ Consider identifying correlations and research opportunities from these areas wh
 ### 🔍 **Problem-Knowledge Correlations**
 - **Direct Correlations**: Problems directly related to known technologies/patterns
 - **Indirect Correlations**: Problems that may be influenced by architectural decisions
-- **Missing Knowledge**: Problems that reveal gaps in the knowledge graph
+- **Missing Knowledge**: Problems that reveal gaps in the project session state / ADR index
 - **Pattern Conflicts**: Problems caused by conflicting architectural patterns
 - **Technology Limitations**: Problems stemming from technology constraints
 
 ### 📊 **Knowledge Gap Analysis**
-- **Unexplored Technologies**: Technologies mentioned in problems but not in knowledge graph
+- **Unexplored Technologies**: Technologies mentioned in problems but not in project session state / ADR index
 - **Missing Patterns**: Architectural patterns that could address problems
 - **Incomplete ADRs**: Decisions that need more research or documentation
 - **Relationship Gaps**: Missing connections between architectural elements

--- a/src/resources/knowledge-graph-resource.ts
+++ b/src/resources/knowledge-graph-resource.ts
@@ -1,8 +1,8 @@
 /**
- * Knowledge Graph Resource - Read-only knowledge graph data
+ * Session State Resource - Read-only project session and tool-usage snapshots
  * URI Pattern: knowledge://graph
- * 
- * Provides direct access to the knowledge graph structure with nodes, edges, and metadata.
+ *
+ * Provides direct access to project session state with entities, relationships, and metadata.
  * This replaces querying KnowledgeGraphManager as a Tool, following ADR-018 atomic tools pattern.
  */
 
@@ -54,31 +54,31 @@ export interface KnowledgeGraphData {
 }
 
 /**
- * Generate knowledge graph resource providing read-only access to graph structure.
- * 
- * Returns comprehensive graph data including nodes (intents, ADRs, tools, code files)
+ * Generate session state resource providing read-only access to project session structure.
+ *
+ * Returns comprehensive session data including nodes (intents, ADRs, tools, code files)
  * and edges (relationships between nodes). This is a read-only view - use the
- * update_knowledge tool to modify the graph.
- * 
+ * update_knowledge tool to modify session state.
+ *
  * **URI Pattern:** `knowledge://graph`
- * 
+ *
  * **Query Parameters:** (none)
- * 
+ *
  * @param params - URL path parameters (none for this resource)
  * @param searchParams - URL query parameters (none used)
  * @param kgManager - KnowledgeGraphManager instance (injected by MCP server)
- * 
+ *
  * @returns Promise resolving to resource generation result containing:
- *   - data: Knowledge graph with nodes, edges, and metadata
+ *   - data: Session state with entities, relationships, and metadata
  *   - contentType: "application/json"
  *   - lastModified: ISO timestamp of generation
  *   - cacheKey: Unique identifier "knowledge-graph"
  *   - ttl: Cache duration (60 seconds)
  *   - etag: Entity tag for cache validation
- * 
+ *
  * @throws {McpAdrError} When:
  *   - RESOURCE_GENERATION_ERROR: KnowledgeGraphManager not provided or graph loading fails
- * 
+ *
  * @example
  * ```typescript
  * // Get knowledge graph
@@ -87,11 +87,11 @@ export interface KnowledgeGraphData {
  *   new URLSearchParams(),
  *   kgManager
  * );
- * 
+ *
  * console.log(`Nodes: ${graph.data.nodes.length}`);
  * console.log(`Edges: ${graph.data.edges.length}`);
  * console.log(`Active Intents: ${graph.data.analytics.activeIntents}`);
- * 
+ *
  * // Expected output structure:
  * {
  *   data: {
@@ -126,7 +126,7 @@ export interface KnowledgeGraphData {
  *   ttl: 60
  * }
  * ```
- * 
+ *
  * @since v2.2.0
  * @see {@link KnowledgeGraphManager.loadKnowledgeGraph} for graph data source
  */
@@ -153,7 +153,7 @@ export async function generateKnowledgeGraphResource(
 
     // Load knowledge graph snapshot
     const snapshot = await kgManager.loadKnowledgeGraph();
-    
+
     // Build nodes from intents
     const nodes: GraphNode[] = [];
     const edges: GraphEdge[] = [];
@@ -250,7 +250,7 @@ export async function generateKnowledgeGraphResource(
     return result;
   } catch (error) {
     throw new McpAdrError(
-      `Failed to generate knowledge graph: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to generate session state: ${error instanceof Error ? error.message : String(error)}`,
       'RESOURCE_GENERATION_ERROR'
     );
   }
@@ -287,5 +287,5 @@ function calculateIntentRelevance(intent: any): number {
 resourceRouter.register(
   '/graph',
   generateKnowledgeGraphResource as any, // TypeScript workaround for manager injection pattern
-  'Knowledge graph structure with nodes, edges, and metadata'
+  'Session state structure with entities, relationships, and metadata'
 );

--- a/src/tools/conversation-memory-tool.ts
+++ b/src/tools/conversation-memory-tool.ts
@@ -60,7 +60,7 @@ export async function expandMemory(
 
     // Add knowledge graph context if included
     if (result.knowledgeGraphContext && result.knowledgeGraphContext.length > 0) {
-      output += `\n## Knowledge Graph Context\n\n`;
+      output += `\n## Session State Context\n\n`;
       result.knowledgeGraphContext.forEach(context => {
         output += `- **${context.intent}**: ${context.outcome} (${context.timestamp})\n`;
       });
@@ -211,7 +211,7 @@ export async function getConversationSnapshot(
 
     // Active intents
     if (snapshot.activeIntents.length > 0) {
-      output += `## Active Knowledge Graph Intents\n\n`;
+      output += `## Active Session Intents\n\n`;
       snapshot.activeIntents.forEach(intent => {
         output += `- **${intent.intent}**: ${intent.status}\n`;
       });

--- a/src/tools/interactive-adr-planning-tool.ts
+++ b/src/tools/interactive-adr-planning-tool.ts
@@ -375,7 +375,7 @@ Please provide:
     const kgSource = research.sources.find(s => s.type === 'knowledge_graph');
     if (kgSource) {
       findings.push({
-        source: 'ADR Knowledge Graph',
+        source: 'Project ADR Index',
         insight: 'Found related architectural decisions that may influence this choice',
         relevance: 'Maintaining architectural consistency',
       });

--- a/src/tools/mcp-tool-schemas.ts
+++ b/src/tools/mcp-tool-schemas.ts
@@ -1204,7 +1204,7 @@ export const MCP_TOOL_SCHEMAS: Tool[] = [
               context: { type: 'string' },
             },
           },
-          description: 'Problems to correlate with knowledge graph',
+          description: 'Problems to correlate with project session/tool-usage state',
         },
         knowledgeGraph: {
           type: 'object',
@@ -1214,7 +1214,7 @@ export const MCP_TOOL_SCHEMAS: Tool[] = [
             adrs: { type: 'array', items: { type: 'object' } },
             relationships: { type: 'array', items: { type: 'object' } },
           },
-          description: 'Architectural knowledge graph',
+          description: 'Project session state (intents, tool usage, ADR registrations)',
         },
         relevantKnowledge: {
           type: 'object',
@@ -1271,7 +1271,7 @@ export const MCP_TOOL_SCHEMAS: Tool[] = [
   {
     name: 'perform_research',
     description:
-      'Perform research using cascading sources: project files → knowledge graph → environment resources → web search (fallback)',
+      'Perform research using cascading sources: project files → session/tool-usage tracker → environment resources → web search (fallback)',
     inputSchema: {
       type: 'object',
       properties: {
@@ -2919,7 +2919,7 @@ export const MCP_TOOL_SCHEMAS: Tool[] = [
         },
         includeContext: {
           type: 'boolean',
-          description: 'Include related conversation context and knowledge graph state',
+          description: 'Include related conversation context and session/tool-usage state',
           default: true,
         },
       },
@@ -2986,14 +2986,14 @@ export const MCP_TOOL_SCHEMAS: Tool[] = [
   {
     name: 'update_knowledge',
     description:
-      'ADR-018: Simple CRUD operations for knowledge graph. Add/remove entities (intents, ADRs, tools, code) and relationships. Use knowledge://graph resource to read current state (zero token cost).',
+      'ADR-018: Simple CRUD operations for project session state. Not a graph database — keyword retrieval over local JSON snapshots. Add/remove entities (intents, ADRs, tools, code) and relationships. Use knowledge://graph resource to read current state (zero token cost).',
     inputSchema: {
       type: 'object',
       properties: {
         operation: {
           type: 'string',
           enum: ['add_entity', 'remove_entity', 'add_relationship', 'remove_relationship'],
-          description: 'Type of operation to perform on the knowledge graph',
+          description: 'Type of operation to perform on project session state',
         },
         entity: {
           type: 'string',

--- a/src/tools/perform-research-tool.ts
+++ b/src/tools/perform-research-tool.ts
@@ -407,7 +407,7 @@ ${generateSearchQueries(question)
 function formatSourceName(sourceType: string): string {
   const names: Record<string, string> = {
     project_files: '📁 Project Files',
-    knowledge_graph: '🧠 Knowledge Graph',
+    knowledge_graph: 'Session & Tool-Usage Tracker',
     environment: '🔧 Environment Resources',
     web_search: '🌐 Web Search',
   };

--- a/src/tools/tool-catalog.ts
+++ b/src/tools/tool-catalog.ts
@@ -162,9 +162,9 @@ TOOL_CATALOG.set('analyze_project_ecosystem', {
 
 TOOL_CATALOG.set('get_architectural_context', {
   name: 'get_architectural_context',
-  shortDescription: 'Retrieve architectural context and knowledge graph',
+  shortDescription: 'Retrieve architectural context and session/tool-usage state',
   fullDescription:
-    'Retrieves the current architectural context including knowledge graph relationships, ADR decisions, and technology mappings.',
+    'Retrieves the current architectural context including session/tool-usage relationships, ADR decisions, and technology mappings.',
   category: 'analysis',
   complexity: 'moderate',
   tokenCost: { min: 2000, max: 5000 },

--- a/src/utils/research-orchestrator.ts
+++ b/src/utils/research-orchestrator.ts
@@ -3,7 +3,7 @@
  *
  * Coordinates multi-source research with cascading fallback:
  * 1. Project Files (local, fast, free)
- * 2. Knowledge Graph (in-memory, instant)
+ * 2. Session/tool-usage tracker (project-local, keyword retrieval)
  * 3. Environment Resources (live runtime data)
  * 4. Web Search (external, last resort)
  */

--- a/src/utils/server-context-generator.ts
+++ b/src/utils/server-context-generator.ts
@@ -517,7 +517,7 @@ ${toolsSection}
         100
     );
 
-    return `## 🧠 Memory & Knowledge Graph Status
+    return `## 🧠 Memory & Session State Status
 
 ### Active Intents
 
@@ -694,7 +694,7 @@ Use MCP resources to get pattern details:
       },
       {
         uri: 'adr://architectural_knowledge_graph',
-        name: 'Knowledge Graph',
+        name: 'Session & Tool-Usage State',
         description: 'Complete architectural relationships and decisions',
       },
       {

--- a/tests/prompts/research-question-prompts.test.ts
+++ b/tests/prompts/research-question-prompts.test.ts
@@ -51,7 +51,7 @@ describe('Research Question Prompts', () => {
     it('should generate prompt with problems and knowledge graph', () => {
       const result = generateProblemKnowledgeCorrelationPrompt(mockProblems, mockKnowledgeGraph);
 
-      expect(result).toContain('Problem-Knowledge Graph Correlation Analysis Guide');
+      expect(result).toContain('Problem-Session State Correlation Analysis Guide');
       expect(result).toContain('Database performance issues');
       expect(result).toContain('Authentication system complexity');
       expect(result).toContain('PostgreSQL');
@@ -66,7 +66,7 @@ describe('Research Question Prompts', () => {
     it('should handle empty problems array', () => {
       const result = generateProblemKnowledgeCorrelationPrompt([], mockKnowledgeGraph);
 
-      expect(result).toContain('Problem-Knowledge Graph Correlation Analysis Guide');
+      expect(result).toContain('Problem-Session State Correlation Analysis Guide');
       expect(result).toContain('"totalProblems": 0');
       expect(result).toContain('PostgreSQL');
     });


### PR DESCRIPTION
## Summary
- Rename user-facing "Knowledge Graph" claims across README, MCP resource/tool descriptions, tool catalog, and all docs pages
- The component is actually project-local session/tool-usage tracking with keyword-scored retrieval over JSON snapshots — not a graph database
- Internal class names, file names, function names, tool names (`get_knowledge_graph`, `update_knowledge`), and resource URIs (`knowledge://graph`) are all unchanged
- 28 files changed across source and documentation

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npx vitest run tests/smoke.test.ts` — 5/5 pass
- [x] No "A graph database maintained" claim in README

Closes #1548

Made with [Cursor](https://cursor.com)