### PR TITLE
fix(tools): stop check_ai_execution_status directing CE-MCP users to buy an API key

### DIFF
--- a/src/mcp-adr-analysis-server.ts
+++ b/src/mcp-adr-analysis-server.ts
@@ -803,13 +803,24 @@ If you're still seeing prompts instead of results, try:
 3. Verify network connectivity to OpenRouter.ai`
 }
 
-## Environment Variables Expected
+${
+  status.executionMode === 'ce-mcp'
+    ? `## Environment Variables (CE-MCP mode)
+No environment variables are required. CE-MCP mode is the default and works
+without any API keys or execution-mode flags.
+
+To switch to legacy OpenRouter execution instead, set:
+- **OPENROUTER_API_KEY**: Your OpenRouter API key
+- **EXECUTION_MODE**: \`full\`
+- **AI_MODEL**: AI model to use (optional, defaults to claude-3-sonnet)`
+    : `## Environment Variables Expected
 - **OPENROUTER_API_KEY**: Your OpenRouter API key
 - **EXECUTION_MODE**: Set to "full" for AI execution
 - **AI_MODEL**: AI model to use (optional, defaults to claude-3-sonnet)
 
 ## Testing
-After fixing the configuration, try calling \`suggest_adrs\` - it should return actual ADR suggestions instead of prompts.
+After fixing the configuration, try calling \`suggest_adrs\` - it should return actual ADR suggestions instead of prompts.`
+}
 `,
           },
         ],
@@ -823,10 +834,12 @@ After fixing the configuration, try calling \`suggest_adrs\` - it should return 
 
 **Error**: ${error instanceof Error ? error.message : String(error)}
 
-This diagnostic tool helps identify why tools return prompts instead of actual results.
+This diagnostic tool checks the execution configuration. The server defaults to
+CE-MCP mode, which requires no API key — so if you have not set any environment
+variables, this error is unlikely to be a configuration problem.
 
-## Manual Check
-Verify these environment variables are set in your MCP configuration:
+## Manual Check (legacy OpenRouter mode only)
+If you explicitly set EXECUTION_MODE=full, verify these environment variables:
 - OPENROUTER_API_KEY
 - EXECUTION_MODE=full
 - AI_MODEL (optional)

--- a/src/utils/prompt-execution.ts
+++ b/src/utils/prompt-execution.ts
@@ -367,10 +367,12 @@ export function getAIExecutionStatus(): {
     const isEnabled = isAIExecutionEnabled(config);
 
     let reason: string | undefined = undefined;
-    if (!hasApiKey) {
-      reason = 'Missing OPENROUTER_API_KEY environment variable';
-    } else if (config.executionMode !== 'full') {
-      reason = `EXECUTION_MODE is '${config.executionMode}', should be 'full'`;
+    if (config.executionMode !== 'ce-mcp') {
+      if (!hasApiKey) {
+        reason = 'Missing OPENROUTER_API_KEY environment variable';
+      } else if (config.executionMode !== 'full') {
+        reason = `EXECUTION_MODE is '${config.executionMode}', should be 'full'`;
+      }
     }
 
     return {

--- a/tests/tools/check-ai-execution-status.test.ts
+++ b/tests/tools/check-ai-execution-status.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for checkAIExecutionStatus honesty fix (#1630).
+ *
+ * CE-MCP is the default mode — the handler must not tell those users to buy an
+ * OpenRouter API key. Legacy (EXECUTION_MODE=full) users still see the old advice.
+ *
+ * The handler lives on McpAdrAnalysisServer (a heavyweight class), so we grab
+ * the unbound method from the prototype and call it with an empty context.
+ * The method only uses `this` nowhere — it does a dynamic import and formats
+ * the result.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetAIExecutionStatus = vi.fn();
+
+vi.mock('../../src/utils/prompt-execution.js', () => ({
+  getAIExecutionStatus: mockGetAIExecutionStatus,
+}));
+
+// Mock the heavy dependencies so the module can be loaded without side effects.
+vi.mock('../../src/utils/config.js', () => ({
+  loadConfig: () => ({
+    projectPath: '/tmp/test',
+    adrDirectory: 'docs/adrs',
+    logLevel: 'error',
+  }),
+}));
+
+vi.mock('../../src/utils/enhanced-logging.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/utils/knowledge-graph-manager.js', () => ({
+  KnowledgeGraphManager: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/utils/state-reinforcement-manager.js', () => ({
+  StateReinforcementManager: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/utils/conversation-memory-manager.js', () => ({
+  ConversationMemoryManager: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/utils/memory-entity-manager.js', () => ({
+  MemoryEntityManager: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/utils/root-manager.js', () => ({
+  RootManager: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/utils/server-context-generator.js', () => ({
+  ServerContextGenerator: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../src/utils/output-masking.js', () => ({
+  createMaskingConfig: () => ({ enabled: false }),
+}));
+
+/** Extract the text body from the handler's CallToolResult. */
+function textOf(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content.map(c => c.text).join('\n');
+}
+
+describe('check_ai_execution_status honesty (#1630)', () => {
+  let callHandler: (args?: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+  }>;
+
+  beforeEach(async () => {
+    mockGetAIExecutionStatus.mockReset();
+    const mod = await import('../../src/mcp-adr-analysis-server.js');
+    const method = mod.McpAdrAnalysisServer.prototype.checkAIExecutionStatus;
+    callHandler = (args = {}) => method.call({}, args);
+  });
+
+  describe('CE-MCP mode (default)', () => {
+    beforeEach(() => {
+      mockGetAIExecutionStatus.mockReturnValue({
+        isEnabled: false,
+        hasApiKey: false,
+        executionMode: 'ce-mcp',
+        model: 'anthropic/claude-3-sonnet',
+        reason: undefined,
+      });
+    });
+
+    it('says no API key is required', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('No API key is required');
+    });
+
+    it('says no environment variables are required', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('No environment variables are required');
+    });
+
+    it('does not instruct users to get an OpenRouter key', async () => {
+      const text = textOf(await callHandler());
+      expect(text).not.toContain('Get an OpenRouter API key');
+      expect(text).not.toContain('openrouter.ai/keys');
+    });
+
+    it('does not show legacy "Environment Variables Expected" heading', async () => {
+      const text = textOf(await callHandler());
+      expect(text).not.toContain('## Environment Variables Expected');
+    });
+
+    it('shows the CE-MCP environment variables section', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('## Environment Variables (CE-MCP mode)');
+    });
+
+    it('shows Running in CE-MCP mode', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('Running in CE-MCP mode');
+    });
+  });
+
+  describe('legacy mode without API key', () => {
+    beforeEach(() => {
+      mockGetAIExecutionStatus.mockReturnValue({
+        isEnabled: false,
+        hasApiKey: false,
+        executionMode: 'prompt-only',
+        model: 'anthropic/claude-3-sonnet',
+        reason: 'Missing OPENROUTER_API_KEY environment variable',
+      });
+    });
+
+    it('shows Issue Detected with the missing-key reason', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('Issue Detected');
+      expect(text).toContain('Missing OPENROUTER_API_KEY');
+    });
+
+    it('directs users to get an OpenRouter key', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('openrouter.ai/keys');
+    });
+
+    it('shows legacy Environment Variables Expected section', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('## Environment Variables Expected');
+    });
+  });
+
+  describe('legacy mode fully configured', () => {
+    beforeEach(() => {
+      mockGetAIExecutionStatus.mockReturnValue({
+        isEnabled: true,
+        hasApiKey: true,
+        executionMode: 'full',
+        model: 'anthropic/claude-3-sonnet',
+        reason: undefined,
+      });
+    });
+
+    it('shows Configuration Looks Good', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('Configuration Looks Good');
+    });
+
+    it('shows legacy Environment Variables Expected section', async () => {
+      const text = textOf(await callHandler());
+      expect(text).toContain('## Environment Variables Expected');
+    });
+  });
+});


### PR DESCRIPTION
## What and why

Fixes #1630 (CE-MCP Batch 0: honesty fixes).

`check_ai_execution_status` told every CE-MCP user to obtain an OpenRouter API key they do not need. The CE-MCP conditional (#1414) already handled the main status section, but two unconditional footer sections still referenced `OPENROUTER_API_KEY` as a required variable, and the error handler did the same.

### Changes

- **Environment Variables section** is now mode-aware: CE-MCP mode says "No environment variables are required" and lists OpenRouter vars only as an opt-in alternative. Legacy section preserved for `EXECUTION_MODE=full`.
- **Error handler** no longer directs CE-MCP users to set `OPENROUTER_API_KEY`. Explains the server defaults to CE-MCP mode.
- **`getAIExecutionStatus()`** no longer sets `reason: "Missing OPENROUTER_API_KEY"` when `executionMode === "ce-mcp"`, since the absence of a key is expected in that mode.

Also verified that the #1456 `hasCEMCPDirective` correction still holds: 12 true / 57 false, matching `CE_MCP_DIRECTIVE_TOOLS` exactly (4/4 drift-guard tests pass).

## How this was verified

- `npm run typecheck` — clean
- `npx vitest run tests/tools/ce-mcp-directives.test.ts` — 4/4 pass (directive claims match reality)
- `npx vitest run tests/tools/tool-dispatch.test.ts` — 74/74 pass
- `npx vitest run tests/utils/prompt-execution.test.ts` — 25/25 pass
- Full test suite via pre-push hook — all pass
- ESLint on both modified files — 0 errors (pre-existing warnings only)

- [x] `npm test` passes locally
- [x] `npm run typecheck` is clean

## Before you open this

- [x] Branch is not `main` — `fix/1630-check-ai-execution-status-honesty`
- [x] Commits follow conventional format: `fix(tools): ...`
- [x] Docs updated if behaviour changed — N/A (user-facing output only, no API docs)

Closes #1630

Made with [Cursor](https://cursor.com)