### PR TITLE
docs: drift-led messaging overhaul — 'Your ADRs are lying to you' (#1686)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9+-blue)](https://www.typescriptlang.org/)
 [![Good First Issues](https://img.shields.io/github/issues/tosin2013/mcp-adr-analysis-server/good%20first%20issue?label=good%20first%20issues&color=7057ff)](https://github.com/tosin2013/mcp-adr-analysis-server/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
-> **Architectural analysis for intelligent development workflows.** 64 MCP tools for drift detection, content safety, and decision memory — powered by your host LLM via CE-MCP directives.
+> **Your ADRs are lying to you.** This MCP server catches it — live drift detection validates architectural decisions against your actual code. Plus content safety, decision memory, and 64 tools powered by your host LLM via CE-MCP.
 
 ## What is MCP?
 
-The **Model Context Protocol (MCP)** is an open standard that enables seamless integration between AI assistants and external tools and data sources. Think of it as a universal adapter that lets AI assistants like Claude, Cline, and Cursor connect to specialized analysis servers. This server enhances AI assistants with deep architectural analysis capabilities, enabling intelligent code generation, decision tracking, and development workflow automation.
+The **Model Context Protocol (MCP)** is an open standard that enables seamless integration between AI assistants and external tools and data sources. Think of it as a universal adapter that lets AI assistants like Claude, Cline, and Cursor connect to specialized servers. This server gives your AI assistant the ability to detect ADR drift against live code, mask sensitive content before it leaks, and remember architectural decisions across conversations.
 
 ## TL;DR
 
-**What:** MCP server providing architectural decision analysis, drift detection, content safety, and ADR management  
+**What:** MCP server that validates architectural decisions against your actual code — drift detection, content safety, and decision memory  
 **Who:** AI coding assistants (Claude, Cline, Cursor, Windsurf), enterprise architects, development teams  
-**Why:** Get immediate architectural insights — no external API key required in CE-MCP mode  
+**Why:** Catch stale ADRs before they cause production incidents — live validation against code evidence, no API key required  
 **How:** `npm install -g mcp-adr-analysis-server` → Add to your MCP client → Start analyzing
 
 **Key Features:** Tree-sitter AST analysis • Security content masking • Drift detection • CE-MCP orchestration directives • Deployment readiness validation

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ slug: /
 
 # MCP ADR Analysis Server
 
-**AI-powered architectural analysis for intelligent development workflows**
+**Your ADRs are lying to you.** This MCP server catches it.
 
-An MCP server that gives AI coding assistants — Claude, Cursor, Cline, Windsurf — deep architectural analysis capabilities. Unlike other tools, it returns **actual analysis results with confidence scoring**, not prompts to submit elsewhere.
+Live drift detection validates architectural decisions against your actual code — plus content safety, decision memory, and 64 tools powered by your host LLM via CE-MCP.
 
 ```bash
 npm install -g mcp-adr-analysis-server
@@ -17,19 +17,19 @@ npm install -g mcp-adr-analysis-server
 
 ## ✨ Core Capabilities
 
-🤖 **AI-Powered Analysis** — Immediate architectural insights via OpenRouter.ai integration
+🔄 **Drift Detection** — Validate ADR decisions against live code and infrastructure evidence. No other ADR tool does this.
 
-📋 **ADR Management** — Generate, suggest, and maintain Architectural Decision Records automatically
+🛡️ **Content Safety** — Detect and mask secrets, PII, and sensitive content automatically before it reaches the LLM.
 
-🔗 **Smart Code Linking** — AI-powered discovery of code files related to ADRs and decisions
+🧠 **Decision Memory** — Session & tool-usage tracking with keyword-scored retrieval across conversations.
 
-🏗️ **Technology Detection** — Identify any tech stack and architectural patterns in your codebase
+🏗️ **Technology Detection** — Identify any tech stack and architectural patterns in your codebase.
 
-🛡️ **Security & Compliance** — Detect and mask sensitive content with configurable patterns
+📋 **ADR Management** — Generate, suggest, and maintain Architectural Decision Records automatically.
 
-🚀 **Deployment Readiness** — Zero-tolerance test validation with hard blocking before deploy
+🔗 **Smart Code Linking** — Discovery of code files related to ADRs and decisions using tree-sitter AST analysis and ripgrep.
 
-🧪 **TDD Integration** — Two-phase Test-Driven Development with automated validation
+🚀 **Deployment Readiness** — Zero-tolerance test validation with hard blocking before deploy.
 
 ---
 
@@ -37,15 +37,15 @@ npm install -g mcp-adr-analysis-server
 
 ### 👨‍💻 AI Assistant Users
 
-Use with **Claude Desktop**, **Cline**, **Cursor**, or **Windsurf** to enhance your AI coding workflow with architectural intelligence. Ask questions in natural language and get real analysis results back.
+Use with **Claude Desktop**, **Cline**, **Cursor**, or **Windsurf** to enhance your AI coding workflow with architectural intelligence. No API key required — the server runs in CE-MCP mode by default, using your host LLM's existing context.
 
 ### 🏢 Enterprise Architects
 
-Track architectural decisions with ADRs, build knowledge graphs across repositories, enforce compliance standards, and generate governance reports — all integrated into your existing toolchain.
+Track architectural decisions with ADRs, detect drift before it causes production incidents, enforce content safety standards, and generate governance reports — all integrated into your existing toolchain.
 
 ### 🛠️ Development Teams
 
-Integrate into CI/CD pipelines for automated code quality checks, deployment readiness validation, security scanning, and test coverage enforcement with >80% thresholds.
+Integrate into CI/CD pipelines for automated ADR validation, deployment readiness checks, security scanning, and architectural compliance enforcement.
 
 ---
 
@@ -57,11 +57,9 @@ Integrate into CI/CD pipelines for automated code quality checks, deployment rea
 npm install -g mcp-adr-analysis-server
 ```
 
-### 2. Get an API Key (optional)
+### 2. Configure Your MCP Client
 
-Sign up at [OpenRouter.ai/keys](https://openrouter.ai/keys) for full AI-powered analysis. No API key? The server still works in **prompt-only mode** — you'll get prompts you can paste into any AI chat.
-
-### 3. Configure Your MCP Client
+No API key required. The server runs in **CE-MCP mode** by default — your host LLM executes the analysis using orchestration directives.
 
 ```json
 {
@@ -69,9 +67,7 @@ Sign up at [OpenRouter.ai/keys](https://openrouter.ai/keys) for full AI-powered 
     "adr-analysis": {
       "command": "mcp-adr-analysis-server",
       "env": {
-        "PROJECT_PATH": "/path/to/your/project",
-        "OPENROUTER_API_KEY": "your_key_here",
-        "EXECUTION_MODE": "full"
+        "PROJECT_PATH": "/path/to/your/project"
       }
     }
   }
@@ -94,7 +90,7 @@ Task-oriented recipes for specific goals: configuring clients, running analyses,
 
 ### [📖 Reference](./reference/api-reference.md)
 
-Technical details on all 23 MCP tools, environment variables, configuration options, and API specifications.
+Technical details on all 64 MCP tools, environment variables, configuration options, and the CE-MCP directive format.
 
 ### [💡 Explanation](./explanation/)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-adr-analysis-server",
   "mcpName": "io.github.tosin2013/mcp-adr-analysis-server",
   "version": "2.14.7",
-  "description": "MCP server for analyzing Architectural Decision Records and project architecture",
+  "description": "MCP server with live ADR drift detection, content safety, and decision memory — validates architectural decisions against your actual code",
   "main": "dist/src/index.js",
   "type": "module",
   "engines": {
@@ -96,8 +96,11 @@
     "mcp",
     "architectural-decision-records",
     "adr",
+    "drift-detection",
+    "content-safety",
+    "ce-mcp",
     "architecture",
-    "analysis",
+    "code-analysis",
     "typescript",
     "model-context-protocol"
   ],


### PR DESCRIPTION
## Summary

Rewrites all public-facing messaging to lead with the drift-detection differentiator. No competing ADR MCP server does live validation of architectural decisions against code evidence — this is the hook.

### New tagline

> **Your ADRs are lying to you.** This MCP server catches it — live drift detection validates architectural decisions against your actual code.

### Surfaces updated

| Surface | Change |
|---------|--------|
| **README.md tagline** | Generic 'architectural analysis' → 'Your ADRs are lying to you' |
| **README.md TL;DR** | 'Get immediate insights' → 'Catch stale ADRs before they cause production incidents' |
| **package.json description** | Generic → drift detection, content safety, decision memory |
| **package.json keywords** | Added: drift-detection, content-safety, ce-mcp, code-analysis |
| **docs/index.md** | Full rewrite: drift-first, CE-MCP default, removed OpenRouter, fixed tool count (64) |
| **GitHub repo description** | Updated via API ✅ |
| **GitHub topics** | Added: drift-detection, content-safety, ce-mcp, code-analysis, mcp ✅ |

### Issue triage (also done in this work)

- Created [milestone 7: Messaging and discovery](https://github.com/tosin2013/mcp-adr-analysis-server/milestone/7)
- Closed #1059 (stale: ai-executor deleted, Jest removed)
- Assigned 6 unmilestoned issues to v3.0/v3.1
- Moved #759, #756, #750, #1676 to Messaging and discovery milestone

Closes #1686

Made with [Cursor](https://cursor.com)