### PR TITLE
ci(dependabot): group /docs React packages so they bump atomically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,6 +81,20 @@ updates:
       timezone: 'UTC'
     allow:
       - dependency-type: 'direct'
+    groups:
+      # Keep the React packages on the same major. Dependabot had split react and
+      # react-dom into separate PRs (#1620 / #1622); each fails `npm ci` on its own
+      # because react-dom@19 peer-requires react@19. Grouping makes the bump atomic.
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+        update-types:
+          - 'major'
+          - 'minor'
+          - 'patch'
     commit-message:
       prefix: 'deps(docs)'
       include: 'scope'


### PR DESCRIPTION
Fixes the `npm ci` ERESOLVE failure on the split React Dependabot PRs.

## Problem
`/docs` (Docusaurus) had `react` and `react-dom` at 18, and Dependabot opened **separate** PRs to bump them to 19 — #1620 (react) and #1622 (react-dom). Each fails `npm ci` on its own: `react-dom@19.2.8` peer-requires `react@^19.2.8`, but the matching react bump is in the other PR. They can only resolve together.

Root cause: the `/docs` npm ecosystem in `.github/dependabot.yml` had **no `groups`** (only `/` did), so Dependabot split the React packages.

## Fix
Add a `react` group under `/docs` (`react`, `react-dom`, `@types/react`, `@types/react-dom`) so future React bumps arrive as one resolvable PR.

- `/docs` stays on **React 18** (what Docusaurus 3.10.2 targets) — `main` is already consistent there.
- #1620 and #1622 are **closed** in favour of this.
- The main package uses no React and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oZ2FvkFuhDrGYHoWiu6Lv