### PR TITLE
feat(tools): migrate adr-suggestion off OpenRouter, deterministically (#1647)

### DIFF
--- a/.repo-governor/acceptance/1647.json
+++ b/.repo-governor/acceptance/1647.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "CE-MCP migration of adr-suggestion-tool.ts (ADR-021 Option B), the deferred half of #1629, done on top of #1466's converter. Remove ai-executor/prompt-execution: suggestAdrs returns a CE-MCP directive; generateAdrFromDecision builds its content DETERMINISTICALLY (via adr-format.ts) instead of the AI-execution result, preserving the autoSave + knowledge-graph auto-registration + release-linkage + manual-instructions behaviour (tests/tools/adr-suggestion-auto-index.test.ts, 3 tests) and DROPPING the [ADR_CONTENT_PLACEHOLDER] write. The auto-index tests are in the bar this time (the gap that broke the first attempt). Import gate fails pre-work; the two test files pass on main and must stay green.",
+  "authority_id": "1647",
+  "criteria": [
+    { "check": "command_exit", "target": "npm run typecheck" },
+    {
+      "check": "command_exit",
+      "target": "npx vitest run tests/tools/adr-suggestion-tool.test.ts tests/tools/adr-suggestion-auto-index.test.ts"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! rg -q \"ai-executor|prompt-execution\" src/tools/adr-suggestion-tool.ts'"
+    }
+  ]
+}

--- a/src/tools/adr-suggestion-tool.ts
+++ b/src/tools/adr-suggestion-tool.ts
@@ -17,11 +17,12 @@ import {
   retrieveRelevantMemories,
   createToolReflexionConfig,
 } from '../utils/reflexion.js';
-import { executeADRSuggestionPrompt, formatMCPResponse } from '../utils/prompt-execution.js';
 import { TreeSitterAnalyzer } from '../utils/tree-sitter-analyzer.js';
 import { findRelatedCode } from '../utils/file-system.js';
+import { buildMadrDocument } from '../utils/adr-format.js';
 // ResearchOrchestrator removed per ADR-018 - using static infrastructure context instead
-import { getAIExecutor } from '../utils/ai-executor.js';
+// Server-side LLM execution removed per CE-MCP migration (#1647): ADR content is now
+// emitted deterministically and suggestions return a CE-MCP directive for the agent.
 import {
   getEnhancedModeDefault,
   getKnowledgeEnhancementDefault,
@@ -701,146 +702,24 @@ ${reflexionResult.prompt}
           enhancedPrompt = implicitResult.analysisPrompt;
         }
 
