### PR TITLE
feat(tools): migrate adr-validation off OpenRouter (CE-MCP Batch 1, reduced)

### DIFF
--- a/.repo-governor/acceptance/1629.json
+++ b/.repo-governor/acceptance/1629.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "CE-MCP Batch 1 (ADR-021 Option B), REDUCED SCOPE. Originally covered the ADR suggestion + validation cluster; reduced to adr-validation-tool.ts only after the adr-suggestion-tool.ts migration was found to be entangled with generateAdrFromDecision's deterministic autoSave + knowledge-graph auto-registration feature (3 tests) and with the content-generation rework in #1466. That half of the cluster is deferred to a follow-up batch coordinated with #1466 (do #1466 first, then migrate adr-suggestion-tool.ts on top of its deterministic MADR content generator). This bar therefore covers adr-validation-tool.ts only.",
+  "authority_id": "1629",
+  "criteria": [
+    { "check": "command_exit", "target": "npm run typecheck" },
+    {
+      "check": "command_exit",
+      "target": "npx vitest run tests/tools/adr-validation-tool.test.ts tests/tools/adr-validation-summary.test.ts"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! rg -q \"ai-executor|prompt-execution\" src/tools/adr-validation-tool.ts'"
+    }
+  ]
+}

--- a/src/tools/adr-validation-tool.ts
+++ b/src/tools/adr-validation-tool.ts
@@ -3,13 +3,12 @@
  *
  * Validates existing ADRs against actual infrastructure state using:
  * - Research Orchestrator (live environment data)
- * - AI Executor (intelligent analysis)
+ * - Deterministic rule-based analysis over the research evidence (ADR-021 Option B)
  * - Knowledge Graph (ADR relationships)
  */
 
 import { McpAdrError } from '../types/index.js';
 import { answerResearchQuestion } from '../utils/research-orchestrator.js';
-import { getAIExecutor } from '../utils/ai-executor.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -146,87 +145,27 @@ async function computeAdrValidation(args: {
     // Step 2: Extract ADR metadata
     const adrTitle = extractAdrTitle(adrContent);
     const adrDecision = extractAdrDecision(adrContent);
-    const adrContext = extractAdrContext(adrContent);
 
     // Step 3: Research current infrastructure state
     const researchQuestion = `Based on the ADR titled "${adrTitle}", verify if the following is still true: ${adrDecision}. Check project files, environment state, and existing implementations.`;
 
     const research = await answerResearchQuestion(researchQuestion, projectPath, adrDirectory);
 
-    // Step 4: Use AI to analyze alignment
-    const aiExecutor = getAIExecutor();
-    let validationResult: ADRValidationResult;
-
-    if (aiExecutor.isAvailable()) {
-      // AI-powered validation
-      const aiAnalysis = await aiExecutor.executeStructuredPrompt<{
-        isValid: boolean;
-        confidence: number;
-        findings: Array<{
-          type: 'compliance' | 'drift' | 'outdated' | 'missing_evidence' | 'conflict';
-          severity: 'critical' | 'high' | 'medium' | 'low';
-          description: string;
-          evidence: string;
-        }>;
-        recommendations: string[];
-      }>(
-        `You are an expert at validating Architecture Decision Records (ADRs) against actual infrastructure.
-
-**ADR Being Validated:**
-Title: ${adrTitle}
-Decision: ${adrDecision}
-Context: ${adrContext}
-
-**Current Infrastructure Research:**
-${research.answer}
-
-**Research Confidence:** ${(research.confidence * 100).toFixed(1)}%
-**Sources Consulted:** ${research.sources.map(s => s.type).join(', ')}
-**Files Analyzed:** ${research.metadata.filesAnalyzed}
-
-**Your Task:**
-Analyze if the ADR decision is still valid and being followed in the current infrastructure.
-
-Return JSON with:
-{
-  "isValid": boolean,
-  "confidence": number (0-1),
-  "findings": [
-    {
-      "type": "compliance" | "drift" | "outdated" | "missing_evidence" | "conflict",
-      "severity": "critical" | "high" | "medium" | "low",
-      "description": "Clear description of the finding",
-      "evidence": "Specific evidence from research data"
-    }
-  ],
-  "recommendations": ["Actionable recommendations"]
-}`,
-        null,
-        {
-          temperature: 0.2,
-          maxTokens: 2000,
-          systemPrompt:
-            'You are a meticulous architecture validator. Base your analysis ONLY on the research evidence provided. Do not hallucinate or assume information not present in the research data.',
-        }
-      );
-
-      validationResult = {
-        adrPath: fullAdrPath,
-        adrTitle,
-        isValid: aiAnalysis.data.isValid,
-        confidence: aiAnalysis.data.confidence,
-        findings: aiAnalysis.data.findings,
-        recommendations: aiAnalysis.data.recommendations,
-        researchData: {
-          sources: research.sources.map(s => s.type),
-          confidence: research.confidence,
-          needsWebSearch: research.needsWebSearch,
-        },
-      };
-    } else {
-      // Fallback: Rule-based validation
-      validationResult = performRuleBasedValidation(fullAdrPath, adrTitle, adrDecision, research);
-    }
+    // Step 4: Validate alignment deterministically (ADR-021 Option B, Batch 1).
+    //
+    // The OpenRouter-backed AI branch that used to run here (getAIExecutor ->
+    // executeStructuredPrompt) was removed. Validation now runs entirely on
+    // rule-based analysis of the research evidence -- no external API call. This
+    // matches ADR-014/ADR-021: the tool returns a deterministic verdict the host
+    // LLM can rely on and, if it wants a richer reading, it has the full research
+    // data (research.answer, sources, findings) in the response to reason over
+    // itself. (#1629)
+    const validationResult: ADRValidationResult = performRuleBasedValidation(
+      fullAdrPath,
+      adrTitle,
+      adrDecision,
+      research
+    );
 
     // The "related ADRs" step is gone. It called
     // KnowledgeGraphManager.getRelationships, which is @deprecated and returns []
