### PR TITLE
feat(adr): ADR format reader + Nygard→MADR converter (#1466)

### DIFF
--- a/.repo-governor/acceptance/1466.json
+++ b/.repo-governor/acceptance/1466.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "Issue #1466 — ADR format READER + Nygard->MADR CONVERTER. New pure-function module src/utils/adr-format.ts (detectAdrFormat + convertNygardToMadr, centralizing the AdrFormat union), reusing adr-discovery.ts field extraction and js-yaml for MADR front matter. Target = the ADR-022 YAML-front-matter MADR shape the real corpus uses, NOT the stale * Status: prompt template. Tests in tests/utils/adr-format.test.ts (TDD). Both file_exists and the vitest run fail pre-work (neither file exists yet).",
+  "authority_id": "1466",
+  "criteria": [
+    { "check": "command_exit", "target": "npm run typecheck" },
+    { "check": "file_exists", "target": "src/utils/adr-format.ts" },
+    { "check": "file_exists", "target": "tests/utils/adr-format.test.ts" },
+    { "check": "command_exit", "target": "npx vitest run tests/utils/adr-format.test.ts" }
+  ]
+}

--- a/src/utils/adr-discovery.ts
+++ b/src/utils/adr-discovery.ts
@@ -6,6 +6,10 @@
 
 import { McpAdrError } from '../types/index.js';
 import { BasicTimeline, TimelineExtractionOptions, AdrWorkQueue } from './adr-timeline-types.js';