-        // Execute the analysis with AI if enabled, otherwise return prompt
-        const aiExecutor = getAIExecutor();
-        let executionResult: any;
-
-        // Try AI-powered analysis with research context
-        if (aiExecutor.isAvailable()) {
-          try {
-            const aiResult = await aiExecutor.executeStructuredPrompt(
-              `You are an expert software architect analyzing a project for ADR recommendations.
-
-${researchContext}
-
-${knowledgeContext}
-
-${reflexionContext}
-
-${codeContext}
-
-Based on the research data above, generate comprehensive ADR suggestions.
-
-${implicitResult.instructions}
-
-${enhancedPrompt}`,
-              null,
-              {
-                temperature: 0.3,
-                maxTokens: 4000,
-                systemPrompt:
-                  'You are an architecture expert. Generate ADR recommendations based on ACTUAL infrastructure data from research, not assumptions. Reference specific files, environment data, and existing ADRs found in the research.',
-              }
-            );
-
-            executionResult = {
-              isAIGenerated: true,
-              content:
-                typeof aiResult.data === 'string'
-                  ? aiResult.data
-                  : JSON.stringify(aiResult.data, null, 2),
-              metadata: aiResult.raw.metadata,
-            };
-          } catch (error) {
-            console.warn('[WARNING] AI execution failed, falling back to prompt-only mode:', error);
-            executionResult = await executeADRSuggestionPrompt(
-              enhancedPrompt,
-              implicitResult.instructions,
-              {
-                temperature: 0.1,
-                maxTokens: 4000,
-              }
-            );
-          }
-        } else {
-          executionResult = await executeADRSuggestionPrompt(
-            enhancedPrompt,
-            implicitResult.instructions,
+        // CE-MCP directive (#1647): the server no longer calls an LLM itself. It
+        // deterministically assembles the research/knowledge/learning context and the
+        // analysis prompt, and returns them as a directive for the calling agent to act
+        // on. No server-side LLM round-trip.
+        return {
+          content: [
             {
-              temperature: 0.1,
-              maxTokens: 4000,
-            }
-          );
-        }
+              type: 'text',
+              text: `# ADR Suggestions: Enhanced Comprehensive Analysis (Research-Driven)
 
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - return actual analysis results
-          return formatMCPResponse({
-            ...executionResult,
-            content: `# ADR Suggestions: AI Analysis Results (Research-Driven)
+This analysis assembles research-driven context and a structured analysis directive for the calling agent to execute. Content is generated deterministically — no server-side LLM call.
 
 ## Enhancement Features
-- **Research-Driven Analysis**: ✅ Enabled (Live infrastructure data)
+- **Research-Driven Analysis**: ✅ Enabled (Static infrastructure context)
 - **Knowledge Generation**: ${knowledgeEnhancement ? '✅ Enabled' : '❌ Disabled'}
 - **Reflexion Learning**: ${learningEnabled ? '✅ Enabled' : '❌ Disabled'}
 - **Enhanced Mode**: ${enhancedMode ? '✅ Enabled' : '❌ Disabled'}
 - **Smart Code Linking**: ${existingAdrs && existingAdrs.length > 0 ? '✅ Enabled' : '❌ No existing ADRs'}
-- **AI Execution**: ✅ Enabled (${executionResult.metadata?.model || 'default model'})
-
-## Project Analysis
-- **Project Path**: ${projectPath}
-- **Existing ADRs**: ${existingAdrs?.length || 0} ADRs provided
-- **Analysis Type**: Comprehensive (Research + AI-driven)
-- **AI Response Time**: ${executionResult.metadata?.executionTime || 'N/A'}ms
-- **Tokens Used**: ${executionResult.metadata?.usage?.totalTokens || 'N/A'}
-
-${researchContext}
-
-${codeContext}
-
-${knowledgeContext}
-
-${reflexionContext}
-
-## AI Analysis Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the analysis above:
-
-1. **Review Suggested ADRs**: Examine each suggested architectural decision
-2. **Prioritize by Impact**: Focus on high-impact decisions first
-3. **Generate ADRs**: Use the \`generate_adr_from_decision\` tool for priority decisions
-4. **Implement Changes**: Plan and execute the architectural changes
-5. **Update Documentation**: Keep ADRs current as decisions evolve
-
-## Integration Workflow
-
-For each suggested decision, use:
-\`\`\`json
-{
-  "tool": "generate_adr_from_decision",
-  "args": {
-    "decisionData": {
-      "title": "Decision title from analysis",
-      "context": "Context from analysis",
-      "decision": "Decision description",
-      "consequences": "Consequences from analysis"
-    }
-  }
-}
-\`\`\`
-`,
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# ADR Suggestions: Enhanced Comprehensive Analysis (Research-Driven)
-
-This enhanced analysis uses research-driven architecture with live infrastructure data and advanced prompting techniques.
-
-## Enhancement Features
-- **Research-Driven Analysis**: ✅ Enabled (Live infrastructure data)
-- **Knowledge Generation**: ${knowledgeEnhancement ? '✅ Enabled' : '❌ Disabled'}
-- **Reflexion Learning**: ${learningEnabled ? '✅ Enabled' : '❌ Disabled'}
-- **Enhanced Mode**: ${enhancedMode ? '✅ Enabled' : '❌ Disabled'}
-- **Smart Code Linking**: ${existingAdrs && existingAdrs.length > 0 ? '✅ Enabled' : '❌ No existing ADRs'}
-- **AI Execution**: ❌ Disabled (set EXECUTION_MODE=full for legacy AI execution)
 
 ## Project Analysis
 - **Project Path**: ${projectPath}
@@ -855,18 +734,18 @@ ${knowledgeContext}
 
 ${reflexionContext}
 
-## AI Analysis Instructions
+## Analysis Instructions
 
 ${implicitResult.instructions}
 
-## Enhanced AI Analysis Prompt
+## Enhanced Analysis Directive
 
 ${enhancedPrompt}
 
 ## Recommended Workflow
 
 ### 1. **Initial Analysis**
-Submit the prompt above to get comprehensive decision detection
+Act on the directive above to get comprehensive decision detection
 
 ### 2. **Priority Review**
 - Focus on **high** and **critical** priority decisions first
@@ -882,10 +761,9 @@ Use \`generate_adr_from_decision\` tool for each prioritized decision
 - Schedule team review sessions
 - Plan implementation tasks
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       default:
@@ -927,7 +805,7 @@ export async function generateAdrFromDecision(args: {
   } = args;
 
   try {
-    const { generateAdrFromDecision, generateNextAdrNumber, suggestAdrFilename } =
+    const { generateNextAdrNumber, suggestAdrFilename } =
       await import('../utils/adr-suggestions.js');
 
     if (
@@ -942,88 +820,66 @@ export async function generateAdrFromDecision(args: {
       );
     }
 
-    const result = await generateAdrFromDecision(decisionData, templateFormat, existingAdrs);
-
     // Generate suggested metadata
     const adrNumber = generateNextAdrNumber(existingAdrs);
     const filename = suggestAdrFilename(decisionData.title, adrNumber);
     const fullPath = `${adrDirectory}/${filename}`;
 
-    // Execute ADR generation with AI if enabled
-    const { executeADRGenerationPrompt } = await import('../utils/prompt-execution.js');
-    const executionResult = await executeADRGenerationPrompt(
-      result.generationPrompt,
-      result.instructions,
-      {
-        temperature: 0.1,
-        maxTokens: 6000,
-        responseFormat: 'text',
-      }
-    );
+    // Deterministically emit the ADR content as a canonical ADR-022 MADR document
+    // (#1647 CE-MCP migration — no server-side LLM call). The emitted content contains
+    // `# <title>` and the MADR heading set built from the decision fields.
+    const adrContent = buildMadrDocument({
+      title: decisionData.title,
+      status: 'proposed',
+      context: decisionData.context,
+      decision: decisionData.decision,
+      consequences: decisionData.consequences,
+    });
 
-    if (executionResult.isAIGenerated) {
-      // AI execution successful - optionally persist and index the ADR
-      let savedSection = `## File Creation Instructions
+    let releaseSection = '';
+    let saved = false;
+    let indexed = false;
 
-To save this ADR to your project:
+    // Auto-save path: write the real deterministic content, register in the knowledge
+    // graph, and preview release linkage. Any failure falls through to the
+    // manual-instructions output below without throwing.
+    if (autoSave) {
+      try {
+        const { writeFile } = await import('../utils/file-system.js');
+        const writeResult = await writeFile(fullPath, adrContent);
+        if (writeResult.success) {
+          saved = true;
 
-1. **Create the ADR directory** (if it doesn't exist):
-   \`\`\`bash
-   mkdir -p ${adrDirectory}
-   \`\`\`
+          // Register in knowledge graph (best-effort)
+          try {
+            const { KnowledgeGraphManager } = await import('../utils/knowledge-graph-manager.js');
+            const kg = new KnowledgeGraphManager();
+            await kg.registerAdr({
+              adrNumber,
+              filename,
+              path: fullPath,
+              title: decisionData.title,
+              status: 'accepted',
+              createdAt: new Date().toISOString(),
+            });
+            indexed = true;
+          } catch {
+            // KG registration is best-effort; do not block user on failure
+          }
 
-2. **Save the ADR content** to the file:
-   \`\`\`bash
-   cat > "${fullPath}" << 'EOF'
-   ${executionResult.content}
-   EOF
-   \`\`\`
-
-3. **Verify the file** was created successfully:
-   \`\`\`bash
-   ls -la "${fullPath}"
-   \`\`\``;
-      let releaseSection = '';
-      let saved = false;
-      let indexed = false;
-
-      if (autoSave) {
-        try {
-          const { writeFile } = await import('../utils/file-system.js');
-          const writeResult = await writeFile(fullPath, executionResult.content);
-          if (writeResult.success) {
-            saved = true;
-
-            // Register in knowledge graph (best-effort)
-            try {
-              const { KnowledgeGraphManager } = await import('../utils/knowledge-graph-manager.js');
-              const kg = new KnowledgeGraphManager();
-              await kg.registerAdr({
-                adrNumber,
-                filename,
-                path: fullPath,
-                title: decisionData.title,
-                status: 'accepted',
-                createdAt: new Date().toISOString(),
-              });
-              indexed = true;
-            } catch {
-              // KG registration is best-effort; do not block user on failure
-            }
-
-            // Preview next release linkage (best-effort)
-            try {
-              const { discoverAdrsInDirectory } = await import('../utils/adr-discovery.js');
-              const { detectReleases, previewNextRelease } =
-                await import('../utils/release-tracker.js');
-              const discovered = await discoverAdrsInDirectory(adrDirectory, projectPath, {
-                includeContent: false,
-                includeTimeline: false,
-              });
-              const releases = await detectReleases(projectPath);
-              const preview = await previewNextRelease(projectPath, discovered.adrs, releases);
-              const queued = preview.pendingAdrs.some(a => a.filename === filename);
-              releaseSection = `## 🔗 Release Linkage
+          // Preview next release linkage (best-effort)
+          try {
+            const { discoverAdrsInDirectory } = await import('../utils/adr-discovery.js');
+            const { detectReleases, previewNextRelease } =
+              await import('../utils/release-tracker.js');
+            const discovered = await discoverAdrsInDirectory(adrDirectory, projectPath, {
+              includeContent: false,
+              includeTimeline: false,
+            });
+            const releases = await detectReleases(projectPath);
+            const preview = await previewNextRelease(projectPath, discovered.adrs, releases);
+            const queued = preview.pendingAdrs.some(a => a.filename === filename);
+            releaseSection = `## 🔗 Release Linkage
 
 - **Next release (predicted bump)**: ${preview.suggestedVersion}
 - **Queued for next release**: ${queued ? 'yes' : 'no (ADR not yet discoverable — check status is "accepted")'}
@@ -1032,25 +888,22 @@ To save this ADR to your project:
 
 Run \`release_tracking\` with \`next_release_preview\` for full details.
 `;
-            } catch {
-              releaseSection = '';
-            }
+          } catch {
+            releaseSection = '';
+          }
 
-            savedSection = `## ✅ File Saved
+          const savedSection = `## ✅ File Saved
 
 - **Saved to**: \`${writeResult.filePath}\`
 - **Size**: ${writeResult.metadata?.size ?? 0} bytes
 - **Knowledge graph**: ${indexed ? 'registered' : 'registration skipped (non-fatal)'}
 `;
-          }
-        } catch {
-          // Fallback to manual-instructions output — do not throw
-        }
-      }
 
-      return formatMCPResponse({
-        ...executionResult,
-        content: `# Generated ADR: ${decisionData.title}
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `# Generated ADR: ${decisionData.title}
 
 ## ADR Metadata
 - **ADR Number**: ${adrNumber}
@@ -1062,7 +915,7 @@ Run \`release_tracking\` with \`next_release_preview\` for full details.
 
 ## Generated ADR Content
 
-${executionResult.content}
+${adrContent}
 
 ${savedSection}
 
@@ -1070,18 +923,10 @@ ${releaseSection}
 
 ## Next Steps
 
-${
-  saved
-    ? `1. **Review the saved ADR** at \`${fullPath}\`
+1. **Review the saved ADR** at \`${fullPath}\`
 2. **Share with stakeholders** for review and approval
 3. **Plan implementation** of the architectural decision
-4. **Run \`release_tracking next_release_preview\`** to confirm the ADR is queued for the next release`
-    : `1. **Review the generated ADR** for accuracy and completeness
-2. **Save the file** using the instructions above
-3. **Update your ADR index** or catalog
-4. **Share with stakeholders** for review and approval
-5. **Plan implementation** of the architectural decision`
-}
+4. **Run \`release_tracking next_release_preview\`** to confirm the ADR is queued for the next release
 
 ## Quality Checklist
 
@@ -1092,47 +937,66 @@ ${
 - ✅ **Format** follows ${templateFormat.toUpperCase()} template standards
 - ✅ **Numbering** is sequential (${adrNumber})
 `,
-      });
-    } else {
-      // Fallback to prompt-only mode
-      const { ensureDirectoryCompat: ensureDirectory, writeFileCompat: writeFile } =
-        await import('../utils/file-system.js');
-      const ensureDirPrompt = await ensureDirectory(adrDirectory);
-      const writeFilePrompt = await writeFile(fullPath, '[ADR_CONTENT_PLACEHOLDER]');
+              },
+            ],
+          };
+        }
+      } catch {
+        // Fallback to manual-instructions output — do not throw
+      }
+    }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `# ADR Generation: ${decisionData.title}
+    // Manual-instructions output: autoSave disabled, or the write failed. No file I/O is
+    // performed here (the directory is NOT created), and nothing is registered.
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `# ADR Generation: ${decisionData.title}
 
