### PR TITLE
feat(ce-mcp): add analyze_deployment_progress directive, remove prompt-execution from deployment/environment (#1634)

### DIFF
--- a/src/tools/ce-mcp-tools.ts
+++ b/src/tools/ce-mcp-tools.ts
@@ -1602,6 +1602,103 @@ export function createValidateRulesDirective(args: CEMCPValidateRulesArgs): Orch
 }
 
 // ============================================================================
+// CE-MCP Batch 5: Deployment/environment directives (#1634)
+// ============================================================================
+
+/**
+ * Arguments for CE-MCP analyze_deployment_progress
+ */
+export interface CEMCPAnalyzeDeploymentProgressArgs {
+  analysisType?: 'tasks' | 'cicd' | 'progress' | 'completion' | 'comprehensive';
+  adrDirectory?: string;
+  todoPath?: string;
+  cicdLogs?: string;
+  pipelineConfig?: string;
+  deploymentTasks?: Array<{
+    taskId: string;
+    taskName: string;
+    status?: string;
+    category?: string;
+  }>;
+  outcomeRules?: Array<{
+    ruleId: string;
+    description: string;
+    criteria: string;
+  }>;
+  actualOutcomes?: Record<string, unknown>;
+  cicdStatus?: Record<string, unknown>;
+  environmentStatus?: Record<string, unknown>;
+}
+
+/**
+ * CE-MCP version of analyze_deployment_progress
+ *
+ * Returns an orchestration directive for deployment analysis instead of calling
+ * OpenRouter. The host LLM performs the analysis directly.
+ */
+export function createAnalyzeDeploymentProgressDirective(
+  args: CEMCPAnalyzeDeploymentProgressArgs
+): OrchestrationDirective {
+  const { analysisType = 'tasks', adrDirectory, todoPath } = args;
+
+  const operations: SandboxOperation[] = [
+    {
+      op: 'analyzeFiles',
+      args: {
+        patterns: adrDirectory ? [`${adrDirectory}/**/*.md`] : ['docs/adr/**/*.md'],
+        maxFiles: 30,
+      },
+      store: 'adrContent',
+    },
+    {
+      op: 'loadKnowledge',
+      args: {
+        domain: 'deployment-analysis',
+        scope: analysisType,
+      },
+      store: 'deploymentKnowledge',
+    },
+    {
+      op: 'generateContext',
+      args: {
+        type: 'deployment-progress',
+        analysisType,
+        adrDirectory,
+        todoPath,
+      },
+      inputs: ['adrContent', 'deploymentKnowledge'],
+      store: 'analysisResults',
+    },
+    {
+      op: 'composeResult',
+      inputs: ['adrContent', 'deploymentKnowledge', 'analysisResults'],
+      return: true,
+    },
+  ];
+
+  return {
+    type: 'orchestration_directive',
+    version: '1.0',
+    tool: 'analyze_deployment_progress',
+    description: `Analyze deployment progress (${analysisType}) for ADRs in ${adrDirectory || 'default directory'}`,
+    sandbox_operations: operations,
+    compose: {
+      sections: [
+        { source: 'adrContent', key: 'architecturalDecisions', transform: 'summarize' },
+        { source: 'analysisResults', key: 'deploymentAnalysis' },
+      ],
+      template: 'deployment_progress_report',
+      format: 'markdown',
+    },
+    metadata: {
+      estimated_tokens: 3000,
+      complexity: 'medium',
+      cacheable: false,
+    },
+  };
+}
+
+// ============================================================================
 // CE-MCP Batch 3: Research-question directives (#1632)
 // ============================================================================
 
