### PR TITLE
docs(#757): add VS Code integration walkthrough and example configs

### DIFF
--- a/.repo-governor/acceptance/757.json
+++ b/.repo-governor/acceptance/757.json
@@ -1,0 +1,9 @@
+{
+  "authority_id": "757",
+  "criteria": [
+    { "check": "file_exists", "target": "docs/how-to-guides/vscode-integration.md" },
+    { "check": "file_exists", "target": "examples/vscode/mcp.json" },
+    { "check": "file_exists", "target": "examples/vscode/launch.json" },
+    { "check": "command_exit", "target": "grep -q 'vscode-integration' README.md" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The **Model Context Protocol (MCP)** is an open standard that enables seamless i
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **ADR**                          | **Architectural Decision Record** — A document that captures an important architectural decision along with its context, alternatives considered, and consequences.                                                |
 | **MCP**                          | **Model Context Protocol** — An open standard enabling AI assistants to connect to external tools and data sources.                                                                                                |
-| **CE-MCP**                       | **Claude-Enriched MCP** — Execution mode where tools return orchestration directives for the host LLM instead of making their own AI calls. Default since v2.14.                                                  |
+| **CE-MCP**                       | **Claude-Enriched MCP** — Execution mode where tools return orchestration directives for the host LLM instead of making their own AI calls. Default since v2.14.                                                   |
 | **Tree-sitter**                  | An incremental parsing library that provides AST (Abstract Syntax Tree) analysis for 50+ languages. Used for semantic code understanding, extracting function signatures, and identifying architectural patterns.  |
 | **Session & Tool-Usage Tracker** | Project-local tracking of session intents, tool executions, and ADR registrations, with keyword-scored retrieval over JSON snapshots. Supports workflow continuity and tool-usage evidence — not a graph database. |
 | **Smart Code Linking**           | Discovery of code files related to ADRs and architectural decisions, using keyword extraction and ripgrep search.                                                                                                  |
@@ -125,7 +125,10 @@ That's it. The server runs in **CE-MCP mode** by default — your host LLM (Clau
 | **Claude Desktop (macOS)**   | `~/Library/Application Support/Claude/claude_desktop_config.json`             |
 | **Claude Desktop (Windows)** | `%APPDATA%\Claude\claude_desktop_config.json`                                 |
 | **Cline (VS Code)**          | VS Code Settings → Cline → MCP Servers (or `.vscode/cline_mcp_settings.json`) |
+| **VS Code (native MCP)**     | `.vscode/mcp.json` in workspace root                                          |
 | **Cursor**                   | Cursor Settings → MCP → Add Server                                            |
+
+📖 **[VS Code Integration Guide →](docs/how-to-guides/vscode-integration.md)** — step-by-step setup for Cline, Continue, and VS Code native MCP with example configs.
 
 </details>
 
@@ -178,13 +181,13 @@ Get your API key at [adraggregator.com](https://adraggregator.com)
 
 ### Execution Modes
 
-|                          | **CE-MCP (default)**                                                                             | **Full Mode (legacy)**                                                                           | **Prompt-Only**                                                   |
-| ------------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| **Requires API key?**    | No                                                                                               | Yes (`OPENROUTER_API_KEY`)                                                                       | No                                                                |
-| **Returns**              | Orchestration directives for the host LLM to execute                                             | Server-side AI analysis results                                                                  | Prompts you can paste into any AI chat                            |
-| **Set via**              | Default (no env var needed)                                                                      | `EXECUTION_MODE=full`                                                                            | `EXECUTION_MODE=prompt-only`                                      |
-| **Best for**             | All users — recommended                                                                          | Legacy workflows with dedicated API budget                                                       | Offline exploration                                               |
-| **Tools available**      | All 64 tools with annotated MCP metadata                                                         | All 64 tools                                                                                     | Analysis prompts, templates, local file operations, ADR discovery |
+|                       | **CE-MCP (default)**                                 | **Full Mode (legacy)**                     | **Prompt-Only**                                                   |
+| --------------------- | ---------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| **Requires API key?** | No                                                   | Yes (`OPENROUTER_API_KEY`)                 | No                                                                |
+| **Returns**           | Orchestration directives for the host LLM to execute | Server-side AI analysis results            | Prompts you can paste into any AI chat                            |
+| **Set via**           | Default (no env var needed)                          | `EXECUTION_MODE=full`                      | `EXECUTION_MODE=prompt-only`                                      |
+| **Best for**          | All users — recommended                              | Legacy workflows with dedicated API budget | Offline exploration                                               |
+| **Tools available**   | All 64 tools with annotated MCP metadata             | All 64 tools                               | Analysis prompts, templates, local file operations, ADR discovery |
 
 **What are CE-MCP directives?** When a tool is called, it returns a structured orchestration directive that tells your host LLM what to analyze, what data to gather, and how to format results. The host LLM (e.g. Claude in Claude Desktop, or GPT in Cursor) executes the directive using its existing context window. This means **zero additional API costs** and **better results** because the LLM already has your conversation context.
 

--- a/docs/how-to-guides/vscode-integration.md
+++ b/docs/how-to-guides/vscode-integration.md
@@ -1,0 +1,190 @@
+# VS Code Integration Guide
+
+This guide walks through setting up the MCP ADR Analysis Server with VS Code using Cline or Continue as your MCP client.
+
+## Prerequisites
+
+- [VS Code](https://code.visualstudio.com/) 1.85+
+- [Node.js](https://nodejs.org/) 18+
+- One of:
+  - [Cline extension](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev) (recommended)
+  - [Continue extension](https://marketplace.visualstudio.com/items?itemName=Continue.continue)
+
+## Step 1: Install the server
+
+```bash
+npm install -g mcp-adr-analysis-server
+```
+
+Verify the installation:
+
+```bash
+mcp-adr-analysis-server --help
+```
+
+If you prefer running from source:
+
+```bash
+git clone https://github.com/tosin2013/mcp-adr-analysis-server.git
+cd mcp-adr-analysis-server
+npm install && npm run build
+```
+
+## Step 2: Configure your MCP client
+
+### Option A: Cline
+
+1. Open VS Code and install the [Cline extension](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev) from the marketplace.
+2. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run **Cline: MCP Servers**.
+3. Click **Edit MCP Settings** to open the settings file, or create `.vscode/cline_mcp_settings.json` in your workspace:
+
+```json
+{
+  "mcpServers": {
+    "adr-analysis": {
+      "command": "mcp-adr-analysis-server",
+      "env": {
+        "PROJECT_PATH": "/path/to/your/project"
+      }
+    }
+  }
+}
+```
+
+4. Replace `/path/to/your/project` with the absolute path to the project you want to analyze.
+5. Cline will detect the new server and show it in the MCP Servers panel. The status indicator should turn green.
+
+> **Tip:** Use the workspace root if you want to analyze the project you have open: set `PROJECT_PATH` to the result of `pwd` in your terminal.
+
+### Option B: Continue
+
+1. Install the [Continue extension](https://marketplace.visualstudio.com/items?itemName=Continue.continue) from the marketplace.
+2. Open Continue settings (`~/.continue/config.yaml` or via the Continue sidebar gear icon).
+3. Add the MCP server under the `mcpServers` section:
+
+```yaml
+mcpServers:
+  - name: adr-analysis
+    command: mcp-adr-analysis-server
+    env:
+      PROJECT_PATH: /path/to/your/project
+```
+
+4. Reload VS Code. Continue will connect to the server on startup.
+
+### Option C: VS Code native MCP support
+
+VS Code 1.99+ has built-in MCP support. Create or copy the example `.vscode/mcp.json` into your workspace:
+
+```json
+{
+  "servers": {
+    "adr-analysis": {
+      "type": "stdio",
+      "command": "mcp-adr-analysis-server",
+      "env": {
+        "PROJECT_PATH": "${workspaceFolder}"
+      }
+    }
+  }
+}
+```
+
+An example file is available at [`examples/vscode/mcp.json`](../../examples/vscode/mcp.json).
+
+## Step 3: Verify the connection
+
+Once configured, verify the server is connected:
+
+1. Open the MCP client panel (Cline sidebar or Continue sidebar).
+2. Check that **adr-analysis** appears in the server list with a connected status.
+3. Try a simple query:
+
+> "List all ADRs in this project"
+
+The server should respond with a list of architectural decision records found in your project's `docs/adrs/` directory (or the path set by `ADR_DIRECTORY`).
+
+## Step 4: Try common workflows
+
+### Analyze project architecture
+
+> "Analyze this project's architecture and suggest ADRs for any implicit decisions"
+
+### Review existing ADRs
+
+> "Review the existing ADRs and check if the code still matches the documented decisions"
+
+### Generate ADRs from a PRD
+
+> "Generate ADRs from docs/PRD.md and create a todo.md with implementation tasks"
+
+### Security analysis
+
+> "Check this codebase for security issues and provide masking recommendations"
+
+## Debugging the server in VS Code
+
+If you are developing or debugging the server itself, use the provided launch configuration. Copy [`examples/vscode/launch.json`](../../examples/vscode/launch.json) to your `.vscode/` directory:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "MCP ADR Analysis Server",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/dist/src/index.js",
+      "env": {
+        "PROJECT_PATH": "${workspaceFolder}",
+        "LOG_LEVEL": "DEBUG"
+      },
+      "console": "integratedTerminal",
+      "preLaunchTask": "npm: build"
+    }
+  ]
+}
+```
+
+Press `F5` to build and launch the server with debug logging. Set breakpoints in `src/` to step through tool execution.
+
+## Configuration reference
+
+| Environment variable     | Default     | Description                                  |
+| ------------------------ | ----------- | -------------------------------------------- |
+| `PROJECT_PATH`           | current dir | Absolute path to the project to analyze      |
+| `ADR_DIRECTORY`          | `docs/adrs` | Relative path to the ADR directory           |
+| `EXECUTION_MODE`         | `ce-mcp`    | `ce-mcp` (default), `full`, or `prompt-only` |
+| `LOG_LEVEL`              | `INFO`      | `DEBUG`, `INFO`, `WARN`, `ERROR`             |
+| `OPENROUTER_API_KEY`     | —           | Required only for `full` execution mode      |
+| `ADR_AGGREGATOR_API_KEY` | —           | Optional SaaS sync for shared ADR context    |
+
+## Troubleshooting
+
+**Server not appearing in Cline**
+
+- Ensure `mcp-adr-analysis-server` is on your `PATH` (run `which mcp-adr-analysis-server`).
+- If installed from source, make sure you ran `npm run build` first.
+- Restart VS Code after changing MCP settings.
+
+**"PROJECT_PATH does not exist"**
+
+- Use an absolute path, not a relative one.
+- On Windows, use forward slashes or escaped backslashes: `C:/Users/you/project`.
+
+**Connection drops or timeouts**
+
+- Check the VS Code Output panel (select "Cline" or "Continue" from the dropdown) for error messages.
+- Set `LOG_LEVEL=DEBUG` to see detailed server logs.
+- Ensure Node.js 18+ is installed (`node --version`).
+
+**No ADRs found**
+
+- The server looks for ADRs in `docs/adrs/` by default. Set `ADR_DIRECTORY` if your ADRs are elsewhere.
+- ADR files must be Markdown (`.md`) and follow the standard ADR format with a `# Title` and `## Status` section.
+
+## Next steps
+
+- [Full configuration reference](../reference/environment-config.md)
+- [MCP client compatibility matrix](mcp-client-compatibility.md)
+- [Tool development guide](tool-development.md)

--- a/examples/vscode/launch.json
+++ b/examples/vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "MCP ADR Analysis Server",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/dist/src/index.js",
+      "args": [],
+      "env": {
+        "PROJECT_PATH": "${workspaceFolder}",
+        "LOG_LEVEL": "DEBUG"
+      },
+      "console": "integratedTerminal",
+      "preLaunchTask": "npm: build"
+    },
+    {
+      "name": "MCP ADR Server (Full Mode)",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/dist/src/index.js",
+      "args": [],
+      "env": {
+        "PROJECT_PATH": "${workspaceFolder}",
+        "EXECUTION_MODE": "full",
+        "OPENROUTER_API_KEY": "${env:OPENROUTER_API_KEY}",
+        "LOG_LEVEL": "DEBUG"
+      },
+      "console": "integratedTerminal",
+      "preLaunchTask": "npm: build"
+    }
+  ]
+}

--- a/examples/vscode/mcp.json
+++ b/examples/vscode/mcp.json
@@ -1,0 +1,11 @@
+{
+  "servers": {
+    "adr-analysis": {
+      "type": "stdio",
+      "command": "mcp-adr-analysis-server",
+      "env": {
+        "PROJECT_PATH": "${workspaceFolder}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `docs/how-to-guides/vscode-integration.md` — step-by-step setup guide covering Cline, Continue, and VS Code native MCP support (1.99+)
- Add `examples/vscode/mcp.json` — copy-paste MCP server config using `${workspaceFolder}`
- Add `examples/vscode/launch.json` — debug launch configs for CE-MCP and Full Mode
- Link the guide from the README client config table with a new "VS Code (native MCP)" row

The guide includes: installation verification, client configuration for 3 VS Code MCP clients, connection verification steps, common workflow examples, a debugging section, environment variable reference, and troubleshooting for common issues.

## Test plan

- [x] All files exist at the paths specified in the issue
- [x] `grep -q 'vscode-integration' README.md` confirms README link
- [x] JSON configs are valid (prettier formatted)
- [x] Pre-commit hooks pass (prettier, typecheck, build, smoke)
- [x] Pre-push hooks pass (full test suite)
- [ ] Manual review: walkthrough tested on a fresh VS Code install (requires human reviewer)

Closes #757