### PR TITLE
fix: add CE-MCP directive for generate_research_questions (#1632)

### DIFF
--- a/src/tools/ce-mcp-tools.ts
+++ b/src/tools/ce-mcp-tools.ts
@@ -1336,6 +1336,110 @@ export function createToolChainOrchestratorDirective(
 }
 
 // ============================================================================
+// CE-MCP Batch 3: Research-question directives (#1632)
+// ============================================================================
+
+/**
+ * Arguments for CE-MCP generate_research_questions
+ */
+export interface CEMCPGenerateResearchQuestionsArgs {
+  analysisType?: 'correlation' | 'relevance' | 'questions' | 'tracking' | 'comprehensive';
+  researchContext?: {
+    topic: string;
+    category: string;
+    scope: string;
+    objectives: string[];
+    constraints?: string[];
+    timeline?: string;
+  };
+  problems?: Array<{
+    id: string;
+    description: string;
+    category: string;
+    severity: string;
+    context: string;
+  }>;
+  projectPath?: string;
+}
+
+/**
+ * CE-MCP version of generate_research_questions
+ *
+ * Returns an orchestration directive for research question generation instead
+ * of calling OpenRouter. The host LLM generates research questions directly.
+ */
+export function createGenerateResearchQuestionsDirective(
+  args: CEMCPGenerateResearchQuestionsArgs
+): OrchestrationDirective {
+  const {
+    analysisType = 'comprehensive',
+    researchContext,
+    problems = [],
+    projectPath = '.',
+  } = args;
+
+  const topic = researchContext?.topic || 'general research';
+
+  const operations: SandboxOperation[] = [
+    {
+      op: 'loadKnowledge',
+      args: {
+        domain: 'research-methodology',
+        scope: 'question-generation',
+      },
+      store: 'researchKnowledge',
+    },
+    {
+      op: 'analyzeFiles',
+      args: {
+        patterns: ['docs/adrs/**/*.md', 'docs/research/**/*.md'],
+        maxFiles: 50,
+      },
+      store: 'existingResearch',
+    },
+    {
+      op: 'generateContext',
+      args: {
+        type: 'research-question-generation',
+        analysisType,
+        topic,
+        problemCount: problems.length,
+        projectPath,
+      },
+      inputs: ['researchKnowledge', 'existingResearch'],
+      store: 'questionContext',
+    },
+    {
+      op: 'composeResult',
+      inputs: ['researchKnowledge', 'existingResearch', 'questionContext'],
+      return: true,
+    },
+  ];
+
+  return {
+    type: 'orchestration_directive',
+    version: '1.0',
+    tool: 'generate_research_questions',
+    description: `Generate ${analysisType} research questions for: ${topic}`,
+    sandbox_operations: operations,
+    compose: {
+      sections: [
+        { source: 'existingResearch', key: 'priorResearch', transform: 'summarize' },
+        { source: 'questionContext', key: 'questions' },
+      ],
+      template: 'research_questions_report',
+      format: 'markdown',
+    },
+    metadata: {
+      estimated_tokens: 2500,
+      complexity: 'medium',
+      cacheable: true,
+      cache_key: `research-questions-${topic}`,
+    },
+  };
+}
+
+// ============================================================================
 // CE-MCP TOOL REGISTRY
 // ============================================================================
 
@@ -1359,6 +1463,8 @@ export function shouldUseCEMCPDirective(toolName: string, config: { mode: string
     'troubleshoot_guided_workflow',
     // Phase 5: OpenRouter Elimination
     'tool_chain_orchestrator',
+    // CE-MCP Batch 3: research-questions (#1632)
+    'generate_research_questions',
   ];
 
   return (
@@ -1387,6 +1493,7 @@ export const CE_MCP_DIRECTIVE_TOOLS: ReadonlySet<string> = new Set([
   'analyze_project_ecosystem',
   'deployment_readiness',
   'generate_adrs_from_prd',
+  'generate_research_questions',
   'generate_rules',
   'interactive_adr_planning',
   'mcp_planning',
@@ -1447,6 +1554,12 @@ export function getCEMCPDirective(
     case 'tool_chain_orchestrator':
       return createToolChainOrchestratorDirective(
         args as unknown as CEMCPToolChainOrchestratorArgs
+      );
+
+    // CE-MCP Batch 3: research-questions (#1632)
+    case 'generate_research_questions':
+      return createGenerateResearchQuestionsDirective(
+        args as unknown as CEMCPGenerateResearchQuestionsArgs
       );
 
     default:

--- a/src/tools/research-question-tool.ts
+++ b/src/tools/research-question-tool.ts
@@ -291,82 +291,14 @@ This relevance analysis provides:
           projectPath
         );
 
-        // Execute the research question generation with AI if enabled, otherwise return prompt
-        const { executeResearchPrompt, formatMCPResponse } =
-          await import('../utils/prompt-execution.js');
-        const executionResult = await executeResearchPrompt(
-          result.questionPrompt,
-          result.instructions,
-          {
-            temperature: 0.2, // Slightly higher for creativity in research questions
-            maxTokens: 6000,
-            systemPrompt: `You are a research specialist who generates comprehensive research questions and methodologies.
-Create detailed research plans that help teams investigate architectural decisions and technologies.
-Focus on practical research approaches that can be executed by development teams.
-Provide clear guidance on research methods, success criteria, and expected outcomes.
-IMPORTANT: Save the generated research questions to the docs/research directory as specified in the instructions.`,
-            responseFormat: 'text',
-          }
-        );
-
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - return actual research question generation results
-          return formatMCPResponse({
-            ...executionResult,
-            content: `# Context-Aware Research Question Generation Results
-
-## Research Context
-- **Topic**: ${effectiveResearchContext.topic}
-- **Category**: ${effectiveResearchContext.category}
-- **Scope**: ${effectiveResearchContext.scope}
-- **Timeline**: ${effectiveResearchContext.timeline}
-- **Project Path**: ${projectPath}
-
-## AI Research Question Generation Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the generated research questions:
-
-1. **Review Generated Questions**: Examine each research question for relevance and feasibility
-2. **Prioritize Research**: Order questions by importance and impact
-3. **Create Research Plan**: Develop timeline and methodology for each question
-4. **Assign Responsibilities**: Determine who will investigate each question
-5. **Track Progress**: Use the research tracking system to monitor progress
-
-## Research Excellence Features
-
-This generation provides:
-- **Comprehensive Coverage**: All aspects of research topic addressed
-- **Actionable Questions**: Questions that can be answered through research
-- **Context Awareness**: Questions tailored to project and architectural context
-- **Priority Guidance**: Clear prioritization for research execution
-- **Quality Standards**: Built-in quality assurance and validation
-- **Persistent Documentation**: Research questions saved for future reference and tracking
-
-## Follow-up Actions
-
-To track research progress:
-\`\`\`json
-{
-  "tool": "generate_research_questions",
-  "args": {
-    "analysisType": "tracking",
-    "researchQuestions": [questions from above]
-  }
-}
-\`\`\`
-`,
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# Context-Aware Research Question Generation with File Persistence
+        // CE-MCP: return prompt text for the host LLM. The directive path in
+        // mcp-adr-analysis-server.ts intercepts this tool before it reaches here
+        // when CE-MCP mode is active; this return serves legacy/prompt-only mode.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# Context-Aware Research Question Generation with File Persistence
 
 ${result.instructions}
 
@@ -383,10 +315,9 @@ The AI agent must save the generated research questions to the docs/research dir
 3. **Save to File**: Create a markdown file with all generated research questions and plans
 4. **Confirm Persistence**: Verify that the research questions file has been created successfully
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       case 'tracking': {

--- a/src/tools/tool-catalog.ts
+++ b/src/tools/tool-catalog.ts
@@ -649,7 +649,7 @@ TOOL_CATALOG.set('generate_research_questions', {
   category: 'research',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - question generation
+  hasCEMCPDirective: true, // CE-MCP Batch 3 (#1632): directive added
   relatedTools: ['perform_research', 'create_research_template'],
   keywords: ['research', 'questions', 'generate', 'gaps'],
   requiresAI: true,

--- a/tests/research-question-tool.test.ts
+++ b/tests/research-question-tool.test.ts
@@ -248,12 +248,7 @@ describe('Research Question Tool', () => {
 
     describe('questions analysis type', () => {
       test('should generate context-aware questions when relevant knowledge provided', async () => {
-        mockExecuteResearchPrompt.mockResolvedValue({
-          isAIGenerated: true,
-          content: 'Generated research questions content',
-        });
-
-        await generateResearchQuestions({
+        const result = await generateResearchQuestions({
           analysisType: 'questions',
           researchContext: sampleResearchContext,
           relevantKnowledge: sampleRelevantKnowledge,
@@ -265,8 +260,8 @@ describe('Research Question Tool', () => {
           sampleRelevantKnowledge,
           '/test/path'
         );
-        expect(mockExecuteResearchPrompt).toHaveBeenCalled();
-        expect(mockFormatMCPResponse).toHaveBeenCalled();
+        // CE-MCP: prompt-execution is no longer called; returns prompt text directly
+        expect(result.content[0].text).toContain('Context-Aware Research Question Generation');
       });
 
       test('should throw error when relevant knowledge missing for questions', async () => {
@@ -551,33 +546,19 @@ describe('Research Question Tool', () => {
         expect(typeof result.content[0].text).toBe('string');
       });
 
-      test('should return proper MCP response format for AI-generated questions', async () => {
-        mockExecuteResearchPrompt.mockResolvedValue({
-          isAIGenerated: true,
-          content: 'AI generated content',
-        });
-
-        mockFormatMCPResponse.mockReturnValue({
-          content: [
-            {
-              type: 'text',
-              text: 'Formatted AI response',
-            },
-          ],
-        });
-
-        await generateResearchQuestions({
+      test('should return prompt-only MCP response for questions', async () => {
+        // CE-MCP: the AI execution path has been removed; the function now
+        // returns prompt text directly for the host LLM to process.
+        const result = await generateResearchQuestions({
           analysisType: 'questions',
           researchContext: sampleResearchContext,
           relevantKnowledge: sampleRelevantKnowledge,
         });
 
-        expect(mockFormatMCPResponse).toHaveBeenCalledWith(
-          expect.objectContaining({
-            isAIGenerated: true,
-            content: expect.stringContaining('Context-Aware Research Question Generation Results'),
-          })
-        );
+        expect(result.content).toHaveLength(1);
+        expect(result.content[0].type).toBe('text');
+        expect(result.content[0].text).toContain('Context-Aware Research Question Generation');
+        expect(result.content[0].text).toContain('File Creation Instructions');
       });
     });
 


### PR DESCRIPTION
## Summary

Add CE-MCP orchestration directive for `generate_research_questions`, removing the direct OpenRouter/prompt-execution call from `research-question-tool.ts`.

## Changes

### `src/tools/ce-mcp-tools.ts`
- Added `createGenerateResearchQuestionsDirective()` — returns an `OrchestrationDirective` with research methodology sandbox ops
- Registered in `CE_MCP_DIRECTIVE_TOOLS` set
- Added case to `getCEMCPDirective()` switch
- Added to `shouldUseCEMCPDirective()` tool list

### `src/tools/research-question-tool.ts`
- Removed `executeResearchPrompt`/`formatMCPResponse` dynamic import from `generateResearchQuestions()`
- Function now returns prompt text directly in legacy/prompt-only mode
- File now has **zero** imports from `prompt-execution` or `ai-executor`

### `src/tools/tool-catalog.ts`
- Set `hasCEMCPDirective: true` for `generate_research_questions`

### `tests/research-question-tool.test.ts`
- Updated 2 tests to expect prompt-only return (no more AI execution assertions)

## Validation

- `npm run typecheck` ✅
- `ce-mcp-directives.test.ts` (4/4 passed) — drift guard confirms catalog/implementation alignment
- `research-question-tool.test.ts` (29/29 passed, 1 skipped)
- Zero imports from `prompt-execution` or `ai-executor` in `research-question-tool.ts`

Closes #1632

Made with [Cursor](https://cursor.com)