### PR TITLE
docs(adr): ADR-026 tool-call best-practices + tool-surface map

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -29,6 +29,7 @@ This directory contains the Architectural Decision Records for the MCP ADR Analy
 | [ADR-022](adr-022-adopt-madr-format.md)                                | Adopt MADR as the default decision-record format | Accepted           | 2026-08-27 | Documentation |
 | [ADR-023](adr-023-tool-surface-scope.md)                               | Which of the 75 tools should still exist         | Accepted           | 2026-08-27 | Architecture  |
 | [ADR-025](adr-025-retire-the-bootstrap-pattern-engine.md)              | Retire the bootstrap pattern-execution engine    | Accepted           | 2026-08-28 | Deployment    |
+| [ADR-026](adr-026-tool-call-best-practices-conformance.md)             | Tool-call best-practices conformance             | Proposed           | 2026-09-02 | Architecture  |
 
 > **ADR-016 was never written.** ADR-017 cites it twice as a predecessor decision
 > ("Replace ripgrep with tree-sitter"), and `tree-sitter-code-tools.ts` cited it in an

--- a/docs/adrs/adr-026-tool-call-best-practices-conformance.md
+++ b/docs/adrs/adr-026-tool-call-best-practices-conformance.md
@@ -1,0 +1,173 @@
+---
+status: proposed
+date: 2026-09-02
+decision-makers: Tosin Akinosho
+consulted: Claude Code (measurement and external research)
+tags:
+  - architecture
+  - process
+---
+
+# ADR-026: Tool-call best-practices conformance
+
+> **The Decision section is deliberately unfilled.** This ADR measures, researches
+> and argues. The disposition is the owner's, as with ADR-021 and ADR-023.
+
+## Context and Problem Statement
+
+ADR-023 asked _which_ of the tools should exist and cut the supported surface to 54.
+This ADR asks a different, orthogonal question about the tools that survive: **do the
+tool calls themselves conform to current MCP practice?**
+
+The distinction matters because the two are independent. A tool can be the right tool
+to keep (ADR-023) and still expose a poor call contract — no typed output, no
+behaviour hints, discoverable only through a mechanism the spec now assigns to the
+host. Removing tools does not fix the calls that remain.
+
+The full evidence base is [`docs/reference/tool-surface-map.md`](../reference/tool-surface-map.md).
+
+### Measured, on `main` at 2026-09-02
+
+Every figure is reproducible by the command beside it.
+
+| measurement                            | value                       | how                                                                                                                                                                              |
+| -------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| tools over the wire                    | **72**                      | `MCP_TOOL_SCHEMAS.length` (`src/tools/mcp-tool-schemas.ts`), served by `getToolListForMCP({ mode: 'full' })` at `src/mcp-adr-analysis-server.ts:235`                             |
+| tools declared in `TOOL_CATALOG`       | **68**                      | `rg -c "^TOOL_CATALOG.set\('" src/tools/tool-catalog.ts` (72 at runtime — see next row)                                                                                          |
+| wire tools backfilled into the catalog | **4**                       | `get_gaps`, `search_codebase`, `set_project_path`, `update_knowledge` — folded into `TOOL_CATALOG` at load by the loop at `tool-catalog.ts:2103` with default `utility` metadata |
+| tools declaring `outputSchema`         | **0**                       | `rg -n "outputSchema" src` → only `prompt-composition.ts:232-255` (unrelated)                                                                                                    |
+| tools declaring any MCP annotation     | **0**                       | `rg -c "readOnlyHint\|destructiveHint\|idempotentHint\|openWorldHint" src`                                                                                                       |
+| CE-MCP directive tools                 | **12**                      | 12 `case` entries in `ce-mcp-tools.ts:1406-1447`; `hasCEMCPDirective: true` ×12 in the catalog                                                                                   |
+| host-native tools marked `deprecated`  | **8**                       | `deprecated: true` in `tool-catalog.ts` + `[DEPRECATED host-native, ADR-023]` on their wire descriptions (#1639)                                                                 |
+| `tools/list` payload                   | **~94,571 B / ~24K tokens** | measured in ADR-023:38                                                                                                                                                           |
+| categories in `search_tools` enum      | **10 of 11**                | `mcp-tool-schemas.ts:19-30` (inside `getSearchToolsDefinition`) omits `aggregator`                                                                                               |
+
+## Decision Drivers
+
+- **The spec moved and this server predates it.** The 2026-07-28 Client Best
+  Practices assign progressive discovery to the host and describe programmatic
+  ("code mode") calling that needs `outputSchema`. This server ships neither
+  contract.
+- **The tool count is above Anthropic's own selection-accuracy band.** Anthropic's
+  guidance ([Writing effective tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents),
+  [Tool search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool))
+  is that Claude's ability to pick the right tool **degrades past ~30–50 available
+  tools**; under ~10 the full list is fine; above the band, defer to host-native
+  tool search rather than a custom one. This server exposes 72; ADR-023's supported
+  54 still sits at the top of the band, and only consolidating the deferred clusters
+  (ADR-024) brings it comfortably inside.
+- **Zero output schemas opts the server out of code mode.** The spec is explicit:
+  "the real fix is for server authors to provide `outputSchema`." With none, every
+  host generating typed stubs falls back to `any`.
+- **Zero annotations hides safety-relevant behaviour.** `read_file` is read-only;
+  `write_file` and `smart_git_push` are destructive. A host cannot tell without
+  `readOnlyHint`/`destructiveHint`, so it must treat all calls as equally risky.
+- **The lightweight listing exists and is already wired in — it is just
+  configured to `full`.** `getToolListForMCP({mode})`
+  (`src/tools/tool-dispatcher.ts:139-171`) **is** the live `tools/list` source
+  (#1416): `src/mcp-adr-analysis-server.ts:235` calls it. But it passes
+  `mode: 'full'`, returning all 72 full `MCP_TOOL_SCHEMAS`, when the same function
+  already offers a `mode: 'lightweight'` path (`:151-166`) that would emit
+  `search_tools` plus name/category stubs. The oversized wire payload is therefore a
+  one-line **configuration choice**, not dead code — a stronger finding than the
+  earlier draft's (which wrongly called `getToolListForMCP` unused).
+- **Catalog integrity is broken in two ways.** Four wire tools (`get_gaps`,
+  `search_codebase`, `set_project_path`, `update_knowledge`) carry no explicit
+  catalog entry; a backfill loop (`tool-catalog.ts:2103`) folds them into
+  `TOOL_CATALOG` at load with default `utility` metadata, so `search_tools` _does_
+  surface them — but mis-categorised and under-described, and `get_gaps` duplicates
+  the properly catalogued `analyze_gaps`. Separately, the `search_tools` category
+  filter silently omits `aggregator`, leaving its 10 tools unfilterable by category.
+
+### The spec moved
+
+[Client Best Practices (2026-07-28)](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices)
+recommends switching to progressive discovery once tool definitions consume 1–5% of
+the context window and notes OpenAI and Anthropic ship tool search natively. At ~24K
+tokens this server is 3–12× that threshold — the same finding ADR-023 used to remove
+`search_tools`/`load_prompt` from the supported surface. It also describes code mode,
+where the host builds a typed API from `outputSchema`; this server declares none.
+
+### Zero annotations
+
+The [Tools spec](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+defines `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` and
+`title` as optional behaviour hints (clients treat them as untrusted unless from a
+verified source). None appear anywhere in `src/`. The clearest cost is safety
+legibility: destructive tools (`write_file`, `smart_git_push`, `sync_to_aggregator`)
+are indistinguishable from read-only ones at the protocol level.
+
+## Considered Options
+
+1. **Status quo.** Keep 72 full-schema tools, no `outputSchema`, no annotations, a
+   custom `search_tools`. _For:_ no work. _Against:_ forces the progressive-discovery
+   mitigation on every host, opts out of code mode, and leaves the catalog bugs.
+
+2. **Full conformance pass on the survivors.** Add `outputSchema` and annotations to
+   the supported set, flip the wire listing from `mode: 'full'` to `mode:
+'lightweight'` (the path already exists), fix the `aggregator` enum omission, and
+   give the 4 backfilled tools proper catalog entries (dedupe
+   `get_gaps`/`analyze_gaps`). _For:_ closes every gap; unblocks code mode. _Against:_
+   largest effort; `outputSchema` for ~54 tools is real work, not mechanical.
+
+3. **Schemas + annotations only; defer discovery to the host.** Add `outputSchema` +
+   annotations, fix the catalog bugs, but do not build more discovery machinery —
+   rely on host-native tool search. _For:_ highest value per unit effort; aligns with
+   the spec putting discovery on the host. _Against:_ leaves the oversized wire
+   payload until ADR-023's removals land.
+
+4. **Defer discovery entirely to the host and drop `search_tools`/`load_prompt`.**
+   Fold the discovery meta-tools into ADR-023's removal track and lean on host-native
+   search. _For:_ smallest long-term surface; stops reimplementing a host feature.
+   _Against:_ couples this ADR to ADR-023's deprecation/retirement timeline; a host
+   without native tool search loses discovery until it catches up.
+
+## Consequences
+
+**Good (whichever of 2–4 is chosen)**
+
+- Tools gain typed outputs (code mode becomes possible) and safety-legible
+  annotations.
+- The catalog stops lying by omission — every wire tool is discoverable and every
+  category filterable.
+
+**Bad / cost**
+
+- `outputSchema` across the surviving tools is per-tool design work, not a codemod.
+- Switching the wire listing changes what every connected host sees; it interacts
+  with prompt caching (adding/removing tool defs mid-conversation invalidates the
+  cached `tools` prefix) and must be validated against real clients.
+
+**Neutral**
+
+- This ADR does not change _which_ tools exist (ADR-023) or consolidate the deferred
+  clusters (ADR-024). It is about the call contract of whatever survives.
+
+## Decision
+
+<!-- Deliberately unfilled. The disposition is the owner's, as with ADR-021/023.
+     Options 2–4 are all defensible; option 1 is the do-nothing baseline. -->
+
+## Confirmation
+
+Verifiable now:
+
+- Every measurement in the table reproduces via the command beside it.
+- The host-native removal track (ADR-023) has already moved one step: the 8
+  host-native tools carry `deprecated: true` and a `[DEPRECATED host-native,
+ADR-023]` marker on their wire descriptions (#1639). The next step is per-asset
+  `retirement.py`, not another edit here.
+- `bash scripts/check-adr-drift.sh` stays at its baseline with this ADR added.
+
+Deliberately **not** claimed: that any tool is safe to remove, or that adding
+`outputSchema`/annotations is mechanical. Execution of any chosen option is separate
+work, admitted on its own, and — for anything that removes a tool — gated by
+`retirement.py` per ADR-023.
+
+## More Information
+
+- [`docs/reference/tool-surface-map.md`](../reference/tool-surface-map.md) — the per-tool evidence base
+- [MCP Client Best Practices, 2026-07-28](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices)
+- [MCP Tools specification, 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+- [Anthropic — Writing effective tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents) (tool-selection accuracy degrades past ~30–50 tools) · [Tool search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)
+- [ADR-023](adr-023-tool-surface-scope.md) (which tools exist) · ADR-024 (deferred clusters, pending usage data) · [ADR-021](adr-021-ai-layer-disposition.md) (AI-layer disposition)

--- a/docs/reference/tool-surface-map.md
+++ b/docs/reference/tool-surface-map.md
@@ -1,0 +1,210 @@
+# Tool Surface Map
+
+> **Reference / evidence, not a decision.** This document maps the MCP tool surface
+> and scores it against current tool-call best practices so removal and refactor
+> candidates are visible in one place. It **authorises nothing**. Which tools exist
+> is decided by [ADR-023](../adrs/adr-023-tool-surface-scope.md); consolidation of
+> the deferred clusters by ADR-024; tool-call conformance by
+> [ADR-026](../adrs/adr-026-tool-call-best-practices-conformance.md). Any actual
+> removal runs through an ADR Decision, then `retirement.py` per asset, then its own
+> admission. Candidates below are **discoveries**.
+
+Measured on `main`, 2026-09-02. Line references drift; re-verify with the command in
+each row before relying on one.
+
+## How the surface works
+
+| Concern                                                   | Where                                                                                                                                 | Note                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wire registration (`tools/list`)                          | `src/mcp-adr-analysis-server.ts:235`                                                                                                  | Calls `getToolListForMCP({ mode: 'full' })`, which returns the canonical `MCP_TOOL_SCHEMAS` array (`src/tools/mcp-tool-schemas.ts`) = **72 tools over the wire**. `src/index.ts` is now a 79-line shim — the tool list is no longer hardcoded there. |
+| Catalog (metadata for `search_tools`)                     | `src/tools/tool-catalog.ts`                                                                                                           | **68 declared** `TOOL_CATALOG.set(...)` entries (category, tokenCost, requiresAI, hasCEMCPDirective, inputSchema) + **4 backfilled from the wire** by the loop at `:2103` = **72 at runtime**.                                                       |
+| Dispatch + CE-MCP gating                                  | `src/mcp-adr-analysis-server.ts:241-304`                                                                                              | `CallToolRequestSchema` handler; CE-MCP directive check (`shouldUseCEMCPDirective`) at `:266-300` short-circuits 12 directive tools before `dispatchTool()` at `:304` (`src/tools/tool-dispatch.ts:30`).                                             |
+| CE-MCP directives                                         | `src/tools/ce-mcp-tools.ts:1406-1447`                                                                                                 | **12** `case` entries.                                                                                                                                                                                                                               |
+| Lightweight listing (exists, wired in, configured `full`) | `src/tools/tool-dispatcher.ts:139-171`                                                                                                | `getToolListForMCP({mode})` **is** the live `tools/list` source (#1416). It is called with `mode: 'full'` (all 72 full schemas); a `mode: 'lightweight'` path (`:151-166`) already exists but is unused. Not dead code — a configuration choice.     |
+| `search_tools` meta-tool                                  | `getSearchToolsDefinition()` in `src/tools/mcp-tool-schemas.ts:9`; executor `executeSearchTools` at `src/tools/tool-dispatcher.ts:77` | Category enum at `mcp-tool-schemas.ts:19-30` lists 10 categories and **omits `aggregator`**.                                                                                                                                                         |
+
+## Best-practices scorecard
+
+Basis: [MCP Client Best Practices, 2026-07-28](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices) · [Tools spec](https://modelcontextprotocol.io/specification/2026-07-28/server/tools).
+
+| Practice                                                                                            | Verdict                       | Evidence (reproduce)                                                                                                                                                                                                                                                                                                                                                                       |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`outputSchema` on tools** (enables code mode / typed calling)                                     | ❌ **0 of 72**                | `rg -n "outputSchema" src` → only `prompt-composition.ts:232-255`, an unrelated helper.                                                                                                                                                                                                                                                                                                    |
+| **MCP annotations** (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`) | ❌ **none**                   | `rg -c "readOnlyHint\|destructiveHint\|idempotentHint\|openWorldHint" src` → 0. `read_file` is read-only, `write_file`/`smart_git_push` are destructive — unmarked.                                                                                                                                                                                                                        |
+| **Progressive discovery deferred to host**                                                          | ❌ reimplemented              | Server ships `search_tools`/`load_prompt`; spec assigns this to the host (OpenAI/Anthropic ship it).                                                                                                                                                                                                                                                                                       |
+| **Token budget < 1–5% of context**                                                                  | ❌ 3–12× over                 | ~94,571 B / ~24K tokens ([ADR-023:38](../adrs/adr-023-tool-surface-scope.md)); 11.8% of 200K, 2.4% of 1M.                                                                                                                                                                                                                                                                                  |
+| **Uses lightweight listing when over budget**                                                       | ❌ configured to `full`       | `getToolListForMCP()` (`tool-dispatcher.ts:139`) **is** the live wire source and ships all 72 full schemas; its `mode: 'lightweight'` path (`:151-166`) exists but is not selected. One-line config, not dead code.                                                                                                                                                                        |
+| **Catalog integrity (every wire tool discoverable)**                                                | ⚠️ backfilled, not classified | `get_gaps`, `search_codebase`, `set_project_path`, `update_knowledge` have no explicit catalog entry; the backfill loop (`tool-catalog.ts:2103`) folds them in with default `utility` metadata, so `search_tools` _does_ find them — but mis-categorised and under-described (`get_gaps` duplicates `analyze_gaps`). `search_tools` enum still drops `aggregator` (10 tools unfilterable). |
+| **Tool count within selection-accuracy band**                                                       | ❌ 72 (band is ~30–50)        | Anthropic: tool-selection accuracy degrades past **~30–50 tools**; under ~10 the full list is fine; above, use host tool search. ADR-023's 54 is still at the top of the band; ADR-024 consolidation gets inside it.                                                                                                                                                                       |
+| **Fewer, single-domain tools**                                                                      | ⚠️ 72 tools, 11 categories    | Spec: "five well-described tools beat fifty." ADR-023 cuts to 54 supported.                                                                                                                                                                                                                                                                                                                |
+
+## Per-tool inventory
+
+72 over the wire (68 explicitly declared in `TOOL_CATALOG` + 4 backfilled from the
+wire at load, so 72 catalogued at runtime). **`outputSchema` = false and
+annotations = none for every tool** — omitted from the table as uniform. `Cand.` =
+candidate disposition (discovery): **K** keep · **Rm** remove (host-native / dead) ·
+**Rf** refactor (needs directive/schema/annotations/consolidation) · **D** deferred
+to ADR-024 · **Agg** aggregator (ADR-023 "separate commercial question").
+
+### analysis (4) — `tool-catalog.ts:132-233`
+
+| tool                      | what it does                                     | tokens     | AI  | CE-MCP | Cand. |
+| ------------------------- | ------------------------------------------------ | ---------- | --- | ------ | ----- |
+| analyze_project_ecosystem | Comprehensive project + architectural analysis   | 8000-15000 | ✓   | ✓      | K/Rf  |
+| get_architectural_context | Retrieve architectural context + knowledge graph | 2000-5000  | –   | –      | K     |
+| analyze_environment       | Analyse deployment environment config            | 2000-4000  | ✓   | ✓      | K     |
+| smart_score               | Code-quality / architecture scores               | 3000-6000  | ✓   | ✓      | K     |
+
+### adr (12) — `tool-catalog.ts:234-451, 758-767`
+
+| tool                       | what it does                    | tokens    | AI  | CE-MCP | Cand. |
+| -------------------------- | ------------------------------- | --------- | --- | ------ | ----- |
+| suggest_adrs               | ADR suggestions from analysis   | 3000-6000 | ✓   | ✓      | K     |
+| generate_adr_from_decision | ADR from a decision             | 2000-4000 | ✓   | –      | Rf    |
+| generate_adrs_from_prd     | ADRs from a PRD                 | 4000-8000 | ✓   | ✓      | K     |
+| discover_existing_adrs     | Find + index ADRs               | 500-1500  | –   | –      | K     |
+| validate_adr               | Validate one ADR                | 500-1500  | –   | –      | K     |
+| validate_all_adrs          | Validate all ADRs               | 1000-3000 | –   | –      | K     |
+| analyze_adr_timeline       | ADR evolution over time         | 1500-3000 | ✓   | –      | Rf    |
+| compare_adr_progress       | Compare implementation progress | 2000-4000 | ✓   | –      | Rf    |
+| review_existing_adrs       | Review existing ADRs            | 2000-4000 | ✓   | –      | Rf    |
+| generate_adr_bootstrap     | Bootstrap ADR infra             | 500-1500  | –   | –      | K     |
+| interactive_adr_planning   | Interactive planning session    | 3000-6000 | ✓   | ✓      | K     |
+| generate_adr_todo          | TODO.md from ADRs (TDD pairing) | 800-3000  | –   | –      | K     |
+
+### content-security (6) — `tool-catalog.ts:469-583`
+
+| tool                        | what it does                       | tokens    | AI  | CE-MCP | Cand. |
+| --------------------------- | ---------------------------------- | --------- | --- | ------ | ----- |
+| analyze_content_security    | Scan content for security concerns | 1500-3000 | ✓   | –      | Rf    |
+| generate_content_masking    | Generate masking rules             | 1000-2500 | ✓   | –      | Rf    |
+| apply_basic_content_masking | Apply basic masking                | 200-500   | –   | –      | K     |
+| configure_custom_patterns   | Configure masking patterns         | 200-500   | –   | –      | K     |
+| validate_content_masking    | Validate masking                   | 300-800   | –   | –      | K     |
+| configure_output_masking    | Configure output masking           | 200-400   | –   | –      | K     |
+
+### research (4) — `tool-catalog.ts:598-671`
+
+| tool                        | what it does         | tokens     | AI  | CE-MCP | Cand. |
+| --------------------------- | -------------------- | ---------- | --- | ------ | ----- |
+| perform_research            | Research a topic     | 4000-10000 | ✓   | ✓      | K/Rf  |
+| incorporate_research        | Incorporate findings | 2000-4000  | ✓   | –      | D     |
+| generate_research_questions | Generate questions   | 1500-3000  | ✓   | –      | D     |
+| create_research_template    | Create template      | 500-1000   | –   | –      | D     |
+
+### deployment (7) — `tool-catalog.ts:687-878`
+
+| tool                         | what it does                           | tokens    | AI  | CE-MCP | Cand. |
+| ---------------------------- | -------------------------------------- | --------- | --- | ------ | ----- |
+| deployment_readiness         | Check deployment readiness             | 2000-4000 | ✓   | ✓      | K     |
+| release_tracking             | Releases mapped to ADR decisions       | 2000-6000 | –   | –      | K     |
+| smart_git_push               | Intelligent git push (**destructive**) | 1000-2500 | –   | –      | K/Rf  |
+| bootstrap_validation_loop    | Guided validation loop                 | 3000-6000 | ✓   | –      | Rf    |
+| analyze_deployment_progress  | Analyse deployment progress            | 1500-3000 | –   | –      | K     |
+| generate_deployment_guidance | Generate guidance                      | 2000-4000 | ✓   | –      | Rf    |
+| troubleshoot_guided_workflow | Guided troubleshooting                 | 3000-7000 | ✓   | ✓      | K     |
+
+### memory (6) — `tool-catalog.ts:895-1003` — cluster **deferred to ADR-024**
+
+| tool                       | what it does            | tokens    | AI  | CE-MCP | Cand. |
+| -------------------------- | ----------------------- | --------- | --- | ------ | ----- |
+| memory_loading             | Load memory context     | 500-2000  | –   | –      | D     |
+| expand_memory              | Expand memory           | 300-800   | –   | –      | D     |
+| query_conversation_history | Query history           | 500-1500  | –   | –      | D     |
+| get_conversation_snapshot  | Conversation snapshot   | 300-800   | –   | –      | D     |
+| get_memory_stats           | Memory statistics       | 200-400   | –   | –      | D     |
+| expand_analysis_section    | Expand analysis section | 1500-3000 | ✓   | –      | D     |
+
+### file-system (5) — `tool-catalog.ts:1019-1110` — **host-native, ADR-023 REMOVE** — **deprecation landed (#1639)**
+
+All five now carry `deprecated: true` in the catalog and a `[DEPRECATED host-native,
+ADR-023]` marker on their wire descriptions. Next step is per-asset `retirement.py`, not
+another marker.
+
+| tool           | what it does                                | tokens   | AI  | CE-MCP | Cand. |
+| -------------- | ------------------------------------------- | -------- | --- | ------ | ----- |
+| read_file      | Read file (host provides)                   | 100-5000 | –   | –      | Rm    |
+| write_file     | Write file (host provides, **destructive**) | 100-1000 | –   | –      | Rm    |
+| read_directory | Read directory (host provides)              | 100-1000 | –   | –      | Rm    |
+| list_directory | List directory (host provides)              | 100-500  | –   | –      | Rm    |
+| list_roots     | List roots (MCP `roots` capability)         | 50-200   | –   | –      | Rm    |
+
+### rules (3) — `tool-catalog.ts:1122-1177`
+
+| tool            | what it does               | tokens    | AI  | CE-MCP | Cand. |
+| --------------- | -------------------------- | --------- | --- | ------ | ----- |
+| generate_rules  | Generate validation rules  | 3000-6000 | ✓   | ✓      | K     |
+| validate_rules  | Validate rules vs codebase | 1500-3000 | –   | –      | K     |
+| create_rule_set | Create rule set            | 500-1000  | –   | –      | K     |
+
+### workflow (5) — `tool-catalog.ts:1190-1298` — `get_*_guidance` deferred to ADR-024
+
+| tool                        | what it does            | tokens    | AI  | CE-MCP | Cand. |
+| --------------------------- | ----------------------- | --------- | --- | ------ | ----- |
+| get_workflow_guidance       | Workflow guidance       | 1500-3000 | ✓   | –      | D     |
+| get_development_guidance    | Development guidance    | 1500-3000 | ✓   | –      | D     |
+| mcp_planning                | MCP planning assistant  | 3000-6000 | ✓   | ✓      | K     |
+| tool_chain_orchestrator     | Orchestrate tool chains | 2000-5000 | ✓   | ✓      | K     |
+| request_action_confirmation | Request confirmation    | 100-300   | –   | –      | K     |
+
+### utility (6) — `tool-catalog.ts:1299-1387`, `search_tools ~1823`
+
+| tool                      | what it does                          | tokens  | AI  | CE-MCP | Cand.                                 |
+| ------------------------- | ------------------------------------- | ------- | --- | ------ | ------------------------------------- |
+| manage_cache              | Cache operations                      | 100-500 | –   | –      | K                                     |
+| check_ai_execution_status | Check AI execution mode               | 100-300 | –   | –      | Rm (dies with AI layer)               |
+| get_server_context        | Server context                        | 200-500 | –   | –      | K                                     |
+| get_current_datetime      | Current date/time (host provides)     | 50-100  | –   | –      | Rm (deprecated #1639)                 |
+| load_prompt               | On-demand prompt (CE-MCP meta)        | 100-500 | –   | –      | Rm (host discovery; deprecated #1639) |
+| search_tools              | Tool search meta-tool (host provides) | 100-300 | –   | –      | Rm (host discovery; deprecated #1639) |
+
+### aggregator (10) — `tool-catalog.ts:1424-1774` — ADR-023 "separate commercial question"
+
+| tool                         | what it does                     | tokens    | AI  | CE-MCP | Cand. |
+| ---------------------------- | -------------------------------- | --------- | --- | ------ | ----- |
+| sync_to_aggregator           | Sync ADRs to Aggregator platform | 1000-3000 | –   | –      | Agg   |
+| get_adr_context              | ADR context from aggregator      | 500-1500  | –   | –      | Agg   |
+| get_staleness_report         | ADR staleness report             | 300-800   | –   | –      | Agg   |
+| get_adr_templates            | ADR templates                    | 300-1000  | –   | –      | Agg   |
+| get_adr_diagrams             | Mermaid diagrams (Pro+)          | 500-1500  | –   | –      | Agg   |
+| validate_adr_compliance      | Compliance check (Pro+)          | 1000-2500 | –   | –      | Agg   |
+| get_knowledge_graph          | Knowledge graph (Team)           | 1000-3000 | –   | –      | Agg   |
+| update_implementation_status | Update impl status (Pro+)        | 300-800   | –   | –      | Agg   |
+| get_adr_priorities           | ADR priorities for roadmap       | 500-1500  | –   | –      | Agg   |
+| analyze_gaps                 | Gaps between ADRs and codebase   | 800-3000  | –   | –      | Agg   |
+
+### BACKFILLED (4) — no explicit catalog entry; folded in with default `utility` metadata
+
+Dispatched from `src/tools/tool-dispatch.ts`. Each is in the wire (`MCP_TOOL_SCHEMAS`)
+but has no `TOOL_CATALOG.set(...)` of its own, so the backfill loop
+(`tool-catalog.ts:2103`) classifies it as `utility` with placeholder tokenCost and
+name-split keywords. `search_tools` _can_ surface them, but mis-categorised and
+under-described — the fix is a proper catalog entry per tool.
+
+| tool             | dispatch               | Cand.                                          |
+| ---------------- | ---------------------- | ---------------------------------------------- |
+| search_codebase  | `tool-dispatch.ts:142` | Rm/Rf (host Grep/Glob overlap)                 |
+| update_knowledge | `tool-dispatch.ts:228` | Rf (catalogue or remove)                       |
+| set_project_path | `tool-dispatch.ts:251` | Rf (catalogue or remove)                       |
+| get_gaps         | `tool-dispatch.ts:324` | **Rm/Rf — overlaps catalogued `analyze_gaps`** |
+
+## Candidate summary (discoveries — not decisions)
+
+| Group                              | Count                                                                                                                                                                       | Route                                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Remove — host-native** (ADR-023) | 8 exposed (`read_file`, `write_file`, `read_directory`, `list_directory`, `list_roots`, `get_current_datetime`, `search_tools`, `load_prompt`) + 3 already absent (`llm_*`) | **Deprecation DONE** (#1639, merged, closed #1638): all 8 carry `deprecated: true` + `[DEPRECATED host-native, ADR-023]` wire markers. **Next: per-asset `retirement.py` → Cleanup milestone.** |
+| **Dies with the AI layer**         | 1 (`check_ai_execution_status`)                                                                                                                                             | Goes with ADR-021 migration Batch 7 / retirement                                                                                                                                                |
+| **Deferred cluster**               | 15 (memory 6, workflow 5, research 4)                                                                                                                                       | ADR-024, pending usage data                                                                                                                                                                     |
+| **Aggregator**                     | 10                                                                                                                                                                          | ADR-023 "separate commercial question"                                                                                                                                                          |
+| **Backfilled, not classified**     | 4 (esp. `get_gaps` vs `analyze_gaps` overlap)                                                                                                                               | ADR-026 / #1416: give each a proper `TOOL_CATALOG` entry so it is categorised, not defaulted to `utility`                                                                                       |
+| **Refactor (quality)**             | all survivors                                                                                                                                                               | ADR-026: add `outputSchema` + annotations, defer discovery, fix the `aggregator` enum, flip the wire listing from `mode: 'full'` to `mode: 'lightweight'`                                       |
+
+## Sources
+
+- [MCP Client Best Practices (2026-07-28)](https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices)
+- [MCP Tools specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+- [MCP Tool Schema Design Guide 2026](https://kansei-link.com/en/insights/mcp-tool-schema-design-guide-2026.html)
+- [Progressive Tool Discovery for Token Efficiency](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/1923)
+- [Anthropic — Writing effective tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents) · [Tool search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) — tool-selection accuracy degrades past ~30–50 tools
+- [ADR-023](../adrs/adr-023-tool-surface-scope.md) · [ADR-026](../adrs/adr-026-tool-call-best-practices-conformance.md)


### PR DESCRIPTION
Adds a **Proposed** ADR-026 and a reference **tool-surface map** — the "how everything works + what else may need removing" deliverable — measured against **current** `main` (post-#1416 refactor).

## Contents
- `docs/adrs/adr-026-tool-call-best-practices-conformance.md` (status: Proposed, MADR; `## Decision` left to the owner)
- `docs/reference/tool-surface-map.md` (best-practices scorecard + full per-tool table + candidate flags)
- ADR-026 row added to `docs/adrs/README.md`

## Key measured findings (current main)
- **72** wire tools via `getToolListForMCP({mode:'full'})` → `MCP_TOOL_SCHEMAS` (`index.ts` is now a 79-line shim); **68 declared + 4 backfilled = 72** catalogued at runtime.
- **0** `outputSchema`, **0** MCP annotations, **12** CE-MCP directives.
- **8** host-native tools now marked deprecated (#1639, merged).
- **Corrected finding:** `getToolListForMCP` **is** the live wire source but is configured `mode:'full'`; a `lightweight` path already exists unused — a one-line config choice, not dead code (the earlier draft, written on a stale base, wrongly called it dead).
- The 4 uncatalogued tools are **backfilled** into the catalog as `utility` (discoverable but mis-categorised; `get_gaps` duplicates `analyze_gaps`); `search_tools` enum omits `aggregator`.
- Tool count (72) is above Anthropic's ~30–50 selection-accuracy band.

## Governance
Evidence + a Proposed decision record — **authorises nothing**. ADR-026's Decision is deliberately unfilled; any removal routes through an ADR Decision + `retirement.py` + admission. `bash scripts/check-adr-drift.sh` at baseline (0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oZ2FvkFuhDrGYHoWiu6Lv