### PR TITLE
feat(ce-mcp): add validate_rules directive, remove prompt-execution from rule-generation (#1633)

### DIFF
--- a/src/tools/ce-mcp-tools.ts
+++ b/src/tools/ce-mcp-tools.ts
@@ -1514,6 +1514,94 @@ export function createGenerateContentMaskingDirective(
 }
 
 // ============================================================================
+// CE-MCP Batch 4: Rule-generation directives (#1633)
+// ============================================================================
+
+/**
+ * Arguments for CE-MCP validate_rules
+ */
+export interface CEMCPValidateRulesArgs {
+  filePath?: string;
+  fileContent?: string;
+  fileName?: string;
+  rules: Array<{
+    name: string;
+    description?: string;
+    pattern?: string;
+    severity?: string;
+  }>;
+  validationType?: 'full' | 'quick' | 'pattern-only';
+}
+
+/**
+ * CE-MCP version of validate_rules
+ *
+ * Returns an orchestration directive for rule validation instead of calling
+ * OpenRouter. The host LLM validates code against rules directly.
+ */
+export function createValidateRulesDirective(args: CEMCPValidateRulesArgs): OrchestrationDirective {
+  const { filePath, rules = [], validationType = 'full' } = args;
+
+  const target = filePath || 'provided content';
+
+  const operations: SandboxOperation[] = [
+    {
+      op: 'analyzeFiles',
+      args: {
+        patterns: filePath ? [filePath] : [],
+        maxFiles: 1,
+      },
+      store: 'codeContent',
+    },
+    {
+      op: 'loadKnowledge',
+      args: {
+        domain: 'architectural-rules',
+        scope: 'validation',
+      },
+      store: 'ruleKnowledge',
+    },
+    {
+      op: 'generateContext',
+      args: {
+        type: 'rule-validation',
+        validationType,
+        ruleCount: rules.length,
+        target,
+      },
+      inputs: ['codeContent', 'ruleKnowledge'],
+      store: 'validationResults',
+    },
+    {
+      op: 'composeResult',
+      inputs: ['codeContent', 'ruleKnowledge', 'validationResults'],
+      return: true,
+    },
+  ];
+
+  return {
+    type: 'orchestration_directive',
+    version: '1.0',
+    tool: 'validate_rules',
+    description: `Validate ${target} against ${rules.length} architectural rules (${validationType})`,
+    sandbox_operations: operations,
+    compose: {
+      sections: [
+        { source: 'codeContent', key: 'analyzedCode', transform: 'summarize' },
+        { source: 'validationResults', key: 'violations' },
+      ],
+      template: 'rule_validation_report',
+      format: 'markdown',
+    },
+    metadata: {
+      estimated_tokens: 2000,
+      complexity: 'medium',
+      cacheable: false,
+    },
+  };
+}
+
+// ============================================================================
 // CE-MCP Batch 3: Research-question directives (#1632)
 // ============================================================================
 
@@ -1646,6 +1734,8 @@ export function shouldUseCEMCPDirective(toolName: string, config: { mode: string
     'generate_content_masking',
     // CE-MCP Batch 3: research-questions (#1632)
     'generate_research_questions',
+    // CE-MCP Batch 4: rule-generation (#1633)
+    'validate_rules',
   ];
 
   return (
@@ -1677,6 +1767,7 @@ export const CE_MCP_DIRECTIVE_TOOLS: ReadonlySet<string> = new Set([
   'generate_adrs_from_prd',
   'generate_content_masking',
   'generate_research_questions',
+  'validate_rules',
   'generate_rules',
   'interactive_adr_planning',
   'mcp_planning',
@@ -1749,6 +1840,10 @@ export function getCEMCPDirective(
       return createGenerateContentMaskingDirective(
         args as unknown as CEMCPGenerateContentMaskingArgs
       );
+
+    // CE-MCP Batch 4: rule-generation (#1633)
+    case 'validate_rules':
+      return createValidateRulesDirective(args as unknown as CEMCPValidateRulesArgs);
 
     // CE-MCP Batch 3: research-questions (#1632)
     case 'generate_research_questions':

--- a/src/tools/rule-generation-tool.ts
+++ b/src/tools/rule-generation-tool.ts
@@ -76,97 +76,14 @@ export async function generateRules(args: {
         const result = await extractRulesFromAdrs(adrDirectory, existingRules as any, projectPath);
         enhancedPrompt = knowledgeContext + result.extractionPrompt;
 
-        // Execute the rule extraction with AI if enabled, otherwise return prompt
-        const { executePromptWithFallback, formatMCPResponse } =
-          await import('../utils/prompt-execution.js');
-        const executionResult = await executePromptWithFallback(
-          enhancedPrompt,
-          result.instructions,
-          {
-            temperature: 0.1,
-            maxTokens: 6000,
-            systemPrompt: `You are an expert software architect specializing in architectural rule extraction and governance.
-Analyze the provided ADRs to extract actionable architectural rules and governance policies.
-Leverage the provided architectural governance knowledge to create comprehensive, industry-standard rules.
-Focus on creating specific, measurable rules that can be validated automatically.
-Provide clear reasoning for each rule and practical implementation guidance.
-Consider compliance standards, governance frameworks, and architectural best practices.`,
-            responseFormat: 'text',
-          }
-        );
-
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - return actual rule extraction results
-          return formatMCPResponse({
-            ...executionResult,
-            content: `# ADR-Based Rule Generation Results (GKP Enhanced)
-
-## Enhancement Features
-- **Generated Knowledge Prompting**: ${knowledgeEnhancement ? '✅ Enabled' : '❌ Disabled'}
-- **Enhanced Mode**: ${enhancedMode ? '✅ Enabled' : '❌ Disabled'}
-- **Knowledge Domains**: Governance frameworks, software architecture, compliance standards
-
-## Analysis Information
-- **ADR Directory**: ${adrDirectory}
-- **Existing Rules**: ${existingRules?.length || 0} rules
-- **Output Format**: ${outputFormat.toUpperCase()}
-
-${
-  knowledgeContext
-    ? `## Applied Governance Knowledge
-
-${knowledgeContext}
-`
-    : ''
-}
-
-## AI Rule Extraction Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the extracted rules:
-
-1. **Review Generated Rules**: Examine each rule for accuracy and completeness
-2. **Save Rule Set**: Create ${outputFormat.toUpperCase()} files for the extracted rules
-3. **Implement Validation**: Set up automated rule checking in your CI/CD pipeline
-4. **Team Training**: Share rules with development team for adoption
-5. **Monitor Compliance**: Track rule adherence and adjust as needed
-
-## Integration Commands
-
-To validate code against these rules, use:
-\`\`\`json
-{
-  "tool": "validate_rules",
-  "args": {
-    "filePath": "path/to/code/file.js",
-    "rules": [extracted rules from above]
-  }
-}
-\`\`\`
-
-To create a machine-readable rule set:
-\`\`\`json
-{
-  "tool": "create_rule_set",
-  "args": {
-    "name": "ADR-Based Architectural Rules",
-    "adrRules": [extracted rules from above],
-    "outputFormat": "${outputFormat}"
-  }
-}
-\`\`\`
-`,
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# Rule Generation: ADR-Based Rules (GKP Enhanced)
+        // CE-MCP: return prompt text for the host LLM. The directive path in
+        // mcp-adr-analysis-server.ts intercepts this tool before it reaches here
+        // when CE-MCP mode is active; this return serves legacy/prompt-only mode.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# Rule Generation: ADR-Based Rules (GKP Enhanced)
 
 ## Enhancement Status
 - **Generated Knowledge Prompting**: ${knowledgeEnhancement ? '✅ Applied' : '❌ Disabled'}
@@ -195,10 +112,9 @@ ${enhancedPrompt}
 4. **Save rules** in ${outputFormat.toUpperCase()} format using the rule format utilities
 5. **Integrate with validation tools** for automated compliance checking
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       case 'patterns': {
@@ -314,98 +230,12 @@ ${enhancedPrompt}
         const result = await generateRulesFromPatterns(projectPath, existingRuleNames);
         enhancedPrompt = knowledgeContext + patternImplementationContext + result.generationPrompt;
 
-        // Execute the pattern-based rule generation with AI if enabled, otherwise return prompt
-        const { executePromptWithFallback, formatMCPResponse } =
-          await import('../utils/prompt-execution.js');
-        const executionResult = await executePromptWithFallback(
-          enhancedPrompt,
-          result.instructions,
-          {
-            temperature: 0.1,
-            maxTokens: 6000,
-            systemPrompt: `You are an expert software architect specializing in code pattern analysis and rule generation.
-Analyze the provided codebase to identify consistent patterns and generate actionable architectural rules.
-Leverage the provided design pattern and code quality knowledge to create comprehensive, industry-standard rules.
-Focus on creating rules that enforce consistency, quality, and maintainability based on observed patterns.
-Consider established design patterns, code quality metrics, and architectural best practices.
-Provide confidence scores and practical implementation guidance for each rule.`,
-            responseFormat: 'text',
-          }
-        );
-
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - return actual pattern-based rule generation results
-          return formatMCPResponse({
-            ...executionResult,
-            content: `# Pattern-Based Rule Generation Results (Enhanced with Smart Code Linking)
-
-## Enhancement Features
-- **Smart Code Linking**: ${patternImplementationContext ? '✅ Active' : '❌ No patterns found'}
-- **Generated Knowledge Prompting**: ${knowledgeEnhancement ? '✅ Enabled' : '❌ Disabled'}
-- **Enhanced Mode**: ${enhancedMode ? '✅ Enabled' : '❌ Disabled'}
-- **Knowledge Domains**: Design patterns, code quality, software architecture
-
-## Analysis Information
-- **Project Path**: ${projectPath}
-- **Existing Rules**: ${existingRules?.length || 0} rules
-- **Output Format**: ${outputFormat.toUpperCase()}
-
-${patternImplementationContext ? `${patternImplementationContext}` : ''}
-
-${
-  knowledgeContext
-    ? `## Applied Pattern Knowledge
-
-${knowledgeContext}
-`
-    : ''
-}
-
-## AI Pattern Analysis Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the pattern analysis:
-
-1. **Review Generated Rules**: Examine each rule for relevance and accuracy
-2. **Validate Patterns**: Confirm patterns are representative of desired practices
-3. **Implement High-Confidence Rules**: Start with rules that have high confidence scores
-4. **Combine with ADR Rules**: Merge with ADR-extracted rules for comprehensive coverage
-5. **Set Up Validation**: Implement automated checking for pattern-based rules
-
-## Pattern-Based Benefits
-
-These rules offer:
-- **Consistency Enforcement**: Based on actual project patterns
-- **Team Alignment**: Reflects current team practices
-- **Gradual Improvement**: Incremental quality improvements
-- **Automated Detection**: High automatability for validation tools
-
-## Integration Commands
-
-To create a comprehensive rule set combining patterns and ADRs:
-\`\`\`json
-{
-  "tool": "generate_rules",
-  "args": {
-    "source": "both",
-    "projectPath": "${projectPath}",
-    "adrDirectory": "${adrDirectory}",
-    "outputFormat": "${outputFormat}"
-  }
-}
-\`\`\`
-`,
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# Rule Generation: Pattern-Based Rules (Enhanced with Smart Code Linking)
+        // CE-MCP: return prompt text directly; directive intercepts in CE-MCP mode.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# Rule Generation: Pattern-Based Rules (Enhanced with Smart Code Linking)
 
 ## Enhancement Status
 - **Smart Code Linking**: ${patternImplementationContext ? '✅ Pattern implementations discovered' : '❌ No patterns found'}
@@ -419,178 +249,26 @@ ${
 `
     : ''
 }${
-                  knowledgeContext
-                    ? `## Governance Knowledge Context
+                knowledgeContext
+                  ? `## Governance Knowledge Context
 
 ${knowledgeContext}
 `
-                    : ''
-                }
+                  : ''
+              }
 
 ${result.instructions}
 
 ## Enhanced AI Analysis Prompt
 
 ${enhancedPrompt}
-
-## Next Steps
-
-1. **Submit the enhanced prompt** to an AI agent for comprehensive pattern analysis
-2. **Parse the JSON response** to get generated rules and pattern metrics
-3. **Review pattern-based rules** using the discovered implementation context
-4. **Combine with ADR-extracted rules** for comprehensive rule set
-5. **Implement validation** for high-confidence pattern rules
-
-## Pattern Implementation Benefits
-
-The Smart Code Linking enhancement provides:
-- **Real Examples**: Rules based on actual pattern implementations found in your codebase
-- **Context-Aware**: Better understanding of how patterns are actually used
-- **Higher Confidence**: Rules validated against existing code patterns
-- **Team Alignment**: Rules that reflect current team practices and implementations
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       case 'both': {
-        let comprehensiveKnowledgeContext = '';
-        let comprehensivePatternContext = '';
-
-        // Smart Code Linking - comprehensive pattern and ADR implementation discovery
-        try {
-          // Find all code and documentation files
-          const findResult = await findFiles(projectPath, [
-            '**/*.{ts,js,jsx,tsx,py,java,cs,go,rs,rb,php,swift,kt,scala,c,cpp}',
-            '**/*.{md,adoc,rst}',
-            '!**/node_modules/**',
-            '!**/dist/**',
-            '!**/build/**',
-            '!**/target/**',
-          ]);
-
-          if (findResult.files.length > 0) {
-            // Use Smart Code Linking to find comprehensive architectural patterns and ADR implementations
-            const comprehensiveContext = [
-              'architectural decisions',
-              'design patterns',
-              'architectural patterns',
-              'software architecture',
-              'architectural governance',
-              'code standards',
-              'best practices',
-              'quality attributes',
-              'security patterns',
-              'performance patterns',
-              'scalability patterns',
-              'maintainability',
-              'testability',
-              'deployment patterns',
-              'integration patterns',
-            ].join(' ');
-
-            const relatedCodeResult = await findRelatedCode(
-              'comprehensive-architecture-analysis',
-              comprehensiveContext,
-              projectPath,
-              {
-                useAI: true,
-                maxFiles: 30,
-                includeContent: false,
-              }
-            );
-
-            if (relatedCodeResult.relatedFiles.length > 0) {
-              // Categorize files by type for better analysis
-              const codeFiles = relatedCodeResult.relatedFiles.filter(f =>
-                f.extension?.match(
-                  /\.(ts|js|jsx|tsx|py|java|cs|go|rs|rb|php|swift|kt|scala|c|cpp)$/
-                )
-              );
-              const docFiles = relatedCodeResult.relatedFiles.filter(f =>
-                f.extension?.match(/\.(md|adoc|rst)$/)
-              );
-
-              comprehensivePatternContext = [
-                '',
-                '## 🔗 Comprehensive Architecture Discovery',
-                '',
-                `Found **${relatedCodeResult.relatedFiles.length}** files relevant to architectural rule generation:`,
-                '',
-                `### Code Implementation Files (${codeFiles.length})`,
-                ...codeFiles.slice(0, 12).map((file, index) => `${index + 1}. **${file.path}**`),
-                codeFiles.length > 12 ? `*Showing top 12 of ${codeFiles.length} code files*` : '',
-                '',
-                docFiles.length > 0
-                  ? [
-                      `### Documentation Files (${docFiles.length})`,
-                      ...docFiles
-                        .slice(0, 8)
-                        .map((file, index) => `${index + 1}. **${file.path}**`),
-                      docFiles.length > 8
-                        ? `*Showing top 8 of ${docFiles.length} documentation files*`
-                        : '',
-                      '',
-                    ].join('\n')
-                  : '',
-                `**Overall Analysis Confidence**: ${(relatedCodeResult.confidence * 100).toFixed(0)}%`,
-                `**Architectural Keywords**: ${relatedCodeResult.keywords?.slice(0, 12).join(', ') || 'N/A'}`,
-                '',
-                '## Technology Stack Analysis',
-                ...Object.entries(
-                  relatedCodeResult.relatedFiles.reduce(
-                    (acc, file) => {
-                      const ext = file.extension || 'unknown';
-                      acc[ext] = (acc[ext] || 0) + 1;
-                      return acc;
-                    },
-                    {} as Record<string, number>
-                  )
-                )
-                  .slice(0, 8)
-                  .map(([ext, count]) => `- **${ext.toUpperCase()}**: ${count} files`),
-                '',
-              ]
-                .filter(Boolean)
-                .join('\n');
-            }
-          }
-        } catch (error) {
-          console.warn('Smart Code Linking failed for comprehensive analysis:', error);
-        }
-
-        // Generate comprehensive domain knowledge if enabled
-        if (enhancedMode && knowledgeEnhancement) {
-          try {
-            const { generateArchitecturalKnowledge } =
-              await import('../utils/knowledge-generation.js');
-            const knowledgeResult = await generateArchitecturalKnowledge(
-              {
-                projectPath,
-                technologies: [],
-                patterns: [],
-                projectType: 'comprehensive-rule-generation',
-              },
-              {
-                domains: ['api-design', 'security-patterns', 'performance-optimization'],
-                depth: 'advanced',
-                cacheEnabled: true,
-              }
-            );
-
-            comprehensiveKnowledgeContext = `\n## Comprehensive Architectural Knowledge Enhancement\n\n${knowledgeResult.prompt}\n\n---\n`;
-          } catch (error) {
-            console.error(
-              '[WARNING] GKP knowledge generation failed for comprehensive analysis:',
-              error
-            );
-            comprehensiveKnowledgeContext =
-              '<!-- Comprehensive knowledge generation unavailable -->\n';
-          }
-        }
-
         const adrResult = await extractRulesFromAdrs(
           adrDirectory,
           existingRules as any,
@@ -599,147 +277,12 @@ The Smart Code Linking enhancement provides:
         const existingRuleNames = existingRules?.map(r => r.name);
         const patternResult = await generateRulesFromPatterns(projectPath, existingRuleNames);
 
-        // Create comprehensive prompt combining both ADR and pattern analysis with knowledge enhancement
-        const comprehensivePrompt = `${comprehensiveKnowledgeContext}${comprehensivePatternContext}
-# Comprehensive Architectural Rule Generation
-
-Generate a complete set of architectural rules by analyzing both ADRs and code patterns with Smart Code Linking context.
-
-## ADR-Based Rule Extraction
-
-${adrResult.extractionPrompt}
-
-## Pattern-Based Rule Generation
-
-${patternResult.generationPrompt}
-
-## Consolidation Requirements
-
-After extracting rules from both sources:
-
-1. **Merge and Deduplicate**: Combine rules from ADRs and patterns, removing duplicates
-2. **Resolve Conflicts**: When ADR rules conflict with pattern rules, prioritize ADR rules (explicit decisions)
-3. **Assign Priorities**: High priority for ADR rules, medium for consistent patterns, low for inconsistent patterns
-4. **Create Dependencies**: Identify relationships between rules and create dependency chains
-5. **Validate Completeness**: Ensure rules cover all major architectural concerns
-
-## Output Requirements
-
-Provide a unified rule set with:
-- **Rule Source**: Whether from ADR, pattern, or both
-- **Confidence Score**: 1-10 rating of rule validity
-- **Priority Level**: High/Medium/Low implementation priority
-- **Validation Pattern**: How to automatically check compliance
-- **Examples**: Valid and invalid code examples
-- **Dependencies**: Other rules this rule depends on
-`;
-
-        // Execute the comprehensive rule generation with AI if enabled, otherwise return prompt
-        const { executePromptWithFallback, formatMCPResponse } =
-          await import('../utils/prompt-execution.js');
-        const executionResult = await executePromptWithFallback(
-          comprehensivePrompt,
-          `${adrResult.instructions}\n\n${patternResult.instructions}`,
-          {
-            temperature: 0.1,
-            maxTokens: 8000,
-            systemPrompt: `You are an expert software architect specializing in comprehensive architectural rule generation.
-Analyze both ADRs and code patterns to create a unified, actionable rule set for the project.
-Leverage the provided comprehensive architectural knowledge including governance frameworks, design patterns, and compliance standards.
-Focus on creating rules that are specific, measurable, and can be validated automatically.
-Prioritize explicit architectural decisions (ADRs) over implicit patterns when conflicts arise.
-Consider industry best practices, compliance requirements, and established architectural principles.`,
-            responseFormat: 'text',
-          }
-        );
-
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - return actual comprehensive rule generation results
-          return formatMCPResponse({
-            ...executionResult,
-            content: `# Comprehensive Rule Generation Results (Enhanced with Smart Code Linking & GKP)
-
-## Enhancement Features
-- **Smart Code Linking**: ${comprehensivePatternContext ? '✅ Active' : '❌ No patterns found'}
-- **Generated Knowledge Prompting**: ${knowledgeEnhancement ? '✅ Enabled' : '❌ Disabled'}
-- **Enhanced Mode**: ${enhancedMode ? '✅ Enabled' : '❌ Disabled'}
-- **Knowledge Domains**: Governance frameworks, software architecture, design patterns, compliance standards, code quality
-- **Knowledge Depth**: Advanced (comprehensive coverage)
-
-## Analysis Information
-- **ADR Directory**: ${adrDirectory}
-- **Project Path**: ${projectPath}
-- **Existing Rules**: ${existingRules?.length || 0} rules
-- **Output Format**: ${outputFormat.toUpperCase()}
-
-${comprehensivePatternContext ? `${comprehensivePatternContext}` : ''}
-
-${
-  comprehensiveKnowledgeContext
-    ? `## Applied Comprehensive Knowledge
-
-${comprehensiveKnowledgeContext}
-`
-    : ''
-}
-
-## AI Comprehensive Analysis Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the comprehensive analysis:
-
-1. **Review Unified Rule Set**: Examine the consolidated rules for completeness
-2. **Validate Rule Priorities**: Confirm priority assignments align with project needs
-3. **Implement High-Priority Rules**: Start with rules marked as high priority
-4. **Set Up Automated Validation**: Configure CI/CD to check rule compliance
-5. **Create Rule Documentation**: Document rules for team reference and training
-
-## Comprehensive Benefits
-
-This approach provides:
-- **Complete Coverage**: Both explicit (ADR) and implicit (pattern) rules
-- **Balanced Approach**: Combines intentional decisions with observed practices
-- **High Confidence**: Rules backed by both documentation and code evidence
-- **Practical Implementation**: Rules that can be validated and enforced
-- **Team Alignment**: Rules that reflect both intentions and reality
-
-## Integration Commands
-
-To create the final rule set:
-\`\`\`json
-{
-  "tool": "create_rule_set",
-  "args": {
-    "name": "Comprehensive Architectural Rules",
-    "adrRules": [ADR rules from above],
-    "patternRules": [pattern rules from above],
-    "outputFormat": "${outputFormat}"
-  }
-}
-\`\`\`
-
-To validate code against the complete rule set:
-\`\`\`json
-{
-  "tool": "validate_rules",
-  "args": {
-    "filePath": "path/to/code/file.js",
-    "rules": [unified rules from above]
-  }
-}
-\`\`\`
-`,
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# Comprehensive Rule Generation
+        // CE-MCP: return prompt text directly; directive intercepts in CE-MCP mode.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# Comprehensive Rule Generation
 
 This comprehensive analysis will generate architectural rules from both ADRs and code patterns for complete coverage.
 
@@ -773,10 +316,9 @@ Submit the pattern analysis prompt to generate rules from code patterns
 - Prioritize based on confidence and impact
 - Create unified rule set with dependencies
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       default:
@@ -816,9 +358,7 @@ export async function validateRules(args: {
     fileName,
     rules,
     validationType = 'file',
-    reportFormat = 'detailed',
-    projectPath = process.cwd(),
-    findRelatedFiles = false,
+    reportFormat: _reportFormat = 'detailed',
   } = args;
 
   try {
@@ -830,62 +370,6 @@ export async function validateRules(args: {
 
     if (!rules || rules.length === 0) {
       throw new McpAdrError('Rules array is required and cannot be empty', 'INVALID_INPUT');
-    }
-
-    // Smart Code Linking - find related files for comprehensive validation context
-    let relatedFilesContext = '';
-    if (findRelatedFiles && filePath) {
-      try {
-        // Create context from the file being validated and the rules
-        const validationContext = [
-          `File being validated: ${filePath}`,
-          'Architectural rules validation',
-          ...rules.slice(0, 5).map(rule => `Rule: ${rule.name} - ${rule.description}`),
-        ].join('\n');
-
-        const relatedCodeResult = await findRelatedCode(
-          'rule-validation-context',
-          validationContext,
-          projectPath,
-          {
-            useAI: true,
-            maxFiles: 12,
-            includeContent: false,
-          }
-        );
-
-        if (relatedCodeResult.relatedFiles.length > 0) {
-          // Filter out the file being validated itself
-          const otherRelatedFiles = relatedCodeResult.relatedFiles.filter(
-            f => f.path !== filePath && !filePath.endsWith(f.path)
-          );
-
-          if (otherRelatedFiles.length > 0) {
-            relatedFilesContext = [
-              '',
-              '## 🔗 Related Files for Validation Context',
-              '',
-              `Found **${otherRelatedFiles.length}** related files that may need similar validation:`,
-              '',
-              ...otherRelatedFiles
-                .slice(0, 8)
-                .map((file, index) => `${index + 1}. **${file.path}**`),
-              otherRelatedFiles.length > 8
-                ? `*Showing top 8 of ${otherRelatedFiles.length} related files*`
-                : '',
-              '',
-              `**Context Confidence**: ${(relatedCodeResult.confidence * 100).toFixed(0)}%`,
-              '',
-              '💡 **Recommendation**: Consider validating these related files against the same rules for comprehensive compliance.',
-              '',
-            ]
-              .filter(Boolean)
-              .join('\n');
-          }
-        }
-      } catch (error) {
-        console.warn('Smart Code Linking failed for validation context:', error);
-      }
     }
 
     // Convert rules to ArchitecturalRule format
@@ -919,89 +403,12 @@ export async function validateRules(args: {
       };
     }
 
-    // Execute the rule validation with AI if enabled, otherwise return prompt
-    const { executePromptWithFallback, formatMCPResponse } =
-      await import('../utils/prompt-execution.js');
-    const executionResult = await executePromptWithFallback(
-      result.validationPrompt,
-      result.instructions,
-      {
-        temperature: 0.1,
-        maxTokens: 5000,
-        systemPrompt: `You are a senior software architect specializing in code quality and architectural compliance.
-Analyze the provided code against architectural rules to identify violations and provide improvement recommendations.
-Focus on providing specific, actionable feedback with clear explanations and fix suggestions.
-Prioritize violations by severity and impact on system architecture.`,
-        responseFormat: 'text',
-      }
-    );
-
-    if (executionResult.isAIGenerated) {
-      // AI execution successful - return actual rule validation results
-      return formatMCPResponse({
-        ...executionResult,
-        content: `# Code Validation Results (Enhanced with Smart Code Linking)
-
-## Validation Information
-- **File**: ${fileName || filePath || 'Content provided'}
-- **Validation Type**: ${validationType}
-- **Rules Applied**: ${rules.length} rules
-- **Report Format**: ${reportFormat}
-- **Smart Code Linking**: ${relatedFilesContext ? '✅ Related files discovered' : findRelatedFiles ? '❌ No related files found' : '⚪ Not requested'}
-
-${relatedFilesContext ? `${relatedFilesContext}` : ''}
-
-## AI Validation Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the validation results:
-
-1. **Address Critical Issues**: Fix any critical violations immediately
-2. **Plan Error Fixes**: Schedule error-level violations for next release
-3. **Batch Warning Fixes**: Group warning-level issues for efficient resolution
-4. **Track Compliance**: Monitor improvement trends over time
-5. **Update Rules**: Refine rules based on validation experience
-
-## Violation Severity Levels
-
-- **Critical**: Must be fixed immediately (security, breaking changes)
-- **Error**: Should be fixed before deployment (functionality issues)
-- **Warning**: Should be addressed in next iteration (quality issues)
-- **Info**: Consider for future improvements (style, optimization)
-
-## Compliance Tracking
-
-Use validation results to:
-- Track compliance trends over time
-- Identify problematic areas or patterns
-- Measure improvement after fixes
-- Generate compliance reports for stakeholders
-
-## Re-validation Command
-
-After applying fixes, re-validate with:
-\`\`\`json
-{
-  "tool": "validate_rules",
-  "args": {
-    "filePath": "${filePath || 'updated-file-path'}",
-    "rules": [same rules array],
-    "reportFormat": "${reportFormat}"
-  }
-}
-\`\`\`
-`,
-      });
-    } else {
-      // Fallback to prompt-only mode
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `# Code Validation Against Architectural Rules
+    // CE-MCP: return prompt text directly; directive intercepts in CE-MCP mode.
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `# Code Validation Against Architectural Rules
 
 ${result.instructions}
 
@@ -1017,10 +424,9 @@ ${result.validationPrompt}
 4. **Apply suggested fixes** to improve compliance
 5. **Re-validate** to confirm improvements
 `,
-          },
-        ],
-      };
-    }
+        },
+      ],
+    };
   } catch (error) {
     throw new McpAdrError(
       `Failed to validate rules: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/tools/tool-catalog.ts
+++ b/src/tools/tool-catalog.ts
@@ -1156,7 +1156,7 @@ TOOL_CATALOG.set('validate_rules', {
   category: 'rules',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - rule validation
+  hasCEMCPDirective: true, // CE-MCP Batch 4 (#1633): directive added
   relatedTools: ['generate_rules', 'create_rule_set'],
   keywords: ['rules', 'validate', 'check', 'violations'],
   requiresAI: false,


### PR DESCRIPTION
## CE-MCP Batch 4: Rule Generation Migration (#1633)

### Changes
- **`src/tools/ce-mcp-tools.ts`**: Added `createValidateRulesDirective()` with validation orchestration. Registered in `CE_MCP_DIRECTIVE_TOOLS`, `getCEMCPDirective` switch, and `shouldUseCEMCPDirective`.
- **`src/tools/rule-generation-tool.ts`**: Removed all 4 `executePromptWithFallback`/`formatMCPResponse` dynamic imports and AI execution branches from `generateRules` (extract-from-ADRs, pattern-based, comprehensive modes) and `validateRules`. Retained prompt-only return paths. Cleaned up dead code (comprehensive prompt template, Smart Code Linking validation context block, unused variables).
- **`src/tools/tool-catalog.ts`**: Set `hasCEMCPDirective: true` for `validate_rules`.

### Verification
- `npm run typecheck` passes
- All 27 tests in `rule-generation-tool.test.ts` + `ce-mcp-directives.test.ts` pass
- Zero `prompt-execution` or `ai-executor` imports remain in `rule-generation-tool.ts`

Closes #1633

Made with [Cursor](https://cursor.com)