### PR TITLE
fix(#1648): unskip + rewrite validateAdr tests for deterministic path

### DIFF
--- a/.repo-governor/acceptance/1648.json
+++ b/.repo-governor/acceptance/1648.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "Unskip + rewrite the 5 skipped tests in adr-validation-tool.test.ts for the deterministic path. All tests must pass, no it.skip placeholders remain, companion summary tests still green.",
+  "authority_id": "1648",
+  "criteria": [
+    { "check": "command_exit", "target": "npx vitest run tests/tools/adr-validation-tool.test.ts" },
+    {
+      "check": "command_exit",
+      "target": "npx vitest run tests/tools/adr-validation-summary.test.ts"
+    },
+    {
+      "check": "command_exit",
+      "target": "bash -c '! grep -q it.skip tests/tools/adr-validation-tool.test.ts'"
+    }
+  ]
+}

--- a/tests/tools/adr-validation-tool.test.ts
+++ b/tests/tools/adr-validation-tool.test.ts
@@ -8,12 +8,10 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Use vi.hoisted to ensure mock constructors are available before vi.mock is hoisted
-const { MockResearchOrchestrator, mockAnswerResearchQuestion } = vi.hoisted(
-  () => ({
-    MockResearchOrchestrator: vi.fn(),
-    mockAnswerResearchQuestion: vi.fn(),
-  })
-);
+const { MockResearchOrchestrator, mockAnswerResearchQuestion } = vi.hoisted(() => ({
+  MockResearchOrchestrator: vi.fn(),
+  mockAnswerResearchQuestion: vi.fn(),
+}));
 
 vi.mock('../../src/utils/research-orchestrator.js', () => ({
   __esModule: true,
@@ -46,20 +44,6 @@ describe('ADR Validation Tool', () => {
       metadata: { filesAnalyzed: 0, duration: 100, sourcesQueried: [] },
       needsWebSearch: false,
     });
-
-    // Set up default research orchestrator mock
-    MockResearchOrchestrator.mockImplementation(
-      () =>
-        ({
-          answerResearchQuestion: vi.fn().mockResolvedValue({
-            answer: 'Default research answer',
-            confidence: 0.8,
-            sources: [],
-            metadata: { filesAnalyzed: 0, duration: 100, sourcesQueried: [] },
-            needsWebSearch: false,
-          }),
-        }) as any
-    );
   });
 
   afterEach(async () => {
@@ -72,16 +56,14 @@ describe('ADR Validation Tool', () => {
   });
 
   describe('validateAdr', () => {
-    // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
-    // See issue #308 for ESM-compatible mocking improvements
-    it.skip('should validate a valid ADR successfully', async () => {
-      // Create actual ADR file
+    it('should validate a valid ADR successfully', async () => {
       const adrContent = `# Use Kubernetes for Container Orchestration
 
 ## Context
 We need a container orchestration platform.
 
 ## Decision
+
 We will use Kubernetes for container orchestration.
 
 ## Consequences
@@ -92,143 +74,138 @@ We will use Kubernetes for container orchestration.
       const adrPath = path.join(tempAdrDir, 'adr-001-kubernetes.md');
       await fs.writeFile(adrPath, adrContent, 'utf-8');
 
-      // Mock research orchestrator
-      MockResearchOrchestrator.mockImplementation(
-        () =>
-          ({
-            answerResearchQuestion: vi.fn().mockResolvedValue({
-              answer:
-                'Kubernetes is deployed and running. Found kubectl config and deployment manifests.',
-              confidence: 0.9,
-              sources: [
-                { type: 'project_files', found: true, confidence: 0.8, data: {} },
-                { type: 'environment', found: true, confidence: 0.95, data: {} },
-              ],
-              metadata: {
-                filesAnalyzed: 5,
-                duration: 200,
-                sourcesQueried: ['project_files', 'environment'],
-              },
-              needsWebSearch: false,
-            }),
-          }) as any
-      );
+      mockAnswerResearchQuestion.mockResolvedValue({
+        answer:
+          'Kubernetes is deployed and running. Found kubectl config and deployment manifests.',
+        confidence: 0.9,
+        sources: [
+          {
+            type: 'project_files',
+            found: true,
+            confidence: 0.8,
+            data: {},
+            timestamp: new Date().toISOString(),
+          },
+          {
+            type: 'environment',
+            found: true,
+            confidence: 0.95,
+            data: {},
+            timestamp: new Date().toISOString(),
+          },
+        ],
+        metadata: {
+          filesAnalyzed: 5,
+          duration: 200,
+          sourcesQueried: ['project_files', 'environment'],
+        },
+        needsWebSearch: false,
+      });
 
       const result = await validateAdr({
         adrPath: 'docs/adrs/adr-001-kubernetes.md',
         projectPath: tempDir,
       });
 
-      expect(result.content).toBeDefined();
-      expect(result.content[0].text).toContain('✅ Valid');
+      const text = result.content[0].text;
+      expect(text).toContain('# ADR Validation Report');
+      expect(text).toContain('✅ Valid');
+      expect(text).toContain('**Confidence**: 90.0%');
+      expect(text).toContain('Deterministic (rule-based over research evidence)');
+      expect(text).toContain('No issues found');
+      expect(text).toContain('project_files');
+      expect(text).toContain('Environment Check**: ✅ Completed');
     });
 
-    // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
-    // See issue #308 for ESM-compatible mocking improvements
-    it.skip('should detect ADR drift when infrastructure differs', async () => {
+    it('should flag ADR with missing Decision section as Needs Review', async () => {
       const adrContent = `# Use Docker Swarm for Container Orchestration
 
-## Decision
-We will use Docker Swarm for container orchestration.
+## Context
+We evaluated several container orchestration platforms.
+
+## Consequences
+- Requires team training
 `;
 
       const adrPath = path.join(tempAdrDir, 'adr-001-docker-swarm.md');
       await fs.writeFile(adrPath, adrContent, 'utf-8');
-
-      MockResearchOrchestrator.mockImplementation(
-        () =>
-          ({
-            answerResearchQuestion: vi.fn().mockResolvedValue({
-              answer: 'Found Kubernetes cluster running, no Docker Swarm detected.',
-              confidence: 0.85,
-              sources: [{ type: 'environment', found: true, confidence: 0.9, data: {} }],
-              metadata: { filesAnalyzed: 3, duration: 150, sourcesQueried: ['environment'] },
-              needsWebSearch: false,
-            }),
-          }) as any
-      );
 
       const result = await validateAdr({
         adrPath: 'docs/adrs/adr-001-docker-swarm.md',
         projectPath: tempDir,
       });
 
-      // Should contain AI-analyzed drift findings (case-insensitive check)
-      expect(result.content[0].text.toLowerCase()).toContain('drift');
+      const text = result.content[0].text;
+      expect(text).toContain('⚠️ Needs Review');
+      expect(text).toContain('MISSING_EVIDENCE');
+      expect(text).toContain('critical');
+      expect(text).toContain('ADR records no decision');
+      expect(text).toContain('Review Findings');
+      expect(text).not.toContain('No issues found');
     });
 
-    // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
-    // See issue #308 for ESM-compatible mocking improvements
-    it.skip('should handle missing evidence gracefully', async () => {
+    it('should handle missing evidence gracefully', async () => {
       const adrContent = `# Use Redis for Caching
 
 ## Decision
+
 We will use Redis for caching.
 `;
 
       const adrPath = path.join(tempAdrDir, 'adr-002-redis.md');
       await fs.writeFile(adrPath, adrContent, 'utf-8');
 
-      MockResearchOrchestrator.mockImplementation(
-        () =>
-          ({
-            answerResearchQuestion: vi.fn().mockResolvedValue({
-              answer: 'No evidence of Redis found in project files or environment.',
-              confidence: 0.3,
-              sources: [{ type: 'project_files', found: false, confidence: 0.2, data: {} }],
-              metadata: { filesAnalyzed: 2, duration: 100, sourcesQueried: ['project_files'] },
-              needsWebSearch: true,
-            }),
-          }) as any
-      );
+      mockAnswerResearchQuestion.mockResolvedValue({
+        answer: 'No evidence of Redis found in project files or environment.',
+        confidence: 0.3,
+        sources: [
+          {
+            type: 'project_files',
+            found: false,
+            confidence: 0.2,
+            data: {},
+            timestamp: new Date().toISOString(),
+          },
+        ],
+        metadata: { filesAnalyzed: 2, duration: 100, sourcesQueried: ['project_files'] },
+        needsWebSearch: true,
+      });
 
       const result = await validateAdr({
         adrPath: 'docs/adrs/adr-002-redis.md',
         projectPath: tempDir,
       });
 
-      // Should indicate missing evidence or web search needed
-      expect(
-        result.content[0].text.includes('missing_evidence') ||
-          result.content[0].text.includes('Needs Web Search') ||
-          result.content[0].text.includes('Not found')
-      ).toBe(true);
+      const text = result.content[0].text;
+      expect(text).toContain('✅ Valid');
+      expect(text).toContain('**Confidence**: 30.0%');
+      expect(text).toContain('MISSING_EVIDENCE');
+      expect(text).toContain('Low confidence in research findings');
+      expect(text).toContain('Additional research may be needed');
+      expect(text).toContain('⚠️ Yes');
+      expect(text).toContain('❌ Not found');
     });
 
-    // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
-    // See issue #308 for ESM-compatible mocking improvements
     it('should work without AI executor (rule-based fallback)', async () => {
       const adrContent = `# Use PostgreSQL
 
 ## Decision
+
 We will use PostgreSQL as our primary database.
 `;
 
       const adrPath = path.join(tempAdrDir, 'adr-003-postgresql.md');
       await fs.writeFile(adrPath, adrContent, 'utf-8');
 
-      MockResearchOrchestrator.mockImplementation(
-        () =>
-          ({
-            answerResearchQuestion: vi.fn().mockResolvedValue({
-              answer: 'Found PostgreSQL in docker-compose.yml and connection strings in config.',
-              confidence: 0.8,
-              sources: [{ type: 'project_files', found: true, confidence: 0.8, data: {} }],
-              metadata: { filesAnalyzed: 4, duration: 120, sourcesQueried: ['project_files'] },
-              needsWebSearch: false,
-            }),
-          }) as any
-      );
-
       const result = await validateAdr({
         adrPath: 'docs/adrs/adr-003-postgresql.md',
         projectPath: tempDir,
       });
 
-      expect(result.content).toBeDefined();
-      // Deterministic path (ADR-021 Option B): no AI executor, rule-based over research.
-      expect(result.content[0].text).toContain('# ADR Validation Report');
-      expect(result.content[0].text).toContain('Deterministic (rule-based over research evidence)');
+      const text = result.content[0].text;
+      expect(text).toContain('# ADR Validation Report');
+      expect(text).toContain('✅ Valid');
+      expect(text).toContain('Deterministic (rule-based over research evidence)');
     });
 
     it('should handle file read errors', async () => {
@@ -243,18 +220,17 @@ We will use PostgreSQL as our primary database.
   });
 
   describe('validateAllAdrs', () => {
-    // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
-    // See issue #308 for ESM-compatible mocking improvements
-    it.skip('should validate multiple ADRs', async () => {
-      // Create multiple ADR files
+    it('should validate multiple ADRs', async () => {
       const adr1Content = `# Test ADR 1
 
 ## Decision
+
 Test decision 1
 `;
       const adr2Content = `# Test ADR 2
 
 ## Decision
+
 Test decision 2
 `;
       const readmeContent = `# README\n\nThis should be filtered out.`;
@@ -263,54 +239,46 @@ Test decision 2
       await fs.writeFile(path.join(tempAdrDir, 'adr-002-redis.md'), adr2Content, 'utf-8');
       await fs.writeFile(path.join(tempAdrDir, 'README.md'), readmeContent, 'utf-8');
 
-      MockResearchOrchestrator.mockImplementation(
-        () =>
-          ({
-            answerResearchQuestion: vi.fn().mockResolvedValue({
-              answer: 'Test answer',
-              confidence: 0.8,
-              sources: [],
-              metadata: { filesAnalyzed: 1, duration: 100, sourcesQueried: [] },
-              needsWebSearch: false,
-            }),
-          }) as any
-      );
+      const result = await validateAllAdrs({
+        projectPath: tempDir,
+        adrDirectory: 'docs/adrs',
+      });
+
+      const text = result.content[0].text;
+      expect(text).toContain('**Total ADRs Validated**: 2');
+      expect(text).toContain('**Valid ADRs**: 2 (100.0%)');
+      expect(text).toContain('**Invalid/Drifted ADRs**: 0');
+      expect(text).not.toContain('README.md');
+    });
+
+    it('should generate validation summary', async () => {
+      const adrContent = `# Test ADR
+
+## Decision
+
+Test decision content
+`;
+      await fs.writeFile(path.join(tempAdrDir, 'adr-001-test.md'), adrContent, 'utf-8');
+
+      mockAnswerResearchQuestion.mockResolvedValue({
+        answer: 'Test',
+        confidence: 0.9,
+        sources: [],
+        metadata: { filesAnalyzed: 1, duration: 50, sourcesQueried: [] },
+        needsWebSearch: false,
+      });
 
       const result = await validateAllAdrs({
         projectPath: tempDir,
         adrDirectory: 'docs/adrs',
       });
 
-      expect(result.content[0].text).toContain('Total ADRs Validated');
-      expect(result.content[0].text).not.toContain('README.md');
-    });
-
-    // Skip: ESM mocking of ResearchOrchestrator fails, causing timeouts
-    // See issue #308 for ESM-compatible mocking improvements
-    it.skip('should generate validation summary', async () => {
-      // Create a test ADR file
-      const adrContent = `# Test\n## Decision\nTest`;
-      await fs.writeFile(path.join(tempAdrDir, 'adr-001-test.md'), adrContent, 'utf-8');
-
-      MockResearchOrchestrator.mockImplementation(
-        () =>
-          ({
-            answerResearchQuestion: vi.fn().mockResolvedValue({
-              answer: 'Test',
-              confidence: 0.9,
-              sources: [],
-              metadata: { filesAnalyzed: 1, duration: 50, sourcesQueried: [] },
-              needsWebSearch: false,
-            }),
-          }) as any
-      );
-
-      const result = await validateAllAdrs({
-        projectPath: tempDir,
-      });
-
-      expect(result.content[0].text).toContain('ADR Validation Summary');
-      expect(result.content[0].text).toContain('Overview');
+      const text = result.content[0].text;
+      expect(text).toContain('# ADR Validation Summary');
+      expect(text).toContain('## Overview');
+      expect(text).toContain('**Total ADRs Validated**: 1');
+      expect(text).toContain('**Valid ADRs**: 1 (100.0%)');
+      expect(text).toContain('## Validation Results');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Unskipped and rewrote 5 `it.skip` tests in `adr-validation-tool.test.ts` for the deterministic rule-based validation path (AI executor was removed in #1642)
- Fixed two root causes: per-test mocks targeted the wrong export (`MockResearchOrchestrator` class instead of `mockAnswerResearchQuestion` function), and ADR templates used single `\n` after `## Decision` but `extractAdrDecision` requires `\n\n`
- Strengthened the existing passing test to assert `✅ Valid` and removed dead mock code from `beforeEach`

## Test plan

- [x] All 7 tests in `adr-validation-tool.test.ts` pass (0 skipped)
- [x] All 5 regression tests in `adr-validation-summary.test.ts` pass
- [x] `grep -c 'it.skip' tests/tools/adr-validation-tool.test.ts` returns 0
- [x] `npm run typecheck` passes
- [x] Full test suite passes (2736 tests, 119 files)
- [x] Repo Governor acceptance bar satisfied (`STOP_COMPLETE`)

Closes #1648
Refs #1629, #1642