-${result.instructions}
-
-## Suggested ADR Metadata
+## ADR Metadata
 - **ADR Number**: ${adrNumber}
 - **Filename**: ${filename}
 - **Full Path**: ${fullPath}
 - **Template Format**: ${templateFormat.toUpperCase()}
+- **Auto-saved**: ${saved ? 'yes' : 'no'}
 
-## Step 1: Create ADR Directory
-${ensureDirPrompt.prompt}
+## Generated ADR Content
 
-## Step 2: Generate ADR Content
+${adrContent}
 
-${result.generationPrompt}
+## File Creation Instructions
 
-## Step 3: Save ADR to File
+To save this ADR to your project:
 
-After generating the ADR content from Step 2, create the ADR file:
+1. **Create the ADR directory** (if it doesn't exist):
+   \`\`\`bash
+   mkdir -p ${adrDirectory}
+   \`\`\`
 
-${writeFilePrompt.prompt}
+2. **Save the ADR content** above to the file:
+   \`\`\`bash
+   cat > "${fullPath}" << 'EOF'
+   <paste the Generated ADR Content above>
+   EOF
+   \`\`\`
 
-**Important**: Replace \`[ADR_CONTENT_PLACEHOLDER]\` with the actual generated ADR content from Step 2.
+3. **Verify the file** was created successfully:
+   \`\`\`bash
+   ls -la "${fullPath}"
+   \`\`\`
+
+## Next Steps
+
+1. **Review the generated ADR** for accuracy and completeness
+2. **Save the file** using the instructions above
+3. **Update your ADR index** or catalog
+4. **Share with stakeholders** for review and approval
+5. **Plan implementation** of the architectural decision
 `,
-          },
-        ],
-      };
-    }
+        },
+      ],
+    };
   } catch (error) {
     throw new McpAdrError(
       `Failed to generate ADR: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/utils/adr-format.ts
+++ b/src/utils/adr-format.ts
@@ -221,25 +221,37 @@ function mapStatusToMadr(status: string | undefined): string {
 }
 
 /**
- * Convert a Nygard-style ADR into the ADR-022 canonical MADR shape.
- *
- * Idempotent: content already detected as `'madr'` is returned unchanged.
- *
- * `'custom'` content is converted best-effort — whatever Nygard-shaped sections can be
- * recovered are carried across, and any section with nothing to carry becomes an empty
- * placeholder heading. The result is always valid MADR (front matter + MADR headings).
+ * The fields a deterministic MADR emitter needs. A superset-friendly subset of
+ * `ExtractedAdrFields`: everything is optional except that a missing title falls back to
+ * `'ADR'` and a missing/unknown status maps to `'proposed'`.
  */
-export function convertNygardToMadr(content: string): string {
-  if (detectAdrFormat(content) === 'madr') {
-    return content;
-  }
+export interface MadrDocumentFields {
+  title?: string | undefined;
+  status?: string | undefined;
+  date?: string | undefined;
+  tags?: string[] | undefined;
+  context?: string | undefined;
+  decision?: string | undefined;
+  consequences?: string | undefined;
+}
 
-  const fields = extractAdrFields(content);
-
+/**
+ * Emit an ADR-022 canonical MADR document from already-extracted fields.
+ *
+ * This is the pure emission half shared by `convertNygardToMadr` (which feeds it the
+ * fields it recovered from a Nygard/custom document) and the deterministic ADR generator
+ * in `adr-suggestion-tool.ts` (which feeds it a decision's title/context/decision/
+ * consequences). The output is always valid MADR: `---` front matter (`status:`, optional
+ * `date:`/`tags:`) followed by `# <title>` and the canonical
+ * `## Context and Problem Statement` / `## Decision` / `## Consequences` /
+ * `## More Information` headings. Any section with nothing to carry becomes an empty
+ * placeholder heading.
+ */
+export function buildMadrDocument(fields: MadrDocumentFields): string {
   // Build the YAML front matter via js-yaml (block style, 2-space indent).
   const frontMatter: Record<string, unknown> = { status: mapStatusToMadr(fields.status) };
   if (fields.date) frontMatter['date'] = fields.date;
-  if (fields.tags.length > 0) frontMatter['tags'] = fields.tags;
+  if (fields.tags && fields.tags.length > 0) frontMatter['tags'] = fields.tags;
 
   const yamlBlock = yaml.dump(frontMatter, { indent: 2, lineWidth: -1 }).trimEnd();
 
@@ -276,4 +288,31 @@ export function convertNygardToMadr(content: string): string {
     .join('\n')
     .replace(/\n{3,}/g, '\n\n')
     .replace(/\s*$/, '\n');
+}
+
+/**
+ * Convert a Nygard-style ADR into the ADR-022 canonical MADR shape.
+ *
+ * Idempotent: content already detected as `'madr'` is returned unchanged.
+ *
+ * `'custom'` content is converted best-effort — whatever Nygard-shaped sections can be
+ * recovered are carried across, and any section with nothing to carry becomes an empty
+ * placeholder heading. The result is always valid MADR (front matter + MADR headings).
+ */
+export function convertNygardToMadr(content: string): string {
+  if (detectAdrFormat(content) === 'madr') {
+    return content;
+  }
+
+  const fields = extractAdrFields(content);
+
+  return buildMadrDocument({
+    title: fields.title,
+    status: fields.status,
+    date: fields.date,
+    tags: fields.tags,
+    context: fields.context,
+    decision: fields.decision,
+    consequences: fields.consequences,
+  });
 }

--- a/tests/tools/adr-suggestion-tool.test.ts
+++ b/tests/tools/adr-suggestion-tool.test.ts
@@ -11,16 +11,17 @@
 import { describe, expect, vi } from 'vitest';
 import { McpAdrError } from '../../src/types/index.js';
 
-// generateAdrFromDecision's prompt-only branch WRITES to disk
-// (adr-suggestion-tool.ts:1101 -> writeFileCompat(fullPath, '[ADR_CONTENT_PLACEHOLDER]')).
-// Tests that omit `adrDirectory` fall back to 'docs/adrs', so every full suite run
-// created docs/adrs/adr-0001-test-decision.md in THIS repository -- a 25-byte
-// placeholder that was then committed and mistaken for a leaked fixture (#1415).
-// It also broke scripts/check-adr-drift.sh on every run.
+// generateAdrFromDecision no longer writes a placeholder: after the #1647 CE-MCP
+// migration the auto-save path (autoSave=true) writes the REAL deterministic MADR
+// content, and the manual path (autoSave=false) performs no file I/O at all. The
+// #1415 hazard was a 25-byte '[ADR_CONTENT_PLACEHOLDER]' write into this repo's
+// docs/adrs on every suite run (via the old prompt-only branch).
 //
-// These tests assert on the returned text, never on the file, so stubbing the
-// writes costs no coverage. The underlying tool behaviour -- writing a
-// placeholder into a real ADR directory -- is a separate product question.
+// These generateAdrFromDecision tests assert on the returned text only, so they pass
+// autoSave:false to exercise the deterministic manual branch without touching disk.
+// The file-write behaviour is covered by tests/tools/adr-suggestion-auto-index.test.ts,
+// which runs against a fresh tmp directory. The file-system stub below remains as a
+// belt-and-braces guard against accidental writes to the real repo.
 vi.mock('../../src/utils/file-system.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../src/utils/file-system.js')>();
   return {
@@ -204,6 +205,7 @@ describe('ADR Suggestion Tool', () => {
 
         const result = await generateAdrFromDecision({
           decisionData,
+          autoSave: false,
         });
 
         expect(result).toBeDefined();
@@ -220,6 +222,7 @@ describe('ADR Suggestion Tool', () => {
 
         const result = await generateAdrFromDecision({
           decisionData,
+          autoSave: false,
         });
 
         // ADR-022 changed the default emitted format from Nygard to MADR.
@@ -237,6 +240,7 @@ describe('ADR Suggestion Tool', () => {
         const result = await generateAdrFromDecision({
           decisionData,
           templateFormat: 'madr',
+          autoSave: false,
         });
 
         expect(result.content[0].text).toContain('MADR');
@@ -259,6 +263,7 @@ describe('ADR Suggestion Tool', () => {
           templateFormat: 'custom',
           existingAdrs: ['Existing ADR'],
           adrDirectory: 'custom/dir',
+          autoSave: false,
         });
 
         expect(result).toBeDefined();
@@ -376,6 +381,7 @@ describe('ADR Suggestion Tool', () => {
 
         const result = await generateAdrFromDecision({
           decisionData,
+          autoSave: false,
         });
 
         expect(result.content[0].text).toContain('docs/adrs');


### PR DESCRIPTION
Closes #1647. The deferred half of the CE-MCP migration (#1629), now done on top of #1466's converter — the whole reason #1466 was sequenced first.

## What this does
Removes the `ai-executor` (OpenRouter) + `prompt-execution` reliance from `src/tools/adr-suggestion-tool.ts`, **without deleting the autoSave feature** the first (reverted) attempt lost.

- **`generateAdrFromDecision`**: content is now built **deterministically** via a new `buildMadrDocument(fields)` emitter in `src/utils/adr-format.ts` (the emission half factored out of `convertNygardToMadr`, which now delegates to it — byte-identical output, so `adr-format.ts` stays wired). No server-side LLM call.
- **Feature preserved**: autoSave file-write, `registerAdr` (knowledge-graph auto-registration), release-linkage preview, and the manual-`mkdir` branch — `tests/tools/adr-suggestion-auto-index.test.ts` (3 tests) pass **unchanged**.
- **Placeholder gone**: `autoSave=true` now writes the real deterministic MADR content, not `[ADR_CONTENT_PLACEHOLDER]`.
- **`suggestAdrs`** returns a deterministic CE-MCP directive.

## Guardrails that held
- The 3 auto-index tests are **in the acceptance bar** this time (the gap that broke attempt #1).
- No stray ADR files written into the repo during tests (five `generateAdrFromDecision` cases routed through the manual branch; autoSave=true still covered against a tmp dir).
- **Dead-code ratchet holds at 5** — `convertNygardToMadr` delegating to `buildMadrDocument` keeps the module wired.

## Scope
`ai-executor.ts` / `prompt-execution.ts` are **not** deleted — that's the later retirement-gated Batch 7. Governed by `.repo-governor/acceptance/1647.json` — engine **STOP_COMPLETE** (typecheck; both test files, incl. auto-index; no AI-layer import). 27 passed, 2 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oZ2FvkFuhDrGYHoWiu6Lv