@@ -1736,6 +1833,8 @@ export function shouldUseCEMCPDirective(toolName: string, config: { mode: string
     'generate_research_questions',
     // CE-MCP Batch 4: rule-generation (#1633)
     'validate_rules',
+    // CE-MCP Batch 5: deployment/environment (#1634)
+    'analyze_deployment_progress',
   ];
 
   return (
@@ -1761,6 +1860,7 @@ export function shouldUseCEMCPDirective(toolName: string, config: { mode: string
  */
 export const CE_MCP_DIRECTIVE_TOOLS: ReadonlySet<string> = new Set([
   'analyze_content_security',
+  'analyze_deployment_progress',
   'analyze_environment',
   'analyze_project_ecosystem',
   'deployment_readiness',
@@ -1844,6 +1944,12 @@ export function getCEMCPDirective(
     // CE-MCP Batch 4: rule-generation (#1633)
     case 'validate_rules':
       return createValidateRulesDirective(args as unknown as CEMCPValidateRulesArgs);
+
+    // CE-MCP Batch 5: deployment/environment (#1634)
+    case 'analyze_deployment_progress':
+      return createAnalyzeDeploymentProgressDirective(
+        args as unknown as CEMCPAnalyzeDeploymentProgressArgs
+      );
 
     // CE-MCP Batch 3: research-questions (#1632)
     case 'generate_research_questions':

--- a/src/tools/deployment-analysis-tool.ts
+++ b/src/tools/deployment-analysis-tool.ts
@@ -65,123 +65,12 @@ export async function analyzeDeploymentProgress(args: {
       case 'tasks': {
         const result = await identifyDeploymentTasks(adrDirectory, todoPath);
 
-        // Execute the deployment task identification with AI if enabled, otherwise return prompt
-        const { executePromptWithFallback, formatMCPResponse } =
-          await import('../utils/prompt-execution.js');
-        const executionResult = await executePromptWithFallback(
-          result.identificationPrompt,
-          result.instructions,
-          {
-            temperature: 0.1,
-            maxTokens: 5000,
-            systemPrompt: `You are a DevOps expert specializing in deployment task identification and management.
-Analyze the provided ADRs and project context to identify comprehensive deployment tasks.
-Focus on creating actionable tasks with clear verification criteria and proper sequencing.
-Provide detailed risk assessment and practical implementation guidance.`,
-            responseFormat: 'text',
-          }
-        );
-
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - use tiered response for token efficiency
-          const { TieredResponseManager } = await import('../utils/tiered-response-manager.js');
-          const { MemoryEntityManager } = await import('../utils/memory-entity-manager.js');
-
-          const memoryManager = new MemoryEntityManager();
-          const tieredManager = new TieredResponseManager(memoryManager);
-          await tieredManager.initialize();
-
-          // Build full analysis content
-          const fullContent = `# Deployment Task Identification Results
-
-## Analysis Information
-- **ADR Directory**: ${adrDirectory}
-- **Todo Path**: ${todoPath || 'Not specified'}
-
-## AI Deployment Task Analysis Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the identified deployment tasks:
-
-1. **Review Task List**: Examine each deployment task for completeness and accuracy
-2. **Validate Dependencies**: Confirm task sequencing and dependency relationships
-3. **Assign Responsibilities**: Determine who will execute each deployment task
-4. **Create Timeline**: Establish deployment schedule with milestones
-5. **Set Up Monitoring**: Implement progress tracking and verification systems
-
-## Deployment Task Management
-
-Use the identified tasks to:
-- **Track Progress**: Monitor deployment progress across all categories
-- **Manage Dependencies**: Ensure proper task sequencing and coordination
-- **Assess Risks**: Identify and mitigate deployment risks
-- **Verify Completion**: Use verification criteria for completion validation
-- **Optimize Process**: Improve deployment efficiency and reliability
-
-## Follow-up Analysis
-
-For deeper deployment insights:
-- **CI/CD Analysis**: \`analyze_deployment_progress\` with \`analysisType: "cicd"\`
-- **Progress Tracking**: \`analyze_deployment_progress\` with \`analysisType: "progress"\`
-- **Completion Verification**: \`analyze_deployment_progress\` with \`analysisType: "completion"\`
-`;
-
-          // Define sections for expandable content
-          const sections = {
-            'Analysis Information': `## Analysis Information
-- **ADR Directory**: ${adrDirectory}
-- **Todo Path**: ${todoPath || 'Not specified'}`,
-            'Task Analysis': `## AI Deployment Task Analysis Results
-
-${executionResult.content}`,
-            'Next Steps': `## Next Steps
-
-Based on the identified deployment tasks:
-
-1. **Review Task List**: Examine each deployment task for completeness and accuracy
-2. **Validate Dependencies**: Confirm task sequencing and dependency relationships
-3. **Assign Responsibilities**: Determine who will execute each deployment task
-4. **Create Timeline**: Establish deployment schedule with milestones
-5. **Set Up Monitoring**: Implement progress tracking and verification systems`,
-            'Task Management': `## Deployment Task Management
-
-Use the identified tasks to:
-- **Track Progress**: Monitor deployment progress across all categories
-- **Manage Dependencies**: Ensure proper task sequencing and coordination
-- **Assess Risks**: Identify and mitigate deployment risks
-- **Verify Completion**: Use verification criteria for completion validation
-- **Optimize Process**: Improve deployment efficiency and reliability`,
-            'Follow-up Analysis': `## Follow-up Analysis
-
-For deeper deployment insights:
-- **CI/CD Analysis**: \`analyze_deployment_progress\` with \`analysisType: "cicd"\`
-- **Progress Tracking**: \`analyze_deployment_progress\` with \`analysisType: "progress"\`
-- **Completion Verification**: \`analyze_deployment_progress\` with \`analysisType: "completion"\``,
-          };
-
-          // Create tiered response
-          const tieredResponse = await tieredManager.createTieredResponse(
-            'analyze_deployment_progress',
-            fullContent,
-            sections,
-            { analysisType, adrDirectory, todoPath }
-          );
-
-          // Format and return tiered response
-          return formatMCPResponse({
-            ...executionResult,
-            content: tieredManager.formatTieredResponse(tieredResponse),
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# Deployment Task Identification
+        // CE-MCP: return prompt text directly; directive intercepts in CE-MCP mode.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# Deployment Task Identification
 
 ${result.instructions}
 
@@ -196,10 +85,9 @@ ${result.identificationPrompt}
 3. **Review task dependencies** and deployment sequencing
 4. **Use tasks** for deployment progress tracking and management
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       case 'cicd': {

--- a/src/tools/environment-analysis-tool.ts
+++ b/src/tools/environment-analysis-tool.ts
@@ -106,10 +106,7 @@ class EnvironmentMemoryManager {
           {
             timestamp: new Date().toISOString(),
             changeType: 'configuration' as
-              | 'configuration'
-              | 'infrastructure'
-              | 'security'
-              | 'dependencies',
+              'configuration' | 'infrastructure' | 'security' | 'dependencies',
             description: `Environment snapshot created for ${environmentType}`,
             impact: 'medium' as 'low' | 'medium' | 'high',
             author: 'environment-analysis-tool',
@@ -623,157 +620,12 @@ comprehensive project context including dependencies, frameworks, and architectu
         const result = await analyzeEnvironmentSpecs(projectPath);
         enhancedPrompt = liveEnvironmentData + knowledgeContext + result.analysisPrompt;
 
-        // Execute the environment analysis with AI if enabled, otherwise return prompt
-        const { executePromptWithFallback, formatMCPResponse } =
-          await import('../utils/prompt-execution.js');
-        const executionResult = await executePromptWithFallback(
-          enhancedPrompt,
-          result.instructions,
-          {
-            temperature: 0.1,
-            maxTokens: 5000,
-            systemPrompt: `You are a DevOps and infrastructure expert specializing in environment analysis.
-Analyze the provided project to understand its infrastructure requirements, deployment patterns, and environment configuration.
-Leverage the provided cloud infrastructure and DevOps knowledge to create comprehensive, industry-standard recommendations.
-Focus on providing actionable insights for environment optimization, security, scalability, and modern DevOps practices.
-Consider cloud-native patterns, containerization best practices, and deployment automation.
-Provide specific recommendations with implementation guidance.`,
-            responseFormat: 'text',
-          }
-        );
-
-        if (executionResult.isAIGenerated) {
-          // AI execution successful - return actual environment analysis results
-
-          // Store environment snapshot in memory if enabled
-          let memoryIntegrationInfo = '';
-          if (memoryManager) {
-            try {
-              // Parse AI result to extract configuration data
-              const analysisData = parseAnalysisResults(executionResult.content, result.actualData);
-
-              // Compare with previous snapshots
-              const comparison = await memoryManager.compareWithPreviousSnapshots(
-                analysisData,
-                environmentType
-              );
-
-              // Store new snapshot
-              const snapshotId = await memoryManager.storeEnvironmentSnapshot(
-                environmentType,
-                analysisData,
-                undefined, // No compliance data for specs analysis
-                projectPath
-              );
-
-              memoryIntegrationInfo = `
-## 🧠 Memory Integration Status
-
-- **Snapshot Stored**: ✅ Environment snapshot saved (ID: ${snapshotId.substring(0, 8)}...)
-- **Environment Type**: ${environmentType}
-- **Change Detection**: ${comparison.hasChanges ? '🔄 Changes detected' : '✅ No changes from previous snapshot'}
-- **Improvements**: ${comparison.improvements.length} detected
-- **Regressions**: ${comparison.regressions.length} detected
-
-${
-  comparison.changes.length > 0
-    ? `### Configuration Changes
-${comparison.changes.map(change => `- ${change}`).join('\n')}
-`
-    : ''
-}
-
-${
-  comparison.improvements.length > 0
-    ? `### Improvements Detected
-${comparison.improvements.map(improvement => `- ${improvement}`).join('\n')}
-`
-    : ''
-}
-
-${
-  comparison.regressions.length > 0
-    ? `### Regressions Detected  
-${comparison.regressions.map(regression => `- ⚠️ ${regression}`).join('\n')}
-`
-    : ''
-}
-`;
-            } catch (memoryError) {
-              memoryIntegrationInfo = `
-## 🧠 Memory Integration Status
-
-- **Status**: ⚠️ Memory storage failed - analysis continued without persistence
-- **Error**: ${memoryError instanceof Error ? memoryError.message : 'Unknown error'}
-`;
-            }
-          }
-
-          return formatMCPResponse({
-            ...executionResult,
-            content: `# Environment Specification Analysis Results (GKP Enhanced)
-
-## Enhancement Features
-- **Generated Knowledge Prompting**: ${knowledgeEnhancement ? '✅ Enabled' : '❌ Disabled'}
-- **Enhanced Mode**: ${enhancedMode ? '✅ Enabled' : '❌ Disabled'}
-- **Memory Integration**: ${enableMemoryIntegration ? '✅ Enabled' : '❌ Disabled'}
-- **Knowledge Domains**: Cloud infrastructure, DevOps practices, containerization, deployment patterns
-
-${memoryIntegrationInfo}
-
-## Analysis Information
-- **Project Path**: ${projectPath}
-- **ADR Directory**: ${adrDirectory}
-- **Analysis Type**: Environment Specifications
-- **Environment Type**: ${environmentType}
-
-${
-  knowledgeContext
-    ? `## Applied Infrastructure Knowledge
-
-${knowledgeContext}
-`
-    : ''
-}
-
-## AI Environment Analysis Results
-
-${executionResult.content}
-
-## Next Steps
-
-Based on the environment analysis:
-
-1. **Review Infrastructure Requirements**: Examine identified infrastructure needs
-2. **Optimize Resource Allocation**: Right-size compute and storage resources
-3. **Improve Security Posture**: Implement security best practices and compliance
-4. **Enhance Scalability**: Design for growth and load handling
-5. **Plan Implementation**: Create tasks for environment improvements
-
-## Environment Optimization Areas
-
-Use the analysis results to:
-- **Optimize Resource Allocation**: Right-size compute and storage resources
-- **Improve Security Posture**: Implement security best practices and compliance
-- **Enhance Scalability**: Design for growth and load handling
-- **Reduce Costs**: Optimize cloud service usage and resource efficiency
-- **Increase Reliability**: Implement redundancy and disaster recovery
-
-## Follow-up Analysis
-
-For deeper insights, consider running:
-- **Containerization Analysis**: \`analyze_environment\` with \`analysisType: "containerization"\`
-- **Compliance Assessment**: \`analyze_environment\` with \`analysisType: "compliance"\`
-- **Requirements Analysis**: \`analyze_environment\` with \`analysisType: "requirements"\`
-`,
-          });
-        } else {
-          // Fallback to prompt-only mode
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `# Environment Specification Analysis (GKP Enhanced)
+        // CE-MCP: return prompt text directly; directive intercepts in CE-MCP mode.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# Environment Specification Analysis (GKP Enhanced)
 
 ## Enhancement Status
 - **Generated Knowledge Prompting**: ${knowledgeEnhancement ? '✅ Applied' : '❌ Disabled'}
@@ -801,10 +653,9 @@ ${enhancedPrompt}
 3. **Review infrastructure requirements** and quality attributes
 4. **Use findings** for environment optimization and planning
 `,
-              },
-            ],
-          };
-        }
+            },
+          ],
+        };
       }
 
       case 'containerization': {
@@ -1255,143 +1106,6 @@ All analyses follow these principles:
   }
 }
 
-/**
- * Helper function to parse AI analysis results into structured configuration data
- */
-function parseAnalysisResults(aiContent: string, actualData?: any): any {
-  // Try to extract structured data from AI response
-  const configuration = {
-    infrastructure: actualData?.infrastructure || {},
-    containerization: {
-      detected:
-        aiContent.toLowerCase().includes('docker') || aiContent.toLowerCase().includes('container'),
-      technologies: extractTechnologies(aiContent, [
-        'docker',
-        'kubernetes',
-        'podman',
-        'containerd',
-      ]),
-    },
-    cloudServices: {
-      providers: extractTechnologies(aiContent, [
-        'aws',
-        'azure',
-        'gcp',
-        'google cloud',
-        'heroku',
-        'vercel',
-        'netlify',
-      ]),
-    },
-    security: {
-      httpsEnabled:
-        aiContent.toLowerCase().includes('https') || aiContent.toLowerCase().includes('ssl'),
-      securityMentioned: aiContent.toLowerCase().includes('security'),
-    },
-    monitoring: {
-      metrics:
-        aiContent.toLowerCase().includes('monitoring') ||
-        aiContent.toLowerCase().includes('metrics'),
-    },
-    deployment: {
-      automated:
-        aiContent.toLowerCase().includes('ci/cd') || aiContent.toLowerCase().includes('pipeline'),
-      loadBalancing:
-        aiContent.toLowerCase().includes('load balanc') || aiContent.toLowerCase().includes('lb'),
-    },
-    discoveredFiles: actualData?.discoveredFiles || [],
-    recommendations: extractRecommendations(aiContent),
-    qualityAttributes: extractQualityAttributes(aiContent),
-    riskAssessment: extractRiskAssessment(aiContent),
-  };
-
-  return configuration;
-}
-
-/**
- * Extract technology mentions from AI content
- */
-function extractTechnologies(content: string, technologies: string[]): string[] {
-  const found = [];
-  const lowerContent = content.toLowerCase();
-
-  for (const tech of technologies) {
-    if (lowerContent.includes(tech.toLowerCase())) {
-      found.push(tech);
-    }
-  }
-
-  return found;
-}
-
-/**
- * Extract recommendations from AI content
- */
-function extractRecommendations(content: string): string[] {
-  const recommendations = [];
-  const lines = content.split('\n');
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (
-      trimmed.startsWith('- ') &&
-      (trimmed.toLowerCase().includes('recommend') ||
-        trimmed.toLowerCase().includes('suggest') ||
-        trimmed.toLowerCase().includes('consider') ||
-        trimmed.toLowerCase().includes('should'))
-    ) {
-      recommendations.push(trimmed.substring(2)); // Remove '- ' prefix
-    }
-  }
-
-  return recommendations;
-}
-
-/**
- * Extract quality attributes from AI content
- */
-function extractQualityAttributes(content: string): any {
-  const attributes: any = {};
-  const lowerContent = content.toLowerCase();
-
-  if (lowerContent.includes('performance')) {
-    attributes.performance = 'mentioned';
-  }
-  if (lowerContent.includes('scalability') || lowerContent.includes('scalable')) {
-    attributes.scalability = 'mentioned';
-  }
-  if (lowerContent.includes('security')) {
-    attributes.security = 'mentioned';
-  }
-  if (lowerContent.includes('reliability') || lowerContent.includes('reliable')) {
-    attributes.reliability = 'mentioned';
-  }
-  if (lowerContent.includes('maintainability') || lowerContent.includes('maintainable')) {
-    attributes.maintainability = 'mentioned';
-  }
-
-  return attributes;
-}
-
-/**
- * Extract risk assessment from AI content
- */
-function extractRiskAssessment(content: string): any {
-  const risks = [];
-  const lowerContent = content.toLowerCase();
-
-  if (lowerContent.includes('risk') || lowerContent.includes('vulnerability')) {
-    risks.push('Security risks mentioned in analysis');
-  }
-  if (lowerContent.includes('single point of failure') || lowerContent.includes('spof')) {
-    risks.push('Single point of failure identified');
-  }
-  if (lowerContent.includes('outdated') || lowerContent.includes('deprecated')) {
-    risks.push('Outdated technologies or dependencies detected');
-  }
-
-  return {
-    risks,
-    riskLevel: risks.length > 2 ? 'high' : risks.length > 0 ? 'medium' : 'low',
-  };
-}
+// AI analysis helpers (parseAnalysisResults, extractTechnologies, etc.) removed
+// during CE-MCP migration — the AI memory integration path that consumed them
+// has been eliminated. See #1634.

--- a/src/tools/tool-catalog.ts
+++ b/src/tools/tool-catalog.ts
@@ -835,7 +835,7 @@ TOOL_CATALOG.set('analyze_deployment_progress', {
   category: 'deployment',
   complexity: 'moderate',
   tokenCost: { min: 1500, max: 3000 },
-  hasCEMCPDirective: false, // Phase 4.3: Moderate tool - deployment tracking
+  hasCEMCPDirective: true, // CE-MCP Batch 5 (#1634)
   relatedTools: ['deployment_readiness', 'generate_deployment_guidance'],
   keywords: ['deployment', 'progress', 'analyze', 'status'],
   requiresAI: false,

--- a/tests/tools/deployment-analysis-tool.test.ts
+++ b/tests/tools/deployment-analysis-tool.test.ts
@@ -42,7 +42,7 @@ const {
   calculateDeploymentProgress,
   verifyDeploymentCompletion,
 } = await import('../../src/utils/deployment-analysis.js');
-const { executePromptWithFallback, formatMCPResponse } =
+const { executePromptWithFallback, formatMCPResponse: _formatMCPResponse } =
   await import('../../src/utils/prompt-execution.js');
 
 describe('deployment-analysis-tool', () => {
@@ -52,36 +52,15 @@ describe('deployment-analysis-tool', () => {
     });
 
     describe('tasks analysis type', () => {
-      it('should identify deployment tasks with AI execution', async () => {
+      it('should identify deployment tasks with prompt-only return', async () => {
         const mockTaskResult = {
           identificationPrompt: 'Mock identification prompt for deployment tasks',
           instructions: 'Mock instructions for task identification',
         };
 
-        const mockExecutionResult = {
-          isAIGenerated: true,
-          content: 'AI-generated deployment task analysis results',
-          metadata: { confidence: 0.95 },
-        };
-
-        const mockFormattedResponse = {
-          content: [
-            {
-              type: 'text',
-              text: 'Formatted deployment task identification results',
-            },
-          ],
-        };
-
         (
           identifyDeploymentTasks as MockedFunction<typeof identifyDeploymentTasks>
         ).mockResolvedValue(mockTaskResult);
-        (
-          executePromptWithFallback as MockedFunction<typeof executePromptWithFallback>
-        ).mockResolvedValue(mockExecutionResult);
-        (formatMCPResponse as MockedFunction<typeof formatMCPResponse>).mockReturnValue(
-          mockFormattedResponse
-        );
 
         const result = await analyzeDeploymentProgress({
           analysisType: 'tasks',
@@ -90,17 +69,9 @@ describe('deployment-analysis-tool', () => {
         });
 
         expect(identifyDeploymentTasks).toHaveBeenCalledWith('docs/adrs', 'TODO.md');
-        expect(executePromptWithFallback).toHaveBeenCalledWith(
-          mockTaskResult.identificationPrompt,
-          mockTaskResult.instructions,
-          expect.objectContaining({
-            temperature: 0.1,
-            maxTokens: 5000,
-            responseFormat: 'text',
-          })
-        );
-        expect(formatMCPResponse).toHaveBeenCalled();
-        expect(result).toEqual(mockFormattedResponse);
+        expect(result.content[0].text).toContain('Deployment Task Identification');
+        expect(result.content[0].text).toContain(mockTaskResult.instructions);
+        expect(result.content[0].text).toContain(mockTaskResult.identificationPrompt);
       });
 
       it('should fallback to prompt-only mode when AI execution fails', async () => {


### PR DESCRIPTION
## CE-MCP Batch 5: Deployment/Environment Migration (#1634)

### Changes
- **`src/tools/ce-mcp-tools.ts`**: Added `createAnalyzeDeploymentProgressDirective()` with deployment analysis orchestration. Registered in `CE_MCP_DIRECTIVE_TOOLS`, `getCEMCPDirective` switch, and `shouldUseCEMCPDirective`.
- **`src/tools/deployment-analysis-tool.ts`**: Removed `executePromptWithFallback`/`formatMCPResponse` dynamic import and AI execution branch from `analyzeDeploymentProgress` (tasks mode). Retained prompt-only return path.
- **`src/tools/environment-analysis-tool.ts`**: Removed `executePromptWithFallback`/`formatMCPResponse` dynamic import and AI execution branch from `analyzeEnvironment` (specs mode). Removed dead AI parsing helpers (`parseAnalysisResults`, `extractTechnologies`, `extractRecommendations`, `extractQualityAttributes`, `extractRiskAssessment`).
- **`src/tools/tool-catalog.ts`**: Set `hasCEMCPDirective: true` for `analyze_deployment_progress`.
- **`tests/tools/deployment-analysis-tool.test.ts`**: Updated test to expect prompt-only return instead of AI execution call.

### Verification
- `npm run typecheck` passes
- All tests in `deployment-analysis-tool.test.ts`, `environment-analysis-tool.test.ts`, and `ce-mcp-directives.test.ts` pass
- Zero `prompt-execution` or `ai-executor` imports remain in either tool file

Closes #1634

Made with [Cursor](https://cursor.com)