@@ -234,7 +173,7 @@ Return JSON with:
     // A heading that is always empty because its source is a stub is worse than
     // no heading. `queryKnowledgeGraph` is the documented replacement if this is
     // ever wanted back. (#1539)
-    return { result: validationResult, research, aiAvailable: aiExecutor.isAvailable() };
+    return { result: validationResult, research, aiAvailable: false };
   } catch (error) {
     throw new McpAdrError(
       `ADR validation failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -352,11 +291,6 @@ function extractAdrDecision(content: string): string {
   return decisionText ? decisionText.substring(0, 500) : 'No decision section found';
 }
 
-function extractAdrContext(content: string): string {
-  const contextMatch = content.match(/##\s+Context\s*\n\n([\s\S]+?)(?=\n##|$)/i);
-  return contextMatch?.[1]?.trim().substring(0, 500) ?? 'No context section found';
-}
-
 function performRuleBasedValidation(
   adrPath: string,
   adrTitle: string,
@@ -433,7 +367,7 @@ function formatValidationResponse(
 - **Confidence**: ${(result.confidence * 100).toFixed(1)}%
 
 ## Validation Method
-- **AI-Powered Analysis**: ${aiEnabled ? '✅ Enabled' : '❌ Disabled (using rule-based validation)'}
+- **Analysis**: ${aiEnabled ? '✅ AI-powered' : '✅ Deterministic (rule-based over research evidence)'}
 - **Research-Driven**: ✅ Enabled
 - **Environment Check**: ${research.sources.some((s: any) => s.type === 'environment') ? '✅ Completed' : '❌ Skipped'}
 

--- a/tests/tools/adr-validation-tool.test.ts
+++ b/tests/tools/adr-validation-tool.test.ts
@@ -271,7 +271,7 @@ We will use Redis for caching.
 
     // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
     // See issue #308 for ESM-compatible mocking improvements
-    it.skip('should work without AI executor (rule-based fallback)', async () => {
+    it('should work without AI executor (rule-based fallback)', async () => {
       const adrContent = `# Use PostgreSQL
 
 ## Decision
@@ -305,7 +305,9 @@ We will use PostgreSQL as our primary database.
       });
 
       expect(result.content).toBeDefined();
-      expect(result.content[0].text).toContain('rule-based validation');
+      // Deterministic path (ADR-021 Option B): no AI executor, rule-based over research.
+      expect(result.content[0].text).toContain('# ADR Validation Report');
+      expect(result.content[0].text).toContain('Deterministic (rule-based over research evidence)');
     });
 
     it('should handle file read errors', async () => {


### PR DESCRIPTION
CE-MCP migration (ADR-021 Option B), issue #1629 — **reduced scope**.

## What this does
Migrates `src/tools/adr-validation-tool.ts` off the `ai-executor` (OpenRouter/OpenAI) path: `computeAdrValidation` always uses the existing deterministic `performRuleBasedValidation` over the research evidence. No external API call.

## Scope reduction (why this shrank)
Originally this was the suggestion+validation cluster. The `adr-suggestion-tool.ts` half was **split out to #1647** (do after #1466): `generateAdrFromDecision` has a deterministic autoSave + knowledge-graph auto-registration feature (3 tests in `adr-suggestion-auto-index.test.ts`) whose content generation must be rebuilt on #1466's deterministic MADR generator. Rushing it here deleted the feature and broke those tests, so it's coordinated with #1466 instead.

## Governance
Bounded by `.repo-governor/acceptance/1629.json` (adr-validation only) — engine **STOP_COMPLETE** (typecheck; `adr-validation-tool.test.ts` + `adr-validation-summary.test.ts`; no `ai-executor`/`prompt-execution` import). Rebased on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oZ2FvkFuhDrGYHoWiu6Lv