### PR TITLE
fix(#1701): align MCP registry metadata with drift-led messaging

### DIFF
--- a/.repo-governor/acceptance/1701.json
+++ b/.repo-governor/acceptance/1701.json
@@ -1,0 +1,9 @@
+{
+  "authority_id": "1701",
+  "criteria": [
+    { "check": "command_exit", "target": "grep -q '2.14.7' server.json" },
+    { "check": "command_exit", "target": "grep -q 'drift detection' server.json" },
+    { "check": "command_exit", "target": "grep -q 'ce-mcp' server.json" },
+    { "check": "file_exists", "target": ".github/workflows/publish-mcp.yml" }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.tosin2013/mcp-adr-analysis-server",
-  "description": "AI-powered MCP server for analyzing Architectural Decision Records (ADRs).",
+  "description": "MCP server with live ADR drift detection, content safety, and decision memory — validates architectural decisions against your actual code",
   "repository": {
     "url": "https://github.com/tosin2013/mcp-adr-analysis-server",
     "source": "github"
   },
-  "version": "2.4.0",
+  "version": "2.14.7",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mcp-adr-analysis-server",
-      "version": "2.4.0",
+      "version": "2.14.7",
       "transport": {
         "type": "stdio"
       },
@@ -30,7 +30,7 @@
         },
         {
           "name": "EXECUTION_MODE",
-          "description": "Execution mode: 'full' for AI results or 'prompt-only' for prompts (default: prompt-only)",
+          "description": "Execution mode: 'ce-mcp' (default), 'full' for AI results, or 'prompt-only' for prompts",
           "isRequired": false,
           "isSecret": false
         },


### PR DESCRIPTION
## Summary
- Updates `server.json` description from old generic text to drift-led messaging (matching package.json and README from #1686)
- Bumps `server.json` version from stale `2.4.0` to current `2.14.7`
- Fixes `EXECUTION_MODE` description to show `ce-mcp` as the default (was incorrectly showing `prompt-only`)

## Context
The server is already published on the [MCP Registry](https://registry.modelcontextprotocol.io/) and the CI workflow (`publish-mcp-registry.yml`) auto-publishes on each NPM release. However, the registry listing still shows the old description because `server.json` was stale. The next publish after this merges will update the registry listing with the drift-led messaging.

Closes #1701

## Test plan
- [x] `server.json` contains version `2.14.7`
- [x] `server.json` contains drift-detection description
- [x] `server.json` shows `ce-mcp` as default execution mode
- [x] Pre-commit checks pass (prettier, typecheck, build, smoke test)
- [x] Pre-push full test suite passes (2778+ tests)
- [ ] After merge: verify next `publish-mcp-registry` workflow run updates the registry listing