+// Field extraction lives in adr-format.ts (the home for ADR-format concerns); discovery
+// consumes it. This direction — discovery -> format — keeps adr-format.ts a wired-in
+// dependency and avoids a cycle (adr-format imports nothing from discovery).
+import { extractAdrFields } from './adr-format.js';
 
 /**
  * Represents a discovered Architectural Decision Record
@@ -311,134 +315,6 @@ function isLikelyAdr(content: string, filename: string): boolean {
 
   // Must have either ADR filename pattern OR ADR content patterns
   return hasAdrFilename || hasAdrContent;
-}
-
-/**
- * Structured fields extracted from an ADR document body.
- *
- * This is the single source of truth for the field-level regexes ADR tooling relies on
- * (title, status, date, number, the Nygard Context/Decision/Consequences sections, and
- * front-matter tags). `parseAdrMetadata` here and the format reader/converter in
- * `adr-format.ts` both read through this helper rather than each keeping a private copy
- * of the regexes.
- */
-export interface ExtractedAdrFields {
-  title?: string;
-  status: string;
-  date?: string;
-  number?: string;
-  context?: string;
-  decision?: string;
-  consequences?: string;
-  tags: string[];
-}
-
-/**
- * Extract ADR fields from raw markdown content.
- *
- * `filename` is optional: when supplied it seeds the title fallback and the ADR-number
- * lookup (callers that only have content, such as the format converter, omit it).
- */
-export function extractAdrFields(content: string, filename = ''): ExtractedAdrFields {
-  // Extract title (usually first # heading)
-  let title: string | undefined = filename ? filename.replace(/\.md$/, '') : undefined;
-  const titleMatch = content.match(/^#\s+(.+)$/m);
-  if (titleMatch && titleMatch[1]) {
-    title = titleMatch[1].trim();
-  }
-
-  // Extract status
-  let status = 'unknown';
-  const statusMatch = content.match(/(?:##?\s*status|status:)\s*(.+?)(?:\n|$)/i);
-  if (statusMatch && statusMatch[1]) {
-    status = statusMatch[1].trim().toLowerCase();
-  }
-
-  // Extract date
-  let date: string | undefined;
-  const dateMatch = content.match(/(?:##?\s*date|date:)\s*(.+?)(?:\n|$)/i);
-  if (dateMatch && dateMatch[1]) {
-    date = dateMatch[1].trim();
-  }
-
-  // Extract ADR number from filename or content
-  let number: string | undefined;
-  const numberMatch =
-    (filename ? filename.match(/(?:adr[-_]?)?(\d+)/i) : null) || content.match(/adr[-_]?(\d+)/i);
-  if (numberMatch && numberMatch[1]) {
-    number = numberMatch[1];
-  }
-
-  // Extract context
-  let context: string | undefined;
-  const contextMatch = content.match(/##?\s*context\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
-  if (contextMatch && contextMatch[1]) {
-    context = contextMatch[1].trim();
-  }
-
-  // Extract decision
-  let decision: string | undefined;
-  const decisionMatch = content.match(/##?\s*decision\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
-  if (decisionMatch && decisionMatch[1]) {
-    decision = decisionMatch[1].trim();
-  }
-
-  // Extract consequences
-  let consequences: string | undefined;
-  const consequencesMatch = content.match(/##?\s*consequences\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
-  if (consequencesMatch && consequencesMatch[1]) {
-    consequences = consequencesMatch[1].trim();
-  }
-
-  // Extract category/tags (if any).
-  //
-  // Three forms occur in the wild, and the idiomatic MADR one used to be the only one
-  // that did NOT work -- a YAML block list returned ["- architecture"], capturing the
-  // dash and dropping every entry after the first. ADR-022 adopted MADR, whose template
-  // uses block lists, so that was the form this needed most.
-  //
-  //   tags:               tags: a, b        tags: [a, b]
-  //     - a
-  //     - b
-  //
-  // Scoped to the leading `---` front-matter block when one is present, so a `tags:`
-  // mention in prose cannot be picked up -- the same discipline scripts/check-adr-drift.sh
-  // and repo-governor's adapters/adr both use after that exact false positive.
-  const tags: string[] = [];
-  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  const tagScope = fmMatch?.[1] ?? content;
-
-  const blockMatch = tagScope.match(
-    /^[ \t]*(?:tags?|categories?):[ \t]*\r?\n((?:[ \t]*-[ \t]*\S.*\r?\n?)+)/im
-  );
-  if (blockMatch?.[1]) {
-    tags.push(
-      ...blockMatch[1]
-        .split(/\r?\n/)
-        .map(line => line.replace(/^[ \t]*-[ \t]*/, '').trim())
-        .filter(Boolean)
-    );
-  } else {
-    const inlineMatch = tagScope.match(/^[ \t]*(?:tags?|categories?):[ \t]*(.+?)[ \t]*\r?$/im);
-    if (inlineMatch?.[1]) {
-      tags.push(
-        ...inlineMatch[1]
-          .replace(/^\[|\]$/g, '') // tolerate the bracket form, which used to keep its brackets
-          .split(',')
-          .map(tag => tag.trim().replace(/^['"]|['"]$/g, ''))
-          .filter(Boolean)
-      );
-    }
-  }
-
-  const fields: ExtractedAdrFields = { status, tags };
-  if (title !== undefined) fields.title = title;
-  if (date) fields.date = date;
-  if (number) fields.number = number;
-  if (context) fields.context = context;
-  if (decision) fields.decision = decision;
-  if (consequences) fields.consequences = consequences;
-  return fields;
 }
 
 /**

--- a/src/utils/adr-discovery.ts
+++ b/src/utils/adr-discovery.ts
@@ -314,11 +314,34 @@ function isLikelyAdr(content: string, filename: string): boolean {
 }
 
 /**
- * Parse ADR metadata from content
+ * Structured fields extracted from an ADR document body.
+ *
+ * This is the single source of truth for the field-level regexes ADR tooling relies on
+ * (title, status, date, number, the Nygard Context/Decision/Consequences sections, and
+ * front-matter tags). `parseAdrMetadata` here and the format reader/converter in
+ * `adr-format.ts` both read through this helper rather than each keeping a private copy
+ * of the regexes.
  */
-function parseAdrMetadata(content: string, filename: string, fullPath: string): DiscoveredAdr {
+export interface ExtractedAdrFields {
+  title?: string;
+  status: string;
+  date?: string;
+  number?: string;
+  context?: string;
+  decision?: string;
+  consequences?: string;
+  tags: string[];
+}
+
+/**
+ * Extract ADR fields from raw markdown content.
+ *
+ * `filename` is optional: when supplied it seeds the title fallback and the ADR-number
+ * lookup (callers that only have content, such as the format converter, omit it).
+ */
+export function extractAdrFields(content: string, filename = ''): ExtractedAdrFields {
   // Extract title (usually first # heading)
-  let title = filename.replace(/\.md$/, '');
+  let title: string | undefined = filename ? filename.replace(/\.md$/, '') : undefined;
   const titleMatch = content.match(/^#\s+(.+)$/m);
   if (titleMatch && titleMatch[1]) {
     title = titleMatch[1].trim();
@@ -340,7 +363,8 @@ function parseAdrMetadata(content: string, filename: string, fullPath: string): 
 
   // Extract ADR number from filename or content
   let number: string | undefined;
-  const numberMatch = filename.match(/(?:adr[-_]?)?(\d+)/i) || content.match(/adr[-_]?(\d+)/i);
+  const numberMatch =
+    (filename ? filename.match(/(?:adr[-_]?)?(\d+)/i) : null) || content.match(/adr[-_]?(\d+)/i);
   if (numberMatch && numberMatch[1]) {
     number = numberMatch[1];
   }
@@ -407,22 +431,39 @@ function parseAdrMetadata(content: string, filename: string, fullPath: string): 
     }
   }
 
+  const fields: ExtractedAdrFields = { status, tags };
+  if (title !== undefined) fields.title = title;
+  if (date) fields.date = date;
+  if (number) fields.number = number;
+  if (context) fields.context = context;
+  if (decision) fields.decision = decision;
+  if (consequences) fields.consequences = consequences;
+  return fields;
+}
+
+/**
+ * Parse ADR metadata from content
+ */
+function parseAdrMetadata(content: string, filename: string, fullPath: string): DiscoveredAdr {
+  const fields = extractAdrFields(content, filename);
+  const tags = fields.tags;
+
   const metadata: DiscoveredAdr['metadata'] = { tags };
-  if (number) metadata.number = number;
+  if (fields.number) metadata.number = fields.number;
   if (tags[0]) metadata.category = tags[0];
 
   const result: DiscoveredAdr = {
     filename,
-    title,
-    status,
-    date,
+    title: fields.title ?? filename.replace(/\.md$/, ''),
+    status: fields.status,
+    date: fields.date,
     path: fullPath,
     metadata,
   };
 
-  if (context) result.context = context;
-  if (decision) result.decision = decision;
-  if (consequences) result.consequences = consequences;
+  if (fields.context) result.context = fields.context;
+  if (fields.decision) result.decision = fields.decision;
+  if (fields.consequences) result.consequences = fields.consequences;
 
   return result;
 }

--- a/src/utils/adr-format.ts
+++ b/src/utils/adr-format.ts
@@ -16,7 +16,6 @@
  */
 
 import yaml from 'js-yaml';
-import { extractAdrFields } from './adr-discovery.js';
 
 /**
  * The three ADR document shapes this module distinguishes.
@@ -27,6 +26,132 @@ import { extractAdrFields } from './adr-discovery.js';
  * scope and #1647.
  */
 export type AdrFormat = 'nygard' | 'madr' | 'custom';
+
+/**
+ * The fields a reader recovers from an ADR document, format-agnostic
+ * (title, status, date, number, the Context/Decision/Consequences sections, and
+ * front-matter tags). This is the single home for the field-extraction regexes:
+ * `adr-discovery.ts`'s `parseAdrMetadata` and this module's reader/converter both
+ * read through `extractAdrFields` rather than each keeping a private copy.
+ */
+export interface ExtractedAdrFields {
+  title?: string;
+  status: string;
+  date?: string;
+  number?: string;
+  context?: string;
+  decision?: string;
+  consequences?: string;
+  tags: string[];
+}
+
+/**
+ * Extract ADR fields from raw markdown content.
+ *
+ * `filename` is optional: when supplied it seeds the title fallback and the ADR-number
+ * lookup (callers that only have content, such as the format converter, omit it).
+ */
+export function extractAdrFields(content: string, filename = ''): ExtractedAdrFields {
+  // Extract title (usually first # heading)
+  let title: string | undefined = filename ? filename.replace(/\.md$/, '') : undefined;
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  if (titleMatch && titleMatch[1]) {
+    title = titleMatch[1].trim();
+  }
+
+  // Extract status
+  let status = 'unknown';
+  const statusMatch = content.match(/(?:##?\s*status|status:)\s*(.+?)(?:\n|$)/i);
+  if (statusMatch && statusMatch[1]) {
+    status = statusMatch[1].trim().toLowerCase();
+  }
+
+  // Extract date
+  let date: string | undefined;
+  const dateMatch = content.match(/(?:##?\s*date|date:)\s*(.+?)(?:\n|$)/i);
+  if (dateMatch && dateMatch[1]) {
+    date = dateMatch[1].trim();
+  }
+
+  // Extract ADR number from filename or content
+  let number: string | undefined;
+  const numberMatch =
+    (filename ? filename.match(/(?:adr[-_]?)?(\d+)/i) : null) || content.match(/adr[-_]?(\d+)/i);
+  if (numberMatch && numberMatch[1]) {
+    number = numberMatch[1];
+  }
+
+  // Extract context
+  let context: string | undefined;
+  const contextMatch = content.match(/##?\s*context\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
+  if (contextMatch && contextMatch[1]) {
+    context = contextMatch[1].trim();
+  }
+
+  // Extract decision
+  let decision: string | undefined;
+  const decisionMatch = content.match(/##?\s*decision\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
+  if (decisionMatch && decisionMatch[1]) {
+    decision = decisionMatch[1].trim();
+  }
+
+  // Extract consequences
+  let consequences: string | undefined;
+  const consequencesMatch = content.match(/##?\s*consequences\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
+  if (consequencesMatch && consequencesMatch[1]) {
+    consequences = consequencesMatch[1].trim();
+  }
+
+  // Extract category/tags (if any).
+  //
+  // Three forms occur in the wild, and the idiomatic MADR one used to be the only one
+  // that did NOT work -- a YAML block list returned ["- architecture"], capturing the
+  // dash and dropping every entry after the first. ADR-022 adopted MADR, whose template
+  // uses block lists, so that was the form this needed most.
+  //
+  //   tags:               tags: a, b        tags: [a, b]
+  //     - a
+  //     - b
+  //
+  // Scoped to the leading `---` front-matter block when one is present, so a `tags:`
+  // mention in prose cannot be picked up -- the same discipline scripts/check-adr-drift.sh
+  // and repo-governor's adapters/adr both use after that exact false positive.
+  const tags: string[] = [];
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const tagScope = fmMatch?.[1] ?? content;
+
+  const blockMatch = tagScope.match(
+    /^[ \t]*(?:tags?|categories?):[ \t]*\r?\n((?:[ \t]*-[ \t]*\S.*\r?\n?)+)/im
+  );
+  if (blockMatch?.[1]) {
+    tags.push(
+      ...blockMatch[1]
+        .split(/\r?\n/)
+        .map(line => line.replace(/^[ \t]*-[ \t]*/, '').trim())
+        .filter(Boolean)
+    );
+  } else {
+    const inlineMatch = tagScope.match(/^[ \t]*(?:tags?|categories?):[ \t]*(.+?)[ \t]*\r?$/im);
+    if (inlineMatch?.[1]) {
+      tags.push(
+        ...inlineMatch[1]
+          .replace(/^\[|\]$/g, '') // tolerate the bracket form, which used to keep its brackets
+          .split(',')
+          .map(tag => tag.trim().replace(/^['"]|['"]$/g, ''))
+          .filter(Boolean)
+      );
+    }
+  }
+
+  const fields: ExtractedAdrFields = { status, tags };
+  if (title !== undefined) fields.title = title;
+  if (date) fields.date = date;
+  if (number) fields.number = number;
+  if (context) fields.context = context;
+  if (decision) fields.decision = decision;
+  if (consequences) fields.consequences = consequences;
+  return fields;
+}
 
 /**
  * Does the document open with a `---...---` YAML front-matter block that declares

--- a/src/utils/adr-format.ts
+++ b/src/utils/adr-format.ts
@@ -1,0 +1,154 @@
+/**
+ * ADR format reader and Nygard -> MADR converter (issue #1466).
+ *
+ * Pure functions, no I/O and no side effects — modelled on `src/utils/rule-format.ts`.
+ * Two capabilities:
+ *
+ *   - `detectAdrFormat(content)` classifies an ADR document as `'nygard'`, `'madr'`,
+ *     or `'custom'`.
+ *   - `convertNygardToMadr(content)` rewrites a Nygard-style ADR into the ADR-022
+ *     canonical MADR shape the real corpus uses (see docs/adrs/adr-025 and adr-026 as
+ *     golden references), with `js-yaml` front matter.
+ *
+ * Field-level parsing (title/status/date/context/decision/consequences/tags) is reused
+ * from `adr-discovery.ts` via the shared `extractAdrFields` helper rather than keeping a
+ * third private copy of those regexes.
+ */
+
+import yaml from 'js-yaml';
+import { extractAdrFields } from './adr-discovery.js';
+
+/**
+ * The three ADR document shapes this module distinguishes.
+ *
+ * Exported for future reuse by the inline `templateFormat` unions elsewhere in the
+ * codebase (adr-suggestion-tool.ts, mcp-tool-schemas.ts, types/tool-arguments.ts,
+ * adr-suggestion-prompts.ts). Those sites are intentionally NOT rewired here — see #1466
+ * scope and #1647.
+ */
+export type AdrFormat = 'nygard' | 'madr' | 'custom';
+
+/**
+ * Does the document open with a `---...---` YAML front-matter block that declares
+ * `status:` and/or `date:`?
+ */
+function hasFrontMatterStatusOrDate(content: string): boolean {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch || !fmMatch[1]) return false;
+  return /^[ \t]*(?:status|date):/im.test(fmMatch[1]);
+}
+
+/** Does the document use MADR-style headings? */
+function hasMadrHeadings(content: string): boolean {
+  return (
+    /^##\s+Context and Problem Statement\s*$/im.test(content) ||
+    /^##\s+Considered Options\s*$/im.test(content) ||
+    /^##\s+Decision Drivers\s*$/im.test(content)
+  );
+}
+
+/**
+ * Detect the format of an ADR document.
+ *
+ * - `'madr'`  — leading YAML front matter with `status:`/`date:` AND MADR headings
+ *   (`## Context and Problem Statement`, and/or `## Considered Options`/
+ *   `## Decision Drivers`).
+ * - `'nygard'` — the Nygard heading set (`## Status`, `## Context`, `## Decision`,
+ *   `## Consequences`) with a status value on the following line.
+ * - `'custom'` — anything else.
+ */
+export function detectAdrFormat(content: string): AdrFormat {
+  if (hasFrontMatterStatusOrDate(content) && hasMadrHeadings(content)) {
+    return 'madr';
+  }
+
+  // Nygard: reuse the field extractor's heading regexes. Context/Decision/Consequences
+  // each require the `##`-heading-then-body form, and a status value on the following
+  // line resolves to something other than the 'unknown' sentinel.
+  const fields = extractAdrFields(content);
+  const hasNygardSet =
+    fields.status !== 'unknown' &&
+    fields.context !== undefined &&
+    fields.decision !== undefined &&
+    fields.consequences !== undefined;
+  if (hasNygardSet) {
+    return 'nygard';
+  }
+
+  return 'custom';
+}
+
+/**
+ * Map a Nygard status value onto the lowercase MADR status vocabulary.
+ *
+ * Nygard "Accepted" -> "accepted", "Deprecated" -> "deprecated",
+ * "Superseded" -> "superseded", "Proposed" -> "proposed". Absent/unknown -> "proposed".
+ * Any other value passes through lowercased.
+ */
+function mapStatusToMadr(status: string | undefined): string {
+  const s = (status ?? '').trim().toLowerCase();
+  if (!s || s === 'unknown') return 'proposed';
+  if (s.startsWith('accept')) return 'accepted';
+  if (s.startsWith('deprecat')) return 'deprecated';
+  if (s.startsWith('supersed')) return 'superseded';
+  if (s.startsWith('propos')) return 'proposed';
+  return s;
+}
+
+/**
+ * Convert a Nygard-style ADR into the ADR-022 canonical MADR shape.
+ *
+ * Idempotent: content already detected as `'madr'` is returned unchanged.
+ *
+ * `'custom'` content is converted best-effort — whatever Nygard-shaped sections can be
+ * recovered are carried across, and any section with nothing to carry becomes an empty
+ * placeholder heading. The result is always valid MADR (front matter + MADR headings).
+ */
+export function convertNygardToMadr(content: string): string {
+  if (detectAdrFormat(content) === 'madr') {
+    return content;
+  }
+
+  const fields = extractAdrFields(content);
+
+  // Build the YAML front matter via js-yaml (block style, 2-space indent).
+  const frontMatter: Record<string, unknown> = { status: mapStatusToMadr(fields.status) };
+  if (fields.date) frontMatter['date'] = fields.date;
+  if (fields.tags.length > 0) frontMatter['tags'] = fields.tags;
+
+  const yamlBlock = yaml.dump(frontMatter, { indent: 2, lineWidth: -1 }).trimEnd();
+
+  const title = fields.title ?? 'ADR';
+
+  const section = (body: string | undefined): string => (body && body.trim() ? body.trim() : '');
+
+  const lines: string[] = [
+    '---',
+    yamlBlock,
+    '---',
+    '',
+    `# ${title}`,
+    '',
+    '## Context and Problem Statement',
+    '',
+    section(fields.context),
+    '',
+    '## Decision',
+    '',
+    section(fields.decision),
+    '',
+    '## Consequences',
+    '',
+    section(fields.consequences),
+    '',
+    '## More Information',
+    '',
+  ];
+
+  // Collapse the doubled blank lines that empty sections introduce, then end with a
+  // single trailing newline.
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\s*$/, '\n');
+}

--- a/tests/utils/adr-format.test.ts
+++ b/tests/utils/adr-format.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for adr-format.ts — the pure-function ADR format reader and the
+ * Nygard -> MADR converter (issue #1466).
+ *
+ * These are pure-function asserts in the spirit of tests/utils/rule-format.test.ts,
+ * with inline ADR markdown constants like tests/utils/adr-discovery-tags.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  detectAdrFormat,
+  convertNygardToMadr,
+  type AdrFormat,
+} from '../../src/utils/adr-format.js';
+
+// A classic Nygard-style ADR: `## Status/## Context/## Decision/## Consequences`
+// headings with the value on the following line, no YAML front matter.
+const NYGARD_ADR = `# ADR-001: Use PostgreSQL
+
+## Status
+
+Accepted
+
+## Context
+
+We need a relational database with strong consistency for the billing service.
+
+## Decision
+
+We will use PostgreSQL as our primary datastore.
+
+## Consequences
+
+We gain ACID guarantees but must manage schema migrations ourselves.
+`;
+
+// A MADR-style ADR: YAML front matter with status/date/tags plus MADR headings.
+const MADR_ADR = `---
+status: accepted
+date: 2026-01-15
+tags:
+  - database
+  - architecture
+---
+
+# ADR-001: Use PostgreSQL
+
+## Context and Problem Statement
+
+We need a relational database with strong consistency.
+
+## Decision
+
+Use PostgreSQL.
+
+## Consequences
+
+Strong consistency, migrations to manage.
+
+## More Information
+
+None.
+`;
+
+// A freeform, non-ADR document.
+const FREEFORM = `# Weekend Notes
+
+Just some random thoughts about the project roadmap and the weather.
+`;
+
+describe('detectAdrFormat', () => {
+  it('detects a Nygard ADR as "nygard"', () => {
+    const format: AdrFormat = detectAdrFormat(NYGARD_ADR);
+    expect(format).toBe('nygard');
+  });
+
+  it('detects a MADR ADR (YAML front matter) as "madr"', () => {
+    expect(detectAdrFormat(MADR_ADR)).toBe('madr');
+  });
+
+  it('detects a freeform document as "custom"', () => {
+    expect(detectAdrFormat(FREEFORM)).toBe('custom');
+  });
+
+  it('does not misread MADR headings without front matter as nygard', () => {
+    // MADR headings but no `## Status/## Decision/## Consequences` Nygard set
+    const noFm = `# ADR-009: Something
+
+## Context and Problem Statement
+
+Some context.
+
+## Considered Options
+
+- a
+- b
+`;
+    expect(detectAdrFormat(noFm)).toBe('custom');
+  });
+});
+
+describe('convertNygardToMadr', () => {
+  it('produces output detected as MADR', () => {
+    const out = convertNygardToMadr(NYGARD_ADR);
+    expect(detectAdrFormat(out)).toBe('madr');
+  });
+
+  it('emits YAML front matter parseable by js-yaml with a lowercased status', () => {
+    const out = convertNygardToMadr(NYGARD_ADR);
+    const fmMatch = out.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    expect(fmMatch).not.toBeNull();
+    const fm = yaml.load(fmMatch![1]) as Record<string, unknown>;
+    expect(fm.status).toBe('accepted');
+  });
+
+  it('preserves the title (including the ADR number)', () => {
+    const out = convertNygardToMadr(NYGARD_ADR);
+    expect(out).toContain('# ADR-001: Use PostgreSQL');
+  });
+
+  it('uses the "## Context and Problem Statement" heading and carries the Context text', () => {
+    const out = convertNygardToMadr(NYGARD_ADR);
+    expect(out).toContain('## Context and Problem Statement');
+    expect(out).toContain('We need a relational database with strong consistency');
+  });
+
+  it('carries the Decision and Consequences text', () => {
+    const out = convertNygardToMadr(NYGARD_ADR);
+    expect(out).toContain('## Decision');
+    expect(out).toContain('We will use PostgreSQL as our primary datastore.');
+    expect(out).toContain('## Consequences');
+    expect(out).toContain('We gain ACID guarantees but must manage schema migrations ourselves.');
+  });
+
+  describe('status mapping', () => {
+    const cases: Array<[string, string]> = [
+      ['Accepted', 'accepted'],
+      ['Deprecated', 'deprecated'],
+      ['Superseded', 'superseded'],
+      ['Proposed', 'proposed'],
+    ];
+
+    it.each(cases)('maps Nygard status %s -> %s', (nygardStatus, madrStatus) => {
+      const doc = NYGARD_ADR.replace('Accepted', nygardStatus);
+      const out = convertNygardToMadr(doc);
+      const fm = yaml.load(out.match(/^---\r?\n([\s\S]*?)\r?\n---/)![1]) as Record<string, unknown>;
+      expect(fm.status).toBe(madrStatus);
+    });
+
+    it('defaults to "proposed" when no status is present', () => {
+      const noStatus = `# ADR-002: Something
+
+## Context
+
+Ctx.
+
+## Decision
+
+Dec.
+
+## Consequences
+
+Con.
+`;
+      const out = convertNygardToMadr(noStatus);
+      const fm = yaml.load(out.match(/^---\r?\n([\s\S]*?)\r?\n---/)![1]) as Record<string, unknown>;
+      expect(fm.status).toBe('proposed');
+    });
+  });
+
+  it('preserves tags from source front matter', () => {
+    // A Nygard-body ADR that nonetheless carries a YAML tags block up top.
+    const withTags = `---
+tags:
+  - database
+  - billing
+---
+
+${NYGARD_ADR}`;
+    const out = convertNygardToMadr(withTags);
+    const fm = yaml.load(out.match(/^---\r?\n([\s\S]*?)\r?\n---/)![1]) as Record<string, unknown>;
+    expect(fm.tags).toEqual(['database', 'billing']);
+  });
+
+  it('preserves the date when present', () => {
+    const withDate = NYGARD_ADR.replace('## Status', '## Date\n\n2026-02-02\n\n## Status');
+    const out = convertNygardToMadr(withDate);
+    const fm = yaml.load(out.match(/^---\r?\n([\s\S]*?)\r?\n---/)![1]) as Record<string, unknown>;
+    expect(String(fm.date)).toContain('2026-02-02');
+  });
+
+  it('is idempotent: converting an already-MADR doc returns it unchanged and still MADR', () => {
+    const out = convertNygardToMadr(MADR_ADR);
+    expect(out).toBe(MADR_ADR);
+    expect(detectAdrFormat(out)).toBe('madr');
+  });
+});


### PR DESCRIPTION
Closes #1466. Extends ADR-022 (MADR default) to **existing** corpora — ADR-022 itself noted this converter "is not a capability this tool has today."

## What this adds
New pure-function module `src/utils/adr-format.ts` (no I/O, modeled on `rule-format.ts`):
- `detectAdrFormat(content) → 'nygard' | 'madr' | 'custom'`
- `convertNygardToMadr(content) → string` (idempotent on MADR input)
- exported `AdrFormat` union (for future reuse by the 4 `templateFormat` sites — not rewired here)

**Emits the ADR-022 canonical MADR shape the real corpus uses** — YAML front matter (`status` lowercased to MADR vocab, `date`/`tags` preserved) via `js-yaml` (already a dependency), then `# Title` / `## Context and Problem Statement` / `## Decision` / `## Consequences` / `## More Information` — not the stale `* Status:` prompt template.

## Reuse, not copy
Factored the field-level regexes out of `parseAdrMetadata` in `src/utils/adr-discovery.ts` into an exported `extractAdrFields(content, filename?)`; `parseAdrMetadata` now delegates to it (behavior preserved — `adr-discovery-tags` tests still green). `adr-format.ts` imports it. No third copy of the parsing.

## Tests
`tests/utils/adr-format.test.ts` — **17 tests**: format detection (incl. MADR-headings-without-front-matter not misread as nygard), round-trip (output detected as `madr`, valid js-yaml front matter, title/sections preserved), status mapping, tags/date preservation, idempotence.

## Why now / what's next
Sequenced first so **#1647** (migrate `adr-suggestion-tool.ts` off OpenRouter) can build `generateAdrFromDecision`'s deterministic autoSave content on this generator, preserving the auto-index/KG feature that a naive migration deleted.

## Governance
Issue #1466 (v3.1), bounded by `.repo-governor/acceptance/1466.json` — engine **STOP_COMPLETE** (typecheck; both files exist; the 17-test suite passes).

Scope: does **not** rewire the existing `templateFormat` duplication sites (that's coordinated with #1647). No behavior change to shipped tools yet — this is the building block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oZ2FvkFuhDrGYHoWiu6Lv